### PR TITLE
fix: count of the last bin missing in distribution metric

### DIFF
--- a/piperider_cli/profiler/profiler.py
+++ b/piperider_cli/profiler/profiler.py
@@ -502,9 +502,7 @@ class NumericColumnProfiler(BaseColumnProfiler):
             if i != num_buckets - 1:
                 cases += [(column < bound, i)]
             else:
-                cases += [(column < bound, i)]
-                # equal comparing
-                cases += [(func.abs(column - bound) < interval / 100, i)]
+                cases += [(column < bound + interval / 100, i)]
 
         cte_with_bucket = select([
             column.label("c"),

--- a/piperider_cli/profiler/profiler.py
+++ b/piperider_cli/profiler/profiler.py
@@ -502,7 +502,9 @@ class NumericColumnProfiler(BaseColumnProfiler):
             if i != num_buckets - 1:
                 cases += [(column < bound, i)]
             else:
-                cases += [(column <= bound, i)]
+                cases += [(column < bound, i)]
+                # equal comparing
+                cases += [(func.abs(column - bound) < interval / 100, i)]
 
         cte_with_bucket = select([
             column.label("c"),


### PR DESCRIPTION
Signed-off-by: Wei-Chun, Chang <wcchang@infuseai.io>

<!--  Thanks for sending a pull request!  Here are some check items for you: -->

** PR checklist **

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed

**What type of PR is this?**
bug

**What this PR does / why we need it**:
The numeric metric, distribution, didn't show the max item on the latest bin.

**Which issue(s) this PR fixes**:
sc-27602

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
NONE