### PR TITLE
[Fix] sc-27574 Fix github report security alert

### DIFF
--- a/static_report/package.json
+++ b/static_report/package.json
@@ -50,6 +50,9 @@
     "ts-to-zod": "^1.11.0",
     "typescript": "^4.7.4"
   },
+  "resolutions": {
+    "nth-check": "2.0.1"
+  },
   "scripts": {
     "analyze": "npx cra-bundle-analyzer",
     "setup": "run-s typing:dts typing:zts embed:html",

--- a/static_report/yarn.lock
+++ b/static_report/yarn.lock
@@ -5898,7 +5898,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"boolbase@npm:^1.0.0, boolbase@npm:~1.0.0":
+"boolbase@npm:^1.0.0":
   version: 1.0.0
   resolution: "boolbase@npm:1.0.0"
   checksum: 3e25c80ef626c3a3487c73dbfc70ac322ec830666c9ad915d11b701142fab25ec1e63eff2c450c74347acfd2de854ccde865cd79ef4db1683f7c7b046ea43bb0
@@ -12982,21 +12982,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nth-check@npm:^1.0.2":
-  version: 1.0.2
-  resolution: "nth-check@npm:1.0.2"
-  dependencies:
-    boolbase: ~1.0.0
-  checksum: 59e115fdd75b971d0030f42ada3aac23898d4c03aa13371fa8b3339d23461d1badf3fde5aad251fb956aaa75c0a3b9bfcd07c08a34a83b4f9dadfdce1d19337c
-  languageName: node
-  linkType: hard
-
-"nth-check@npm:^2.0.1":
-  version: 2.1.1
-  resolution: "nth-check@npm:2.1.1"
+"nth-check@npm:2.0.1":
+  version: 2.0.1
+  resolution: "nth-check@npm:2.0.1"
   dependencies:
     boolbase: ^1.0.0
-  checksum: 5afc3dafcd1573b08877ca8e6148c52abd565f1d06b1eb08caf982e3fa289a82f2cae697ffb55b5021e146d60443f1590a5d6b944844e944714a5b549675bcd3
+  checksum: 5386d035c48438ff304fe687704d93886397349d1bed136de97aeae464caba10e8ffac55a04b215b86b3bc8897f33e0a5aa1045a9d8b2f251ae61b2a3ad3e450
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
 - Force to use nth-check@2.0.1

Signed-off-by: Kent Huang <kent@infuseai.io>

<!--  Thanks for sending a pull request!  Here are some check items for you: -->

** PR checklist **

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed

**What type of PR is this?**
Security patch

**What this PR does / why we need it**:
- Fix github report security alert
- Force to use nth-check@2.0.1


**Which issue(s) this PR fixes**:
sc-27574

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
