### PR TITLE
Feature/sc 27377/compare reports rename all base input terms

### DIFF
--- a/static_report/src/components/ComparisonReport/CRList.tsx
+++ b/static_report/src/components/ComparisonReport/CRList.tsx
@@ -38,14 +38,13 @@ export function ComparisonReportList({
 }: {
   data: ComparisonReportSchema;
 }) {
-  const { base, input } = data;
-
+  const { base, input: target } = data;
   ZSingleSchema.parse(base);
-  ZSingleSchema.parse(input);
+  ZSingleSchema.parse(target);
 
   const tables = nestComparisonValueByKey<TableSchema>(
     base.tables,
-    input.tables,
+    target.tables,
   );
 
   useDocumentTitle('Report List');
@@ -71,14 +70,14 @@ export function ComparisonReportList({
                 <Tr>
                   <Th width="10%" />
                   <Th width="45%">Base</Th>
-                  <Th width="45%">Input</Th>
+                  <Th width="45%">Target</Th>
                 </Tr>
               </Thead>
               <Tbody>
                 <Tr>
                   <Td>ID</Td>
                   <Td>{base.id}</Td>
-                  <Td>{input.id}</Td>
+                  <Td>{target.id}</Td>
                 </Tr>
                 <Tr>
                   <Td>Data Source</Td>
@@ -86,13 +85,13 @@ export function ComparisonReportList({
                     {base.datasource.name}: {base.datasource.type}
                   </Td>
                   <Td>
-                    {input.datasource.name}: {input.datasource.type}
+                    {target.datasource.name}: {target.datasource.type}
                   </Td>
                 </Tr>
                 <Tr>
                   <Td>Generated At</Td>
                   <Td>{formatReportTime(base.created_at)}</Td>
-                  <Td>{formatReportTime(input.created_at)}</Td>
+                  <Td>{formatReportTime(target.created_at)}</Td>
                 </Tr>
               </Tbody>
             </Table>
@@ -104,7 +103,7 @@ export function ComparisonReportList({
             </Heading>
             <Tooltip
               label={
-                'The numbers of passed tests, failed tests, rows, and columns are displayed in a side-by-side comparison (left: BASE; right: INPUT). When the table does not exist in the BASE or INPUT source, it will display "-".'
+                'The numbers of passed tests, failed tests, rows, and columns are displayed in a side-by-side comparison (left: BASE; right: TARGET). When the table does not exist in the BASE or TARGET source, it will display "-".'
               }
             >
               <InfoIcon mt={1} color="gray.400" boxSize={'14px'} />
@@ -142,17 +141,18 @@ export function ComparisonReportList({
               <Tbody data-cy="cr-report-list">
                 {Object.keys(tables).map((key) => {
                   const table = tables[key];
-                  ZComparisonTableSchema.parse(table);
+                  console.log(table);
 
-                  const [baseOverview, inputOverview] = getComparisonAssertions(
-                    {
+                  ZComparisonTableSchema(false).parse(table);
+
+                  const [baseOverview, targetOverview] =
+                    getComparisonAssertions({
                       data,
                       reportName: key,
                       type: 'piperider',
-                    },
-                  );
+                    });
 
-                  const [dbtBaseOverview, dbtInputOverview] =
+                  const [dbtBaseOverview, dbtTargetOverview] =
                     getComparisonAssertions({
                       data,
                       reportName: key,
@@ -171,24 +171,24 @@ export function ComparisonReportList({
                           <Text as="span">{baseOverview.passed}</Text>
                           {' / '}
                           <Text as="span" mr={10}>
-                            {inputOverview.passed}
+                            {targetOverview.passed}
                           </Text>
 
                           <Text as="span">{baseOverview.failed}</Text>
                           {' / '}
-                          <Text as="span">{inputOverview.failed}</Text>
+                          <Text as="span">{targetOverview.failed}</Text>
                         </Td>
 
                         <Td>
                           <Text as="span">{dbtBaseOverview.passed}</Text>
                           {' / '}
                           <Text as="span" mr={10}>
-                            {dbtInputOverview.passed}
+                            {dbtTargetOverview.passed}
                           </Text>
 
                           <Text as="span">{dbtBaseOverview.failed}</Text>
                           {' / '}
-                          <Text as="span">{dbtInputOverview.failed}</Text>
+                          <Text as="span">{dbtTargetOverview.failed}</Text>
                         </Td>
 
                         <Td>
@@ -198,7 +198,7 @@ export function ComparisonReportList({
                           )}
                           {' / '}
                           {formatColumnValueWith(
-                            table.input.row_count,
+                            table.target.row_count,
                             formatNumber,
                           )}
                         </Td>
@@ -209,7 +209,7 @@ export function ComparisonReportList({
                           )}
                           {' / '}
                           {formatColumnValueWith(
-                            table.input.col_count,
+                            table.target.col_count,
                             formatNumber,
                           )}
                         </Td>

--- a/static_report/src/components/ComparisonReport/CRList.tsx
+++ b/static_report/src/components/ComparisonReport/CRList.tsx
@@ -141,7 +141,6 @@ export function ComparisonReportList({
               <Tbody data-cy="cr-report-list">
                 {Object.keys(tables).map((key) => {
                   const table = tables[key];
-                  console.log(table);
 
                   ZComparisonTableSchema(false).parse(table);
 

--- a/static_report/src/components/ComparisonReport/CRModal/CRModal.tsx
+++ b/static_report/src/components/ComparisonReport/CRModal/CRModal.tsx
@@ -12,7 +12,7 @@ import {
 } from '@chakra-ui/react';
 import { AssertionTest } from '../../../sdlc/single-report-schema';
 
-import { CRInputData } from '../../../types';
+import { CRTargetData } from '../../../types';
 import { DbtTable } from './CRModalDbtTable';
 import { PipeRiderTable } from './CRModalPiperiderTable';
 
@@ -20,12 +20,12 @@ export type CRModalData = {
   level: 'Column' | 'Table';
   column: string;
   name: string;
-} & CRInputData<AssertionTest & { message?: string }>;
-
-interface Props extends UseDisclosureReturn {
+} & CRTargetData<AssertionTest & { message?: string }>;
+export type TestDetail = {
   type?: 'piperider' | 'dbt';
   data?: CRModalData;
-}
+};
+type Props = UseDisclosureReturn & TestDetail;
 
 export function CRModal({
   data,

--- a/static_report/src/components/ComparisonReport/CRModal/CRModalDbtTable.tsx
+++ b/static_report/src/components/ComparisonReport/CRModal/CRModalDbtTable.tsx
@@ -35,9 +35,9 @@ export function DbtTable({ data }: Props) {
           </Tr>
 
           <Tr>
-            <Td fontWeight={700}>Input</Td>
+            <Td fontWeight={700}>Target</Td>
             <Td>
-              <TestStatus status={data?.input?.status as any} />
+              <TestStatus status={data?.target?.status as any} />
             </Td>
             <Td>{(data?.base?.message as any) ?? '-'}</Td>
           </Tr>

--- a/static_report/src/components/ComparisonReport/CRModal/CRModalDbtTable.tsx
+++ b/static_report/src/components/ComparisonReport/CRModal/CRModalDbtTable.tsx
@@ -12,8 +12,6 @@ import { CRModalData } from './CRModal';
 
 type Props = { data: CRModalData };
 export function DbtTable({ data }: Props) {
-  console.log(data);
-
   return (
     <TableContainer>
       <Table variant="simple">

--- a/static_report/src/components/ComparisonReport/CRModal/CRModalPiperiderTable.tsx
+++ b/static_report/src/components/ComparisonReport/CRModal/CRModalPiperiderTable.tsx
@@ -13,7 +13,6 @@ import { CRModalData } from './CRModal';
 
 type Props = { data: CRModalData };
 export function PipeRiderTable({ data }: Props) {
-  console.log(data);
   return (
     <TableContainer>
       <Table variant="simple">

--- a/static_report/src/components/ComparisonReport/CRModal/CRModalPiperiderTable.tsx
+++ b/static_report/src/components/ComparisonReport/CRModal/CRModalPiperiderTable.tsx
@@ -37,12 +37,12 @@ export function PipeRiderTable({ data }: Props) {
           </Tr>
 
           <Tr>
-            <Td fontWeight={700}>Input</Td>
+            <Td fontWeight={700}>Target</Td>
             <Td>
-              <TestStatus status={data?.input?.status} />
+              <TestStatus status={data?.target?.status} />
             </Td>
-            <Td>{formatTestExpectedOrActual(data?.input?.expected)}</Td>
-            <Td>{formatTestExpectedOrActual(data?.input?.actual)}</Td>
+            <Td>{formatTestExpectedOrActual(data?.target?.expected)}</Td>
+            <Td>{formatTestExpectedOrActual(data?.target?.actual)}</Td>
           </Tr>
         </Tbody>
       </Table>

--- a/static_report/src/components/ComparisonReport/CRTabProfilingDetails.tsx
+++ b/static_report/src/components/ComparisonReport/CRTabProfilingDetails.tsx
@@ -1,6 +1,6 @@
 import { Flex, Grid } from '@chakra-ui/react';
 import { useEffect, useState } from 'react';
-import { ColumnSchema } from '../../sdlc/single-report-schema';
+import { ColumnSchema, TableSchema } from '../../sdlc/single-report-schema';
 import { ZTableSchema } from '../../types';
 import {
   transformBaseDistribution,
@@ -11,13 +11,17 @@ import {
 import { CRBarChart } from './CRBarChart';
 import { CRTableColumnDetails } from './CRTableColumnDetails';
 
-export function CRTabProfilingDetails({ base, input }) {
-  ZTableSchema.parse(base);
-  ZTableSchema.parse(input);
+type Props = {
+  baseTable: TableSchema;
+  targetTable: TableSchema;
+};
+export function CRTabProfilingDetails({ baseTable, targetTable }: Props) {
+  ZTableSchema.parse(baseTable);
+  ZTableSchema.parse(targetTable);
 
   const transformedData = nestComparisonValueByKey<ColumnSchema>(
-    base.columns,
-    input.columns,
+    baseTable.columns,
+    targetTable.columns,
   );
 
   return (
@@ -28,7 +32,7 @@ export function CRTabProfilingDetails({ base, input }) {
             key={key}
             name={key}
             base={value.base}
-            input={value.input}
+            target={value.target}
           />
         );
       })}
@@ -44,19 +48,19 @@ export function CRTabProfilingDetails({ base, input }) {
 type CRProfilingColumnProp = {
   name: string;
   base?: ColumnSchema;
-  input?: ColumnSchema;
+  target?: ColumnSchema;
 };
-function CRProfilingColumn({ name, base, input }: CRProfilingColumnProp) {
+function CRProfilingColumn({ name, base, target }: CRProfilingColumnProp) {
   const [data, setData] = useState<CRDistributionDatum[][]>([]);
 
   useEffect(() => {
     if (
-      base?.type === input?.type &&
+      base?.type === target?.type &&
       (base?.type === 'string' || base?.type === 'datetime')
     ) {
       const transformResult = transformCRStringDateDistributions({
         base: base.distribution,
-        input: input.distribution,
+        target: target.distribution,
       });
 
       setData([transformResult]);
@@ -68,25 +72,25 @@ function CRProfilingColumn({ name, base, input }: CRProfilingColumnProp) {
           })
         : null;
 
-      const inputData = input
+      const targetData = target
         ? transformBaseDistribution({
-            baseCounts: input.distribution.counts,
-            baseLabels: input.distribution.labels,
+            baseCounts: target.distribution.counts,
+            baseLabels: target.distribution.labels,
           })
         : null;
 
-      setData([baseData, inputData]);
+      setData([baseData, targetData]);
     }
-  }, [base, input]);
+  }, [base, target]);
 
   return (
     <Flex key={name} direction="column">
       <Grid my={8} templateColumns="500px 1fr" gap={12}>
-        {/* case: base and input not always avail due to column shifts, but base will always exist */}
+        {/* case: base and target not always avail due to column shifts, but base will always exist */}
         <CRTableColumnDetails
           baseColumn={base}
-          inputColumn={input}
-          column={base ? base : input}
+          targetColumn={target}
+          column={base ? base : target}
         />
 
         {/* Diff between string datetime vs. others */}

--- a/static_report/src/components/ComparisonReport/CRTabSchemaDetails.tsx
+++ b/static_report/src/components/ComparisonReport/CRTabSchemaDetails.tsx
@@ -34,18 +34,18 @@ const getEnrichedColumnsFor = (columns, type): EnrichedColumnData['columns'] =>
 
 type Props = {
   base: TableSchema;
-  input: TableSchema;
+  target: TableSchema;
 };
-export function CRTabSchemaDetails({ base, input }: Props) {
+export function CRTabSchemaDetails({ base, target }: Props) {
   ZTableSchema.parse(base);
-  ZTableSchema.parse(input);
+  ZTableSchema.parse(target);
 
   const baseColEntries = getEnrichedColumnsFor(base.columns, 'base');
-  const inputColEntries = getEnrichedColumnsFor(input.columns, 'input');
-  const combinedColEntries = [...baseColEntries, ...inputColEntries];
+  const targetColEntries = getEnrichedColumnsFor(target.columns, 'target');
+  const combinedColEntries = [...baseColEntries, ...targetColEntries];
 
-  const addedTest = inputColEntries.length - baseColEntries.length;
-  const deletedTest = baseColEntries.length - inputColEntries.length;
+  const addedTest = targetColEntries.length - baseColEntries.length;
+  const deletedTest = baseColEntries.length - targetColEntries.length;
 
   // Reduce
   const aggregateEnrichedColumns =
@@ -54,13 +54,14 @@ export function CRTabSchemaDetails({ base, input }: Props) {
         //index offsets when iterating both columns together
         const currBaseIndex =
           idx < baseColEntries.length ? idx : idx - baseColEntries.length;
-        const currInputIndex =
+        const currTargetIndex =
           idx >= baseColEntries.length ? idx : idx + baseColEntries.length;
 
         //cross-checks if schema type is changed
         const currBaseSchema = combinedColEntries[currBaseIndex].schema_type;
-        const currInputSchema = combinedColEntries[currInputIndex].schema_type;
-        const isSchemaChanged = currBaseSchema !== currInputSchema;
+        const currTargetSchema =
+          combinedColEntries[currTargetIndex].schema_type;
+        const isSchemaChanged = currBaseSchema !== currTargetSchema;
         const changed = acc.changed + (isSchemaChanged ? 1 : 0);
 
         //write schema detail for UI rows
@@ -82,7 +83,7 @@ export function CRTabSchemaDetails({ base, input }: Props) {
   // UI vars
   const { added, deleted, changed, columns } = aggregateEnrichedColumns;
   const baseColumns = columns.slice(0, baseColEntries.length);
-  const inputColumns = columns.slice(baseColEntries.length);
+  const targetColumns = columns.slice(baseColEntries.length);
 
   return (
     <Flex direction="column">
@@ -137,7 +138,7 @@ export function CRTabSchemaDetails({ base, input }: Props) {
               </Tr>
             </Thead>
             <Tbody>
-              {inputColumns.map((column) => (
+              {targetColumns.map((column) => (
                 <Tr
                   key={nanoid(10)}
                   color={column.changed ? 'red.500' : 'inherit'}

--- a/static_report/src/components/ComparisonReport/CRTabTestDetails.tsx
+++ b/static_report/src/components/ComparisonReport/CRTabTestDetails.tsx
@@ -11,7 +11,7 @@ import {
 } from '@chakra-ui/react';
 import groupBy from 'lodash/groupBy';
 import { nanoid } from 'nanoid';
-import { CRAssertionTests, CRInputData } from '../../types';
+import { CRAssertionTests, CRTargetData } from '../../types';
 import { TestStatus } from '../shared/TestStatus';
 
 type TestGroupRow = {
@@ -19,13 +19,13 @@ type TestGroupRow = {
   column: string;
   name: string;
   base?: CRAssertionTests;
-  input?: CRAssertionTests;
+  target?: CRAssertionTests;
 };
-type Props = CRInputData<CRAssertionTests[]> & { onDetailVisible: Function };
-export function CRTabTestDetails({ base = [], input = [], ...props }: Props) {
+type Props = CRTargetData<CRAssertionTests[]> & { onDetailVisible: Function };
+export function CRTabTestDetails({ base = [], target = [], ...props }: Props) {
   // group by "level", "column", "name"
   const groupedTests = groupBy(
-    [...base, ...input],
+    [...base, ...target],
     (test) => `${test.level}_${test.column}_${test.name}`,
   );
 
@@ -40,7 +40,7 @@ export function CRTabTestDetails({ base = [], input = [], ...props }: Props) {
       if (test.from === 'base') {
         row.base = test;
       } else {
-        row.input = test;
+        row.target = test;
       }
     });
 
@@ -64,7 +64,7 @@ export function CRTabTestDetails({ base = [], input = [], ...props }: Props) {
             <Th>Column</Th>
             <Th>Assertion</Th>
             <Th>Base Status</Th>
-            <Th>Input Status</Th>
+            <Th>Target Status</Th>
             <Th />
           </Tr>
         </Thead>
@@ -79,7 +79,7 @@ export function CRTabTestDetails({ base = [], input = [], ...props }: Props) {
                   <TestStatus status={test.base?.status} />
                 </Td>
                 <Td>
-                  <TestStatus status={test.input?.status} />
+                  <TestStatus status={test.target?.status} />
                 </Td>
                 <Td
                   onClick={() => {

--- a/static_report/src/components/ComparisonReport/CRTableColumnDetails.tsx
+++ b/static_report/src/components/ComparisonReport/CRTableColumnDetails.tsx
@@ -9,17 +9,17 @@ import { NumericTableColumn } from '../shared/NumericTableColumn';
 type CRTableColumnDetailsProps = {
   column?: ColumnSchema;
   baseColumn?: ColumnSchema;
-  inputColumn?: ColumnSchema;
+  targetColumn?: ColumnSchema;
 };
 export const CRTableColumnDetails = ({
   column,
   baseColumn,
-  inputColumn,
+  targetColumn,
 }: CRTableColumnDetailsProps) => {
   const emptyLabel = '-';
   ZColSchema.parse(column);
   ZColSchema.parse(baseColumn);
-  ZColSchema.parse(inputColumn);
+  ZColSchema.parse(targetColumn);
 
   return (
     <Flex direction="column" gap={2} minH="250px">
@@ -45,14 +45,14 @@ export const CRTableColumnDetails = ({
               Base
             </Text>
             <Text fontWeight={700} textAlign="right" width="100px">
-              Input
+              Target
             </Text>
           </Flex>
         </Flex>
 
         <Flex direction="column" mt={3}>
           <GeneralTableColumn
-            inputColumn={inputColumn}
+            targetColumn={targetColumn}
             baseColumn={baseColumn}
           />
         </Flex>
@@ -60,7 +60,7 @@ export const CRTableColumnDetails = ({
           <>
             <NumericTableColumn
               baseColumn={baseColumn}
-              inputColumn={inputColumn}
+              targetColumn={targetColumn}
             />
           </>
         )}
@@ -70,12 +70,12 @@ export const CRTableColumnDetails = ({
             <MetricsInfo
               name="Min"
               base={(baseColumn?.min as string | number) ?? emptyLabel}
-              input={(inputColumn?.min as string | number) ?? emptyLabel}
+              target={(targetColumn?.min as string | number) ?? emptyLabel}
             />
             <MetricsInfo
               name="Max"
               base={(baseColumn?.max as string | number) ?? emptyLabel}
-              input={(inputColumn?.max as string | number) ?? emptyLabel}
+              target={(targetColumn?.max as string | number) ?? emptyLabel}
             />
           </Flex>
         )}

--- a/static_report/src/components/ComparisonReport/CRTableOverview.tsx
+++ b/static_report/src/components/ComparisonReport/CRTableOverview.tsx
@@ -14,20 +14,20 @@ import { getReportAggregateAssertions } from '../../utils/assertion';
 
 type Props = {
   baseTable: TableSchema;
-  inputTable: TableSchema;
+  targetTable: TableSchema;
 };
 
-export function CRTableOverview({ baseTable, inputTable }: Props) {
+export function CRTableOverview({ baseTable, targetTable }: Props) {
   ZTableSchema.parse(baseTable);
-  ZTableSchema.parse(inputTable);
+  ZTableSchema.parse(targetTable);
 
   const baseAssertions = getReportAggregateAssertions(
     baseTable.piperider_assertion_result,
     baseTable?.dbt_assertion_result,
   );
-  const inputAssertions = getReportAggregateAssertions(
-    inputTable.piperider_assertion_result,
-    inputTable?.dbt_assertion_result,
+  const targetAssertions = getReportAggregateAssertions(
+    targetTable.piperider_assertion_result,
+    targetTable?.dbt_assertion_result,
   );
 
   return (
@@ -37,7 +37,7 @@ export function CRTableOverview({ baseTable, inputTable }: Props) {
           <Tr>
             <Th width="10%" />
             <Th width="45%">Base</Th>
-            <Th width="45%">Input</Th>
+            <Th width="45%">Target</Th>
           </Tr>
         </Thead>
 
@@ -45,17 +45,17 @@ export function CRTableOverview({ baseTable, inputTable }: Props) {
           <Tr>
             <Td>Table</Td>
             <Td>{baseTable?.name ?? '-'}</Td>
-            <Td>{inputTable?.name ?? '-'}</Td>
+            <Td>{targetTable?.name ?? '-'}</Td>
           </Tr>
           <Tr>
             <Td>Rows</Td>
             <Td>{baseTable?.row_count ?? '-'}</Td>
-            <Td>{inputTable?.row_count ?? '-'}</Td>
+            <Td>{targetTable?.row_count ?? '-'}</Td>
           </Tr>
           <Tr>
             <Td>Columns</Td>
             <Td>{baseTable?.col_count ?? '-'}</Td>
-            <Td>{inputTable?.col_count ?? '-'}</Td>
+            <Td>{targetTable?.col_count ?? '-'}</Td>
           </Tr>
           <Tr>
             <Td>Test status</Td>
@@ -79,16 +79,16 @@ export function CRTableOverview({ baseTable, inputTable }: Props) {
             <Td>
               <Text>
                 <Text as="span" fontWeight={700}>
-                  {inputAssertions.passed}{' '}
+                  {targetAssertions.passed}{' '}
                 </Text>
                 Passed
                 {', '}
                 <Text
                   as="span"
                   fontWeight={700}
-                  color={inputAssertions.failed > 0 ? 'red.500' : 'inherit'}
+                  color={targetAssertions.failed > 0 ? 'red.500' : 'inherit'}
                 >
-                  {inputAssertions.failed}{' '}
+                  {targetAssertions.failed}{' '}
                 </Text>
                 Failed
               </Text>

--- a/static_report/src/components/ComparisonReport/ComparisonReport.tsx
+++ b/static_report/src/components/ComparisonReport/ComparisonReport.tsx
@@ -19,7 +19,7 @@ import { Main } from '../shared/Main';
 import { getComparisonAssertions } from '../../utils/assertion';
 
 import { useDocumentTitle } from '../../hooks/useDocumentTitle';
-import { CRModal } from './CRModal/CRModal';
+import { CRModal, TestDetail } from './CRModal/CRModal';
 import {
   ComparisonReportSchema,
   ZComparisonSchema,
@@ -35,24 +35,24 @@ type Props = {
   name: string;
 };
 export default function ComparisonReport({ data, name: reportName }: Props) {
-  const [testDetail, setTestDetail] = useState(null);
+  const [testDetail, setTestDetail] = useState<TestDetail>(null);
   const modal = useDisclosure();
 
-  const { base, input } = data;
-  ZComparisonSchema.parse(data);
+  const { base, input: target } = data;
+  ZComparisonSchema(true).parse(data);
 
   const baseTable = base.tables[reportName];
-  const inputTable = input.tables[reportName];
+  const targetTable = target.tables[reportName];
   const existsDbtTests = base.tables[reportName]?.dbt_assertion_result;
   ZTableSchema.parse(baseTable);
-  ZTableSchema.parse(inputTable);
+  ZTableSchema.parse(targetTable);
 
-  const [baseOverview, inputOverview] = getComparisonAssertions({
+  const [baseOverview, targetOverview] = getComparisonAssertions({
     data,
     reportName,
     type: 'piperider',
   });
-  const [dbtBaseOverview, dbtInputOverview] = getComparisonAssertions({
+  const [dbtBaseOverview, dbtTargetOverview] = getComparisonAssertions({
     data,
     reportName,
     type: 'dbt',
@@ -92,7 +92,7 @@ export default function ComparisonReport({ data, name: reportName }: Props) {
         >
           {/* overview */}
           <Heading fontSize={24}>Overview</Heading>
-          <CRTableOverview baseTable={baseTable} inputTable={inputTable} />
+          <CRTableOverview baseTable={baseTable} targetTable={targetTable} />
 
           <Tabs isLazy>
             <TabList>
@@ -104,17 +104,20 @@ export default function ComparisonReport({ data, name: reportName }: Props) {
 
             <TabPanels>
               <TabPanel>
-                <CRTabSchemaDetails base={baseTable} input={inputTable} />
+                <CRTabSchemaDetails base={baseTable} target={targetTable} />
               </TabPanel>
 
               <TabPanel>
-                <CRTabProfilingDetails base={baseTable} input={inputTable} />
+                <CRTabProfilingDetails
+                  baseTable={baseTable}
+                  targetTable={targetTable}
+                />
               </TabPanel>
 
               <TabPanel>
                 <CRTabTestDetails
                   base={baseOverview?.tests}
-                  input={inputOverview?.tests}
+                  target={targetOverview?.tests}
                   onDetailVisible={(data) => {
                     setTestDetail({
                       type: 'piperider',
@@ -127,7 +130,7 @@ export default function ComparisonReport({ data, name: reportName }: Props) {
 
               <TabPanel>
                 {dbtBaseOverview?.tests.length === 0 &&
-                dbtInputOverview?.tests.length === 0 ? (
+                dbtTargetOverview?.tests.length === 0 ? (
                   <Flex
                     justifyContent="center"
                     alignItems="center"
@@ -138,7 +141,7 @@ export default function ComparisonReport({ data, name: reportName }: Props) {
                 ) : (
                   <CRTabTestDetails
                     base={dbtBaseOverview?.tests}
-                    input={dbtInputOverview?.tests}
+                    target={dbtTargetOverview?.tests}
                     onDetailVisible={(data) => {
                       setTestDetail({
                         type: 'dbt',

--- a/static_report/src/components/shared/GeneralTableColumn.tsx
+++ b/static_report/src/components/shared/GeneralTableColumn.tsx
@@ -8,8 +8,8 @@ import {
 import { getColumnDetails } from '../../utils/transformers';
 import { MetricsInfo } from './MetrisInfo';
 
-type Props = { baseColumn: ColumnSchema; inputColumn?: ColumnSchema };
-export function GeneralTableColumn({ baseColumn, inputColumn }: Props) {
+type Props = { baseColumn: ColumnSchema; targetColumn?: ColumnSchema };
+export function GeneralTableColumn({ baseColumn, targetColumn }: Props) {
   if (baseColumn) {
     ZColSchema.parse(baseColumn);
     var {
@@ -23,67 +23,67 @@ export function GeneralTableColumn({ baseColumn, inputColumn }: Props) {
     } = getColumnDetails(baseColumn);
   }
 
-  if (inputColumn) {
-    ZColSchema.parse(inputColumn);
+  if (targetColumn) {
+    ZColSchema.parse(targetColumn);
     var {
-      total: inputTotal,
-      mismatchOfTotal: inputMismatchOfTotal,
-      validOfTotal: inputValidOfTotal,
-      missingOfTotal: inputMissingOfTotal,
-    } = getColumnDetails(inputColumn);
+      total: targetTotal,
+      mismatchOfTotal: targetMismatchOfTotal,
+      validOfTotal: targetValidOfTotal,
+      missingOfTotal: targetMissingOfTotal,
+    } = getColumnDetails(targetColumn);
   }
 
   //NOTE: `base` will show amount (non-%) in single-reports
-  //NOTE: `input` will show ratio (%) in single-reports
+  //NOTE: `target` will show ratio (%) in single-reports
   return (
     <>
       <MetricsInfo
         name="Total"
         base={formatColumnValueWith(baseTotal, formatNumber)}
-        input={formatColumnValueWith(
-          inputColumn ? inputTotal : baseTotalOfTotal,
-          inputColumn ? formatNumber : formatIntervalMinMax,
+        target={formatColumnValueWith(
+          targetColumn ? targetTotal : baseTotalOfTotal,
+          targetColumn ? formatNumber : formatIntervalMinMax,
         )}
       />
       <MetricsInfo
         name="Valid"
         base={formatColumnValueWith(
-          inputColumn ? baseValidOfTotal : baseTotal,
-          inputColumn ? formatIntervalMinMax : formatNumber,
+          targetColumn ? baseValidOfTotal : baseTotal,
+          targetColumn ? formatIntervalMinMax : formatNumber,
         )}
-        input={formatColumnValueWith(
-          inputColumn ? inputValidOfTotal : baseValidOfTotal,
+        target={formatColumnValueWith(
+          targetColumn ? targetValidOfTotal : baseValidOfTotal,
           formatIntervalMinMax,
         )}
       />
       <MetricsInfo
         name="Mismatched"
         base={formatColumnValueWith(
-          inputColumn ? baseMismatchOfTotal : baseMismatch,
-          inputColumn ? formatIntervalMinMax : formatNumber,
+          targetColumn ? baseMismatchOfTotal : baseMismatch,
+          targetColumn ? formatIntervalMinMax : formatNumber,
         )}
-        input={formatColumnValueWith(
-          inputColumn ? inputMismatchOfTotal : baseMismatchOfTotal,
+        target={formatColumnValueWith(
+          targetColumn ? targetMismatchOfTotal : baseMismatchOfTotal,
           formatIntervalMinMax,
         )}
       />
       <MetricsInfo
         name="Missing"
         base={formatColumnValueWith(
-          inputColumn ? baseMissingOfTotal : baseMissing,
-          inputColumn ? formatIntervalMinMax : formatNumber,
+          targetColumn ? baseMissingOfTotal : baseMissing,
+          targetColumn ? formatIntervalMinMax : formatNumber,
         )}
-        input={formatColumnValueWith(
-          inputColumn ? inputMissingOfTotal : baseMissingOfTotal,
+        target={formatColumnValueWith(
+          targetColumn ? targetMissingOfTotal : baseMissingOfTotal,
           formatIntervalMinMax,
         )}
       />
       <MetricsInfo
         name="Distinct"
         base={formatColumnValueWith(baseColumn?.distinct, formatNumber)}
-        input={
-          inputColumn &&
-          formatColumnValueWith(inputColumn?.distinct, formatNumber)
+        target={
+          targetColumn &&
+          formatColumnValueWith(targetColumn?.distinct, formatNumber)
         }
       />
     </>

--- a/static_report/src/components/shared/MetrisInfo.tsx
+++ b/static_report/src/components/shared/MetrisInfo.tsx
@@ -3,17 +3,17 @@ import { Flex, Text } from '@chakra-ui/react';
 interface Props {
   name: string;
   base: string | number;
-  input?: string | number;
+  target?: string | number;
   baseWidth?: string;
-  inputWidth?: string;
+  targetWidth?: string;
 }
 
 export function MetricsInfo({
   name,
   base,
-  input = null,
+  target = null,
   baseWidth = '100px',
-  inputWidth = '100px',
+  targetWidth = '100px',
 }: Props) {
   return (
     <Flex justifyContent="space-between">
@@ -23,9 +23,9 @@ export function MetricsInfo({
           {base}
         </Text>
 
-        {input && (
-          <Text textAlign="right" width={inputWidth}>
-            {input}
+        {target && (
+          <Text textAlign="right" width={targetWidth}>
+            {target}
           </Text>
         )}
       </Flex>

--- a/static_report/src/components/shared/NumericTableColumn.tsx
+++ b/static_report/src/components/shared/NumericTableColumn.tsx
@@ -6,10 +6,10 @@ import { MetricsInfo } from './MetrisInfo';
 
 type Props = {
   baseColumn: ColumnSchema;
-  inputColumn?: ColumnSchema;
+  targetColumn?: ColumnSchema;
 };
 
-export function NumericTableColumn({ baseColumn, inputColumn }: Props) {
+export function NumericTableColumn({ baseColumn, targetColumn }: Props) {
   ZColSchema.parse(baseColumn);
   ZColSchema.parse(baseColumn);
   return (
@@ -18,16 +18,17 @@ export function NumericTableColumn({ baseColumn, inputColumn }: Props) {
         <MetricsInfo
           name="Average"
           base={formatColumnValueWith(baseColumn?.avg, formatNumber)}
-          input={
-            inputColumn && formatColumnValueWith(inputColumn?.avg, formatNumber)
+          target={
+            targetColumn &&
+            formatColumnValueWith(targetColumn?.avg, formatNumber)
           }
         />
         <MetricsInfo
           name="Std. Deviation"
           base={formatColumnValueWith(baseColumn?.stddev, formatNumber)}
-          input={
-            inputColumn &&
-            formatColumnValueWith(inputColumn?.stddev, formatNumber)
+          target={
+            targetColumn &&
+            formatColumnValueWith(targetColumn?.stddev, formatNumber)
           }
         />
       </Flex>
@@ -35,50 +36,57 @@ export function NumericTableColumn({ baseColumn, inputColumn }: Props) {
         <MetricsInfo
           name="Min"
           base={formatColumnValueWith(baseColumn?.min, formatNumber)}
-          input={
-            inputColumn && formatColumnValueWith(inputColumn?.min, formatNumber)
+          target={
+            targetColumn &&
+            formatColumnValueWith(targetColumn?.min, formatNumber)
           }
         />
         <MetricsInfo
           name="5%"
           base={formatColumnValueWith(baseColumn?.p5, formatNumber)}
-          input={
-            inputColumn && formatColumnValueWith(inputColumn?.p5, formatNumber)
+          target={
+            targetColumn &&
+            formatColumnValueWith(targetColumn?.p5, formatNumber)
           }
         />
         <MetricsInfo
           name="25%"
           base={formatColumnValueWith(baseColumn?.p25, formatNumber)}
-          input={
-            inputColumn && formatColumnValueWith(inputColumn?.p25, formatNumber)
+          target={
+            targetColumn &&
+            formatColumnValueWith(targetColumn?.p25, formatNumber)
           }
         />
         <MetricsInfo
           name="50%"
           base={formatColumnValueWith(baseColumn?.p50, formatNumber)}
-          input={
-            inputColumn && formatColumnValueWith(inputColumn?.p50, formatNumber)
+          target={
+            targetColumn &&
+            formatColumnValueWith(targetColumn?.p50, formatNumber)
           }
         />
         <MetricsInfo
           name="75%"
           base={formatColumnValueWith(baseColumn?.p75, formatNumber)}
-          input={
-            inputColumn && formatColumnValueWith(inputColumn?.p75, formatNumber)
+          target={
+            targetColumn &&
+            formatColumnValueWith(targetColumn?.p75, formatNumber)
           }
         />
         <MetricsInfo
           name="95%"
           base={formatColumnValueWith(baseColumn?.p95, formatNumber)}
-          input={
-            inputColumn && formatColumnValueWith(inputColumn?.p95, formatNumber)
+          target={
+            targetColumn &&
+            formatColumnValueWith(targetColumn?.p95, formatNumber)
           }
         />
         <MetricsInfo
           name="Max"
           base={formatColumnValueWith(baseColumn?.max, formatNumber)}
-          input={
-            inputColumn && formatColumnValueWith(inputColumn?.max, formatNumber)
+          target={
+            targetColumn &&
+            formatColumnValueWith(targetColumn?.max, formatNumber)
           }
         />
       </Flex>

--- a/static_report/src/hooks/useComparisonChart.ts
+++ b/static_report/src/hooks/useComparisonChart.ts
@@ -5,12 +5,12 @@ import { formatNumber } from '../utils/formatters';
 import { getChartTooltip } from '../utils/chart';
 import { CRDistributionDatum } from '../utils/transformers';
 
-const GROUPED = ['base', 'input'];
+const GROUPED = ['base', 'target'];
 const X_PADDING = 0.2;
 const X_SUB_PADDING = 0.05;
 const TOOLTIPS_BG_COLOR = 'var(--chakra-colors-gray-500)';
 const BASE_CHART_COLOR = 'var(--chakra-colors-blue-100)';
-const INPUT_CHART_COLOR = 'var(--chakra-colors-blue-300)';
+const TARGET_CHART_COLOR = 'var(--chakra-colors-blue-300)';
 
 type CRChartHookArgs = {
   target: RefObject<SVGSVGElement>;
@@ -61,7 +61,7 @@ export function useComparisonChart({
     // Y-Axis
     const yScale = d3
       .scaleLinear()
-      .domain([0, d3.max(data, ({ base, input }) => Math.max(base, input))])
+      .domain([0, d3.max(data, ({ base, target }) => Math.max(base, target))])
       .range([dimensions.height, 0]);
     const yAxis = d3.axisLeft(yScale);
     // plox Y axis
@@ -70,7 +70,7 @@ export function useComparisonChart({
     const color = d3
       .scaleOrdinal()
       .domain(GROUPED)
-      .range([BASE_CHART_COLOR, INPUT_CHART_COLOR]);
+      .range([BASE_CHART_COLOR, TARGET_CHART_COLOR]);
 
     const grouped = svg
       .selectAll('.grouped-chart')

--- a/static_report/src/sdlc/single-report-schema.d.ts
+++ b/static_report/src/sdlc/single-report-schema.d.ts
@@ -40,15 +40,7 @@ export interface ColumnSchema {
   distribution?: null | Distribution;
   name: string;
   description: string;
-  type:
-    | 'string'
-    | 'numeric'
-    | 'integer'
-    | 'datetime'
-    | 'date'
-    | 'time'
-    | 'boolean'
-    | 'other';
+  type: "string" | "numeric" | "integer" | "datetime" | "date" | "time" | "boolean" | "other";
   schema_type: string;
   valid?: number;
   mismatched?: number;
@@ -83,7 +75,7 @@ export interface PipeRiderAssertionResult {
 }
 export interface AssertionTest {
   name: string;
-  status: 'passed' | 'failed';
+  status: "passed" | "failed";
   parameters?: {
     [k: string]: unknown;
   };

--- a/static_report/src/sdlc/single-report-schema.d.ts
+++ b/static_report/src/sdlc/single-report-schema.d.ts
@@ -34,13 +34,13 @@ export interface TableSchema {
  */
 export interface ColumnSchema {
   total: number;
-  nulls?: number;
+  nulls: number;
   non_nulls: number;
   distinct: number;
-  distribution?: null | Distribution;
+  distribution?: Distribution;
   name: string;
   description: string;
-  type: "string" | "numeric" | "integer" | "datetime" | "date" | "time" | "boolean" | "other";
+  type: "string" | "integer" | "numeric" | "datetime" | "date" | "time" | "boolean" | "other";
   schema_type: string;
   valid?: number;
   mismatched?: number;

--- a/static_report/src/sdlc/single-report-schema.z.ts
+++ b/static_report/src/sdlc/single-report-schema.z.ts
@@ -29,16 +29,16 @@ export const dataSourceSchema = z.object({
 
 export const columnSchemaSchema = z.object({
   total: z.number(),
-  nulls: z.number().optional(),
+  nulls: z.number(),
   non_nulls: z.number(),
   distinct: z.number(),
-  distribution: distributionSchema.optional().nullable(),
+  distribution: distributionSchema.optional(),
   name: z.string(),
   description: z.string(),
   type: z.union([
     z.literal('string'),
-    z.literal('numeric'),
     z.literal('integer'),
+    z.literal('numeric'),
     z.literal('datetime'),
     z.literal('date'),
     z.literal('time'),

--- a/static_report/src/types/index.ts
+++ b/static_report/src/types/index.ts
@@ -11,7 +11,7 @@ export interface ComparisonReportSchema {
   input: SingleReportSchema;
 }
 
-export type ComparsionSource = 'base' | 'input';
+export type ComparsionSource = 'base' | 'target';
 
 export type AssertionValue =
   | TableSchema['piperider_assertion_result']
@@ -36,15 +36,16 @@ export type CRAssertionTests = {
   actual?: unknown;
 };
 
-export interface CRInputData<T> {
+export interface CRTargetData<T> {
   base: T;
-  input: T;
+  target: T;
 }
 
 /**
  * This exists due to certain modifications needed on literal enum types (e.g. `type`); Also, for parts of the schema that are incorrect and need to be ignored
  */
-const zWrapForComparison = (base, input) => z.object({ base, input });
+const zWrapForComparison = (base, input, flag?: boolean) =>
+  z.object({ base, [flag ? 'input' : 'target']: input });
 
 export const ZColSchema = columnSchemaSchema
   .merge(
@@ -79,16 +80,14 @@ export const ZTableSchema = tableSchemaSchema.merge(
   z.object({ columns: z.record(ZColSchema) }),
 );
 
-export const ZComparisonTableSchema = zWrapForComparison(
-  ZTableSchema,
-  ZTableSchema,
-);
+//TODO: temp bypass flag until `input` -> `target` on schema.json
+export const ZComparisonTableSchema = (flag?: boolean) =>
+  zWrapForComparison(ZTableSchema, ZTableSchema, flag);
 
 export const ZSingleSchema = singleReportSchemaSchema.merge(
   z.object({ tables: z.record(ZTableSchema) }),
 );
 
-export const ZComparisonSchema = zWrapForComparison(
-  ZSingleSchema,
-  ZSingleSchema,
-);
+//TODO: temp bypass flag until `input` -> `target` on schema.json
+export const ZComparisonSchema = (flag?: boolean) =>
+  zWrapForComparison(ZSingleSchema, ZSingleSchema, flag);

--- a/static_report/src/types/index.ts
+++ b/static_report/src/types/index.ts
@@ -8,7 +8,7 @@ import { SingleReportSchema, TableSchema } from '../sdlc/single-report-schema';
 
 export interface ComparisonReportSchema {
   base: SingleReportSchema;
-  input: SingleReportSchema;
+  input: SingleReportSchema; //old code: future key will be `target`
 }
 
 export type ComparsionSource = 'base' | 'target';
@@ -43,9 +43,13 @@ export interface CRTargetData<T> {
 
 /**
  * This exists due to certain modifications needed on literal enum types (e.g. `type`); Also, for parts of the schema that are incorrect and need to be ignored
+ * @param base the baseline value
+ * @param target the `target` -- this value compared against your base
+ * @param flag a flag that allows for escaping the newer `target`, and looking up with `input
+ * @returns Zod validation object with {base, target}
  */
-const zWrapForComparison = (base, input, flag?: boolean) =>
-  z.object({ base, [flag ? 'input' : 'target']: input });
+const zWrapForComparison = (base, target, flag?: boolean) =>
+  z.object({ base, [flag ? 'input' : 'target']: target });
 
 export const ZColSchema = columnSchemaSchema
   .merge(

--- a/static_report/src/utils/assertion.ts
+++ b/static_report/src/utils/assertion.ts
@@ -107,9 +107,12 @@ export function getComparisonAssertions({
   };
 
   const baseTables = { type: 'base', tables: data.base.tables[reportName] };
-  const inputTables = { type: 'input', tables: data.input.tables[reportName] };
+  const targetTables = {
+    type: 'target',
+    tables: data.input.tables[reportName], //legacy 'input' key
+  };
 
-  const assertions = [baseTables, inputTables].map((source) =>
+  const assertions = [baseTables, targetTables].map((source) =>
     getComparisonAssertionTests({
       assertion: source.tables[targets[type]],
       from: source.type as ComparsionSource,

--- a/static_report/src/utils/formatters.tsx
+++ b/static_report/src/utils/formatters.tsx
@@ -120,7 +120,7 @@ export function getSRModeMetrics(column: ColumnSchema) {
   return tops.join(', ');
 }
 /**
- * A method to handle falsey non-numbers (relevant for comparison reports with column shifts, where base/input values can be undefined)
+ * A method to handle falsey non-numbers (relevant for comparison reports with column shifts, where base/target values can be undefined)
  * @param input any value that will be checked as number
  * @param fn any function to format the valid number
  * @param emptyLabel


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some check items for you: -->

** PR checklist **

- [X ] Ensure you have added or ran the appropriate tests for your PR.
- [X] DCO signed

**What type of PR is this?**
Update to UI layer. 
**What this PR does / why we need it**:
Change 'input' wording /codebase to 'target'; 
Additionally fixed any issues from uncaught property changes from schema (nullables)

**Which issue(s) this PR fixes**:
SC 27377
**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
Yes
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
Changed wording from 'input' to 'target', for generally recognizable vector of comparison data
