### PR TITLE
fix recommending range assertions in wrong format

### DIFF
--- a/piperider_cli/assertion_engine/recommended_rules/table_assertions.py
+++ b/piperider_cli/assertion_engine/recommended_rules/table_assertions.py
@@ -46,7 +46,7 @@ def recommended_column_min_assertion(table, column, profiling_result) -> Recomme
         if count / total > 0.95:
             test_function_name = 'assert_column_min_in_range'
             assertion_values = {
-                'min': [round(column_min * 0.9, 4), round(column_min * 1.1, 4)]
+                'min': sorted([round(column_min * 0.9, 4), round(column_min * 1.1, 4)])
             }
             assertion = RecommendedAssertion(test_function_name, assertion_values)
             return assertion
@@ -73,7 +73,7 @@ def recommended_column_max_assertion(table, column, profiling_result) -> Recomme
         if count / total > 0.95:
             test_function_name = 'assert_column_max_in_range'
             assertion_values = {
-                'max': [round(column_max * 0.9, 4), round(column_max * 1.1, 4)]
+                'max': sorted([round(column_max * 0.9, 4), round(column_max * 1.1, 4)])
             }
             assertion = RecommendedAssertion(test_function_name, assertion_values)
             return assertion


### PR DESCRIPTION
Signed-off-by: Wei-Chun, Chang <wcchang@infuseai.io>

<!--  Thanks for sending a pull request!  Here are some check items for you: -->

** PR checklist **

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed

**What type of PR is this?**
bug

**What this PR does / why we need it**:
it may recommend assertions in wrong format to a negative metric 

**Which issue(s) this PR fixes**:
sc-27062

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
NONE