### PR TITLE
[Chore] sc-27700 Fix PR title checker prefixes end with a space

### DIFF
--- a/.github/PULL_REQUEST_TITLE_CHECKER.json
+++ b/.github/PULL_REQUEST_TITLE_CHECKER.json
@@ -5,11 +5,11 @@
   },
   "CHECKS": {
     "prefixes": [
-      "[Feature]",
-      "[Bug]",
-      "[Release]",
-      "[Document]",
-      "[Chore]"
+      "[Feature] ",
+      "[Bug] ",
+      "[Release] ",
+      "[Document] ",
+      "[Chore] "
     ],
     "ignoreLabels": [
       "Skip PR Title Check"


### PR DESCRIPTION
Signed-off-by: Kent Huang <kent@infuseai.io>

<!--  Thanks for sending a pull request!  Here are some check items for you: -->

**PR checklist**

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed

**What type of PR is this?**
Chore

**What this PR does / why we need it**:
Fix PR title checker prefixes end with a space

**Which issue(s) this PR fixes**:
sc-27700

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
