### PR TITLE
[Bug] comparison report changed metrics 27701

### DIFF
--- a/static_report/src/components/ComparisonReport/CRTabProfilingDetails.tsx
+++ b/static_report/src/components/ComparisonReport/CRTabProfilingDetails.tsx
@@ -95,8 +95,14 @@ function CRProfilingColumn({ name, base, target }: CRProfilingColumnProps) {
           my={4}
           templateColumns={`1fr ${combinedData ? '' : '1fr'}`}
           gap={combinedData ? 0 : 12}
+          className="foobarbaz"
+          overflowX={'clip'}
         >
-          {combinedData && <CRBarChart data={combinedData} />}
+          {combinedData ? (
+            <CRBarChart data={combinedData} />
+          ) : combinedData ? (
+            <NoData />
+          ) : null}
           {splitData[0] ? (
             <SRBarChart data={splitData[0]} />
           ) : combinedData ? null : (

--- a/static_report/src/components/ComparisonReport/CRTabProfilingDetails.tsx
+++ b/static_report/src/components/ComparisonReport/CRTabProfilingDetails.tsx
@@ -95,8 +95,7 @@ function CRProfilingColumn({ name, base, target }: CRProfilingColumnProps) {
           my={4}
           templateColumns={`1fr ${combinedData ? '' : '1fr'}`}
           gap={combinedData ? 0 : 12}
-          className="foobarbaz"
-          overflowX={'clip'}
+          overflowX={'hidden'}
         >
           {combinedData ? (
             <CRBarChart data={combinedData} />

--- a/static_report/src/components/ComparisonReport/CRTableOverview.tsx
+++ b/static_report/src/components/ComparisonReport/CRTableOverview.tsx
@@ -7,6 +7,8 @@ import {
   Tbody,
   Td,
   Text,
+  Heading,
+  Flex,
 } from '@chakra-ui/react';
 import { TableSchema } from '../../sdlc/single-report-schema';
 import { zReport, ZTableSchema } from '../../types';
@@ -32,71 +34,74 @@ export function CRTableOverview({ baseTable, targetTable }: Props) {
   );
 
   return (
-    <TableContainer>
-      <Table variant="simple">
-        <Thead>
-          <Tr>
-            <Th width="10%" />
-            <Th width="45%">Base</Th>
-            <Th width="45%">Target</Th>
-          </Tr>
-        </Thead>
+    <Flex gap={4} direction={'column'}>
+      <Heading fontSize={24}>Overview</Heading>
+      <TableContainer>
+        <Table variant="simple">
+          <Thead>
+            <Tr>
+              <Th width="10%" />
+              <Th width="45%">Base</Th>
+              <Th width="45%">Target</Th>
+            </Tr>
+          </Thead>
 
-        <Tbody>
-          <Tr>
-            <Td>Table</Td>
-            <Td>{baseTable?.name ?? NO_VALUE}</Td>
-            <Td>{targetTable?.name ?? NO_VALUE}</Td>
-          </Tr>
-          <Tr>
-            <Td>Rows</Td>
-            <Td>{baseTable?.row_count ?? NO_VALUE}</Td>
-            <Td>{targetTable?.row_count ?? NO_VALUE}</Td>
-          </Tr>
-          <Tr>
-            <Td>Columns</Td>
-            <Td>{baseTable?.col_count ?? NO_VALUE}</Td>
-            <Td>{targetTable?.col_count ?? NO_VALUE}</Td>
-          </Tr>
-          <Tr>
-            <Td>Test status</Td>
-            <Td>
-              <Text>
-                <Text as="span" fontWeight={700}>
-                  {baseAssertions.passed}{' '}
+          <Tbody>
+            <Tr>
+              <Td>Table</Td>
+              <Td>{baseTable?.name ?? NO_VALUE}</Td>
+              <Td>{targetTable?.name ?? NO_VALUE}</Td>
+            </Tr>
+            <Tr>
+              <Td>Rows</Td>
+              <Td>{baseTable?.row_count ?? NO_VALUE}</Td>
+              <Td>{targetTable?.row_count ?? NO_VALUE}</Td>
+            </Tr>
+            <Tr>
+              <Td>Columns</Td>
+              <Td>{baseTable?.col_count ?? NO_VALUE}</Td>
+              <Td>{targetTable?.col_count ?? NO_VALUE}</Td>
+            </Tr>
+            <Tr>
+              <Td>Test status</Td>
+              <Td>
+                <Text>
+                  <Text as="span" fontWeight={700}>
+                    {baseAssertions.passed}{' '}
+                  </Text>
+                  Passed
+                  {', '}
+                  <Text
+                    as="span"
+                    fontWeight={700}
+                    color={baseAssertions.failed > 0 ? 'red.500' : 'inherit'}
+                  >
+                    {baseAssertions.failed}{' '}
+                  </Text>
+                  Failed
                 </Text>
-                Passed
-                {', '}
-                <Text
-                  as="span"
-                  fontWeight={700}
-                  color={baseAssertions.failed > 0 ? 'red.500' : 'inherit'}
-                >
-                  {baseAssertions.failed}{' '}
+              </Td>
+              <Td>
+                <Text>
+                  <Text as="span" fontWeight={700}>
+                    {targetAssertions.passed}{' '}
+                  </Text>
+                  Passed
+                  {', '}
+                  <Text
+                    as="span"
+                    fontWeight={700}
+                    color={targetAssertions.failed > 0 ? 'red.500' : 'inherit'}
+                  >
+                    {targetAssertions.failed}{' '}
+                  </Text>
+                  Failed
                 </Text>
-                Failed
-              </Text>
-            </Td>
-            <Td>
-              <Text>
-                <Text as="span" fontWeight={700}>
-                  {targetAssertions.passed}{' '}
-                </Text>
-                Passed
-                {', '}
-                <Text
-                  as="span"
-                  fontWeight={700}
-                  color={targetAssertions.failed > 0 ? 'red.500' : 'inherit'}
-                >
-                  {targetAssertions.failed}{' '}
-                </Text>
-                Failed
-              </Text>
-            </Td>
-          </Tr>
-        </Tbody>
-      </Table>
-    </TableContainer>
+              </Td>
+            </Tr>
+          </Tbody>
+        </Table>
+      </TableContainer>
+    </Flex>
   );
 }

--- a/static_report/src/components/ComparisonReport/ComparisonReport.tsx
+++ b/static_report/src/components/ComparisonReport/ComparisonReport.tsx
@@ -3,7 +3,6 @@ import {
   BreadcrumbItem,
   BreadcrumbLink,
   Flex,
-  Heading,
   Text,
   Tabs,
   TabList,
@@ -66,7 +65,7 @@ export default function ComparisonReport({ data, name: reportName }: Props) {
   return (
     <Main>
       <Flex direction="column" minH="calc(100vh + 1px)" width="100%">
-        <Flex mx="10%" mt={4}>
+        <Flex mx="5%" mt={4}>
           <Breadcrumb fontSize="lg">
             <BreadcrumbItem>
               <Link href="/">
@@ -89,11 +88,9 @@ export default function ComparisonReport({ data, name: reportName }: Props) {
           borderRadius="md"
           p={6}
           mt={3}
-          mx="10%"
+          mx="5%"
           direction="column"
-          gap={8}
         >
-          <Heading fontSize={24}>Overview</Heading>
           <CRTableOverview baseTable={baseTable} targetTable={targetTable} />
 
           <Tabs isLazy>

--- a/static_report/src/components/shared/ColumnCard/index.tsx
+++ b/static_report/src/components/shared/ColumnCard/index.tsx
@@ -33,7 +33,7 @@ export function ColumnCard({ columnDatum }: Props) {
       h={[700]}
       my={3}
       rounded={'lg'}
-      overflowX={'hidden'}
+      overflowX={'clip'}
     >
       <ColumnCardHeader columnDatum={columnDatum} />
       <ColumnCardDataVisualContainer

--- a/static_report/src/components/shared/ColumnCard/index.tsx
+++ b/static_report/src/components/shared/ColumnCard/index.tsx
@@ -33,7 +33,7 @@ export function ColumnCard({ columnDatum }: Props) {
       h={[700]}
       my={3}
       rounded={'lg'}
-      overflowX={'clip'}
+      overflowX={'hidden'}
     >
       <ColumnCardHeader columnDatum={columnDatum} />
       <ColumnCardDataVisualContainer

--- a/static_report/src/components/shared/GeneralTableColumn.tsx
+++ b/static_report/src/components/shared/GeneralTableColumn.tsx
@@ -75,7 +75,7 @@ export function GeneralTableColumn({ baseColumn, targetColumn }: Props) {
         }
       />
       <MetricsInfo
-        name="Mismatched"
+        name="Invalid"
         firstSlot={formatColumnValueWith(
           targetColumn ? baseInvalidsOfTotal : baseInvalids,
           targetColumn ? formatIntervalMinMax : formatNumber,
@@ -106,7 +106,10 @@ export function GeneralTableColumn({ baseColumn, targetColumn }: Props) {
       />
       <MetricsInfo
         name="Distinct"
-        firstSlot={formatColumnValueWith(baseColumn?.distinct, formatNumber)}
+        firstSlot={formatColumnValueWith(
+          baseDistinctOfTotal,
+          formatIntervalMinMax,
+        )}
         secondSlot={
           isTargetNull
             ? NO_VALUE

--- a/static_report/src/utils/transformers.tsx
+++ b/static_report/src/utils/transformers.tsx
@@ -69,26 +69,6 @@ export function transformCRStringDateHistograms({
   return result;
 }
 
-type TransSingleDistArgs = {
-  counts?: number[];
-  labels?: (string | null)[];
-};
-export function transformCRHistogram({
-  counts,
-  labels,
-}: TransSingleDistArgs): CRHistogramDatum[] | null {
-  if (!labels || !counts) return null;
-  const result = counts.map((count, idx) => {
-    return {
-      label: labels[idx],
-      base: count,
-      target: 0,
-    };
-  });
-
-  return result;
-}
-
 export function getColumnDetails(columnData: ColumnSchema) {
   const {
     nulls,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some check items for you: -->

**PR checklist**

- [ X] Ensure you have added or ran the appropriate tests for your PR.
- [ X] DCO signed

**What this PR does / why we need it**:
1. UI updates due to changes/deprecation of certain metrics (e.g. `mismatch`, `distribution`, `topk`, `histogram`)
2. Fix UI overflow of chart labels (`overflow-x` `clip` is used)
3. Fix UI use proper split chart vs. combined chart for Comparison Report charts (single vs. dual-bins)

**Which issue(s) this PR fixes**:
27701, 27861, 27889
**Special notes for your reviewer**:
![image](https://user-images.githubusercontent.com/11186480/183334792-280d97fa-fd3d-4e26-b7d5-50f195fbdf42.png)
![image](https://user-images.githubusercontent.com/11186480/183334866-ef91d04e-8c8c-42d9-a4a5-12a88f9e0913.png)


**Does this PR introduce a user-facing change?**: yes
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
1. Replaced `mismatch` references to `invalids`
2. Fix issue where Comparison Report charts was showing base/target histogram dual-bins when the charts should be split individually (single-bin)
3. Fix issue where report chart labels was overflowing if too long (now these will be clipped)