### PR TITLE
Make the `assertion_results` in output json are always non-null.

### DIFF
--- a/piperider_cli/workspace.py
+++ b/piperider_cli/workspace.py
@@ -447,9 +447,6 @@ def _show_table_summary(console: Console, table: str, profiled_result, assertion
 
 
 def _transform_assertion_result(table: str, results):
-    if not results:
-        return
-
     tests = []
     columns = {}
     for r in results:


### PR DESCRIPTION
If there is no tests, the single and comparison reports would show empty page.

** PR checklist **

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed

**What type of PR is this?**
Bug fix
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
