### PR TITLE
fix unsupported operand type for dict before python3.9

### DIFF
--- a/piperider_cli/workspace.py
+++ b/piperider_cli/workspace.py
@@ -297,7 +297,11 @@ def _fetch_dbt_catalog(dbt, table=None):
         with open(dbt_catalog) as fd:
             catalog = json.loads(fd.read())
         # TODO we should consider the case that the table name is not unique
-        for k, v in (catalog.get('nodes', {}) | catalog.get('sources', {})).items():
+        # syntax after py3.9:
+        # content = catalog.get('nodes', {}) | catalog.get('sources', {})
+        content = catalog.get('nodes', {})
+        content.update(catalog.get('sources', {}))
+        for k, v in content.items():
             metadata = v.get('metadata', {})
             name = metadata.get('name')
             schema = metadata.get('schema')


### PR DESCRIPTION
Signed-off-by: Wei-Chun, Chang <wcchang@infuseai.io>

<!--  Thanks for sending a pull request!  Here are some check items for you: -->

** PR checklist **

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed

**What type of PR is this?**
fix unsupported operand type for dict

**What this PR does / why we need it**:
to support python before python 3.9

**Which issue(s) this PR fixes**:
sc-26474

**Special notes for your reviewer**:
tested with `piperider run`, `piperider debug` with python 3.8

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
Node
