### PR TITLE
fix: typo on dbt assertion key (schema renaming)

### DIFF
--- a/static_report/src/components/ComparisonReport/ComparisonReport.tsx
+++ b/static_report/src/components/ComparisonReport/ComparisonReport.tsx
@@ -37,7 +37,7 @@ export default function ComparisonReport({ data, name: reportName }: Props) {
   const { base, input } = data;
   const baseTables = base.tables[reportName];
   const inputTables = input.tables[reportName];
-  const existsDbtTests = (base.tables[reportName] as any)?.dbt_test_result;
+  const existsDbtTests = base.tables[reportName].dbt_assertion_result;
 
   const [baseOverview, inputOverview] = getComparisonAssertions({
     data,

--- a/static_report/src/components/SingleReport/SingleReport.tsx
+++ b/static_report/src/components/SingleReport/SingleReport.tsx
@@ -77,7 +77,6 @@ export default function SingleReport({ data, name }: Props) {
             <TabList>
               <Tab>Profiling</Tab>
               <Tab>Tests</Tab>
-              {/* If have `dbt_test_result` it will render this tab */}
               {table.dbt_assertion_result && <Tab>dbt Tests</Tab>}
             </TabList>
 

--- a/static_report/src/utils/index.tsx
+++ b/static_report/src/utils/index.tsx
@@ -238,7 +238,7 @@ export function getComparisonAssertions({
 }: ComparisonAssertions) {
   const targets = {
     piperider: 'piperider_assertion_result',
-    dbt: 'dbt_test_result',
+    dbt: 'dbt_assertion_result',
   };
 
   const baseTables = { type: 'base', tables: data.base.tables[reportName] };
@@ -251,6 +251,7 @@ export function getComparisonAssertions({
     }),
   );
 
+  console.log(assertions);
   return assertions;
 }
 

--- a/static_report/src/utils/index.tsx
+++ b/static_report/src/utils/index.tsx
@@ -251,7 +251,6 @@ export function getComparisonAssertions({
     }),
   );
 
-  console.log(assertions);
   return assertions;
 }
 


### PR DESCRIPTION
hotfix for not-shown `dbt_assertion_result`. will default to `-/-` when no assertions are provided