### PR TITLE
fix: display <0.1% when columns have some missing values

### DIFF
--- a/static_report/src/utils/index.tsx
+++ b/static_report/src/utils/index.tsx
@@ -89,9 +89,15 @@ export function getMissingValue(column) {
     return '-';
   }
 
-  return `${(
+  const num = (
     Number((column.total - column.non_nulls) / column.total) * 100
-  ).toFixed(1)}%`;
+  ).toFixed(1);
+
+  if (Math.floor(num) === 0.0) {
+    return '<0.1%';
+  }
+
+  return `${num}%`;
 }
 
 export function formatReportTime(time) {


### PR DESCRIPTION
## Description

- [sc-26982](https://app.shortcut.com/infuseai/story/26982/missing-values-show-the-0-1-if-just-a-few-missing-samples-observed)

Signed-off-by: Jie Peng <im@jiepeng.me>

<!--  Thanks for sending a pull request!  Here are some check items for you: -->

** PR checklist **

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed