### PR TITLE
[Fix] sc-26965 Handle when not assertion folder found

### DIFF
--- a/piperider_cli/assertion_engine/assertion.py
+++ b/piperider_cli/assertion_engine/assertion.py
@@ -302,6 +302,7 @@ class AssertionEngine:
 
     def _dump_assertions_files(self, assertions, prefix=''):
         paths = []
+        os.makedirs(self.assertion_search_path, exist_ok=True)
         for name, assertion in assertions.items():
             filename = f'{prefix}_{name}.yml' if prefix else f'{name}.yml'
             file_path = os.path.join(self.assertion_search_path, filename)

--- a/piperider_cli/error.py
+++ b/piperider_cli/error.py
@@ -23,6 +23,14 @@ class PipeRiderCredentialError(PipeRiderError):
         self.message = f"The credential of '{name}' is not configured. Please execute command 'piperider init' to move forward."
 
 
+class PipeRiderNoProfilingResultError(PipeRiderError):
+    def __init__(self, result_file):
+        self.result_file = result_file
+        pass
+
+    message = "No profiling result is found. Please execute command 'piperider run' to move forward."
+
+
 class PipeRiderInvalidDataSourceError(PipeRiderError):
     def __init__(self, name, config_file):
         self.name = name

--- a/piperider_cli/workspace.py
+++ b/piperider_cli/workspace.py
@@ -21,7 +21,8 @@ from piperider_cli.compare_report import CompareReport
 from piperider_cli.configuration import Configuration, PIPERIDER_WORKSPACE_NAME, PIPERIDER_CONFIG_PATH, \
     PIPERIDER_CREDENTIALS_PATH
 from piperider_cli.datasource import DataSource
-from piperider_cli.error import PipeRiderCredentialError, DbtManifestError, PipeRiderDiagnosticError
+from piperider_cli.error import PipeRiderCredentialError, DbtManifestError, PipeRiderDiagnosticError, \
+    PipeRiderNoProfilingResultError
 from piperider_cli.profiler import Profiler
 
 PIPERIDER_OUTPUT_PATH = os.path.join(os.getcwd(), PIPERIDER_WORKSPACE_NAME, 'outputs')
@@ -853,8 +854,7 @@ def generate_recommended_assertions(input=None, interaction=True):
 
     run_json_path = _get_run_json_path(input)
     if not os.path.isfile(run_json_path):
-        console.print(f'[bold red]Error: {run_json_path} is not a file[/bold red]')
-        return
+        raise PipeRiderNoProfilingResultError(run_json_path)
 
     with open(run_json_path) as f:
         profiling_result = json.loads(f.read())
@@ -905,8 +905,7 @@ def generate_report(input=None):
 
     run_json_path = _get_run_json_path(input)
     if not os.path.isfile(run_json_path):
-        console.print(f'[bold red]Error: {run_json_path} is not a file[/bold red]')
-        return
+        raise PipeRiderNoProfilingResultError(run_json_path)
 
     with open(run_json_path) as f:
         result = json.loads(f.read())


### PR DESCRIPTION


Signed-off-by: Kent Huang <kent@infuseai.io>

<!--  Thanks for sending a pull request!  Here are some check items for you: -->

** PR checklist **

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed

**What type of PR is this?**
Bugfix

**What this PR does / why we need it**:
 - Create `assertion` folder under `.piperider/` if this folder is not
   existed
 - Modify the error message if not profiling result found during command `generate-report` and `generate-assertions`

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
