### PR TITLE
[Fix] nightly build version number without dev string

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -6,8 +6,8 @@ on:
     branches:
       - main
     inputs:
-      version_postfix:
-        description: 'Version postfix serial number'
+      alpha_version:
+        description: 'Alpha version serial number'
         required: true
         type: number
         default: '0'
@@ -45,19 +45,20 @@ jobs:
 
           # update version number
           echo "Nightly build version: $(date '+%Y%m%d')"
-          if [ "$VERSION_POSTFIX" != "" ]; then
-            echo "Manually version postfix serial number: $VERSION_POSTFIX"
-            sed -i.bak "s/\.dev\$/.$(date '+%Y%m%d').post$VERSION_POSTFIX.dev/" piperider_cli/VERSION
+          if [ "ALPHA_VERSION" != "" ]; then
+            echo "Manually alpha version serial number: ALPHA_VERSION"
+            sed -i.bak "s/\.dev\$/\.$(date '+%Y%m%d')a$ALPHA_VERSION/" piperider_cli/VERSION
           else
-            sed -i.bak "s/\.dev\$/.$(date '+%Y%m%d').dev/" piperider_cli/VERSION
+            sed -i.bak "s/\.dev\$/\.$(date '+%Y%m%d')/" piperider_cli/VERSION
           fi
+          echo "Nightly build version: $(cat piperider_cli/VERSION)"
           echo ::set-output name=nightly_version::$(cat piperider_cli/VERSION)
 
           # release to PyPI
           make release
         env:
           PYPIRC: ${{ secrets.PYPI_NIGHTLY }}
-          VERSION_POSTFIX: ${{ inputs.version_postfix || '' }}
+          ALPHA_VERSION: ${{ inputs.alpha_version || '' }}
 
       - name: Mark Sentry Release
         uses: getsentry/action-release@v1
@@ -66,7 +67,7 @@ jobs:
           SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
           SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
         with:
-          environment: development
+          environment: nightly
           ignore_empty: true
           ignore_missing: true
           version: ${{ steps.vars.outputs.nightly_version }}

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -46,7 +46,7 @@ jobs:
           # update version number
           echo "Nightly build version: $(date '+%Y%m%d')"
           if [ "ALPHA_VERSION" != "" ]; then
-            echo "Manually alpha version serial number: ALPHA_VERSION"
+            echo "Manually alpha version serial number: $ALPHA_VERSION"
             sed -i.bak "s/\.dev\$/\.$(date '+%Y%m%d')a$ALPHA_VERSION/" piperider_cli/VERSION
           else
             sed -i.bak "s/\.dev\$/\.$(date '+%Y%m%d')/" piperider_cli/VERSION

--- a/piperider_cli/cli.py
+++ b/piperider_cli/cli.py
@@ -9,8 +9,23 @@ from rich.syntax import Syntax
 from piperider_cli import workspace, __version__, event
 from piperider_cli.event.track import TrackCommand
 
-sentry_env = 'development' if '.dev' in __version__ else 'production'
-release_version = __version__ if sentry_env == 'production' else None
+
+def set_sentry_env():
+    if '.dev' in __version__:
+        return 'development'
+    elif 'nightly' in sys.argv[0]:
+        return 'nightly'
+    elif 'a' in __version__:
+        return 'alpha'
+    elif 'b' in __version__:
+        return 'beta'
+    elif 'rc' in __version__:
+        return 'release-candidate'
+    return 'production'
+
+
+sentry_env = set_sentry_env()
+release_version = __version__ if sentry_env != 'development' else None
 
 sentry_sdk.init(
     "https://41930bf397884adfb2617fe350231439@o1081482.ingest.sentry.io/6463955",

--- a/piperider_cli/cli.py
+++ b/piperider_cli/cli.py
@@ -13,7 +13,7 @@ from piperider_cli.event.track import TrackCommand
 def set_sentry_env():
     if '.dev' in __version__:
         return 'development'
-    elif 'nightly' in sys.argv[0]:
+    elif 'nightly' in os.path.basename(sys.argv[0]):
         return 'nightly'
     elif 'a' in __version__:
         return 'alpha'


### PR DESCRIPTION
 - Manually trigger build will be `alpha` release

Signed-off-by: Kent Huang <kent@infuseai.io>

<!--  Thanks for sending a pull request!  Here are some check items for you: -->

** PR checklist **

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed

**What type of PR is this?**
Fix Nightly build CI/CD

**What this PR does / why we need it**:
- Nightly build will remove `dev` in version
- Manually trigger nightly build will be `alpha` release


**Which issue(s) this PR fixes**:
n/a

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
