### PR TITLE
[Feature] Support to change the report directory by --report-dir

### DIFF
--- a/piperider_cli/__init__.py
+++ b/piperider_cli/__init__.py
@@ -120,7 +120,7 @@ def ensure_directory_writable(directory):
             return False
 
 
-def raise_exception_when_output_directory_not_writable(output):
+def raise_exception_when_directory_not_writable(output):
     if output:
         if not ensure_directory_writable(output):
             raise Exception(f'The path "{output}" is not writable')

--- a/piperider_cli/assertion_generator.py
+++ b/piperider_cli/assertion_generator.py
@@ -4,14 +4,17 @@ import os
 from rich.console import Console
 from rich.table import Table
 
+from piperider_cli import raise_exception_when_directory_not_writable
 from piperider_cli.assertion_engine import AssertionEngine
-from piperider_cli.configuration import PIPERIDER_OUTPUT_PATH
 from piperider_cli.error import PipeRiderNoProfilingResultError
+from piperider_cli.filesystem import FileSystem
 
 console = Console()
 
 
-def _get_run_json_path(input=None):
+def _get_run_json_path(filesystem: FileSystem, input=None):
+    console = Console()
+    run_json = None
     if input:
         if not os.path.exists(input):
             console.print(f'[bold red]Error: {input} not found[/bold red]')
@@ -21,7 +24,7 @@ def _get_run_json_path(input=None):
         else:
             run_json = input
     else:
-        latest = os.path.join(PIPERIDER_OUTPUT_PATH, 'latest')
+        latest = os.path.join(filesystem.get_output_dir(), 'latest')
         run_json = os.path.join(latest, 'run.json')
     return run_json
 
@@ -35,8 +38,11 @@ def _validate_input_result(result):
 
 class AssertionGenerator():
     @staticmethod
-    def exec(input=None, interaction=True):
-        run_json_path = _get_run_json_path(input)
+    def exec(input=None, report_dir: str = None):
+        filesystem = FileSystem(report_dir=report_dir)
+        raise_exception_when_directory_not_writable(report_dir)
+
+        run_json_path = _get_run_json_path(filesystem, input)
         if not os.path.isfile(run_json_path):
             raise PipeRiderNoProfilingResultError(run_json_path)
 

--- a/piperider_cli/cli.py
+++ b/piperider_cli/cli.py
@@ -147,6 +147,7 @@ def diagnose(**kwargs):
 @click.option('--skip-recommend', is_flag=True, help='Skip recommending assertions.')
 @click.option('--dbt-test', is_flag=True, help='Run dbt test.')
 @click.option('--dbt-build', is_flag=True, help='Run dbt build.')
+@click.option('--report-dir', default=None, type=click.STRING, help='Use a different report directory.')
 @add_options(debug_option)
 def run(**kwargs):
     'Profile data source, run assertions, and generate report(s). By default, the raw results and reports are saved in ".piperider/outputs".'
@@ -165,27 +166,30 @@ def run(**kwargs):
                       interaction=not kwargs.get('no_interaction'),
                       skip_report=skip_report,
                       skip_recommend=skip_recommend,
-                      dbt_command=dbt_command)
+                      dbt_command=dbt_command,
+                      report_dir=kwargs.get('report_dir'))
     if not skip_report and ret == 0:
-        GenerateReport.exec(None, output)
+        GenerateReport.exec(None, kwargs.get('report_dir'), output)
 
 
 @cli.command(short_help='Generate recommended assertions.', cls=TrackCommand)
 @click.option('--input', default=None, type=click.Path(exists=True), help='Specify the raw result file.')
+@click.option('--report-dir', default=None, type=click.STRING, help='Use a different report directory.')
 @add_options(debug_option)
 def generate_assertions(**kwargs):
     'Generate recommended assertions based on the latest result. By default, the profiling result will be loaded from ".piperider/outputs".'
     input = kwargs.get('input')
-    AssertionGenerator.exec(input=input)
+    AssertionGenerator.exec(input=input, report_dir=kwargs.get('report_dir'))
 
 
 @cli.command(short_help='Generate a report.', cls=TrackCommand)
 @click.option('--input', default=None, type=click.Path(exists=True), help='Specify the raw result file.')
 @click.option('--output', '-o', default=None, type=click.STRING, help='Directory to save the results.')
+@click.option('--report-dir', default=None, type=click.STRING, help='Use a different report directory.')
 @add_options(debug_option)
 def generate_report(**kwargs):
     'Generate a report from the latest raw result or specified result. By default, the raw results are saved in ".piperider/outputs".'
-    GenerateReport.exec(input=kwargs.get('input'), output=kwargs.get('output'))
+    GenerateReport.exec(input=kwargs.get('input'), report_dir=kwargs.get('report_dir'), output=kwargs.get('output'))
 
 
 @cli.command(short_help='Compare two existing reports.', cls=TrackCommand)
@@ -195,6 +199,7 @@ def generate_report(**kwargs):
 @click.option('--datasource', default=None, type=click.STRING, metavar='DATASOURCE_NAME',
               help='Specify the datasource.')
 @click.option('--output', '-o', default=None, type=click.STRING, help='Directory to save the results.')
+@click.option('--report-dir', default=None, type=click.STRING, help='Use a different report directory.')
 @add_options(debug_option)
 def compare_reports(**kwargs):
     'Compare two existing reports selected in interactive mode or by option.'
@@ -203,5 +208,6 @@ def compare_reports(**kwargs):
     b = kwargs.get('target')
     last = kwargs.get('last')
     datasource = kwargs.get('datasource')
-    CompareReport.exec(a=a, b=b, last=last, datasource=datasource, output=kwargs.get('output'),
+    CompareReport.exec(a=a, b=b, last=last, datasource=datasource,
+                       report_dir=kwargs.get('report_dir'), output=kwargs.get('output'),
                        debug=kwargs.get('debug', False))

--- a/piperider_cli/configuration.py
+++ b/piperider_cli/configuration.py
@@ -18,9 +18,6 @@ from piperider_cli.error import \
 PIPERIDER_WORKSPACE_NAME = '.piperider'
 PIPERIDER_CONFIG_PATH = os.path.join(os.getcwd(), PIPERIDER_WORKSPACE_NAME, 'config.yml')
 PIPERIDER_CREDENTIALS_PATH = os.path.join(os.getcwd(), PIPERIDER_WORKSPACE_NAME, 'credentials.yml')
-PIPERIDER_OUTPUT_PATH = os.path.join(os.getcwd(), PIPERIDER_WORKSPACE_NAME, 'outputs')
-PIPERIDER_REPORT_PATH = os.path.join(os.getcwd(), PIPERIDER_WORKSPACE_NAME, 'reports')
-PIPERIDER_COMPARISON_PATH = os.path.join(os.getcwd(), PIPERIDER_WORKSPACE_NAME, 'comparisons')
 
 # ref: https://docs.getdbt.com/dbt-cli/configure-your-profile
 DBT_PROFILES_DIR_DEFAULT = '~/.dbt/'
@@ -30,7 +27,7 @@ DBT_PROFILE_FILE = 'profiles.yml'
 class Configuration(object):
     """
     Configuration represents the config file in the piperider project
-    at $PROJECT_ROOT./piperider/config.yml
+    at $PROJECT_ROOT/.piperider/config.yml
     """
 
     def __init__(self, dataSources: List[DataSource], **kwargs):
@@ -38,6 +35,14 @@ class Configuration(object):
         self.telemetry_id = kwargs.get('telemetry_id', None)
         if self.telemetry_id is None:
             self.telemetry_id = uuid.uuid4().hex
+        self.report_dir = self._to_report_dir(kwargs.get('report_dir', '.'))
+
+    def _to_report_dir(self, dirname: str):
+        if dirname is None or dirname.strip() == '':
+            dirname = '.'
+        if dirname.startswith('.'):
+            return os.path.abspath(os.path.join(os.getcwd(), PIPERIDER_WORKSPACE_NAME, dirname))
+        return os.path.abspath(dirname)
 
     def get_telemetry_id(self):
         return self.telemetry_id
@@ -145,6 +150,7 @@ class Configuration(object):
         return cls(
             dataSources=data_sources,
             telemetry_id=config.get('telemetry', {}).get('id'),
+            report_dir=config.get('report_dir', '.')
         )
 
     def dump(self, path):

--- a/piperider_cli/filesystem.py
+++ b/piperider_cli/filesystem.py
@@ -1,0 +1,40 @@
+import os
+
+from piperider_cli import raise_exception_when_directory_not_writable
+from piperider_cli.configuration import PIPERIDER_WORKSPACE_NAME, Configuration
+
+piperider_default_report_dir = os.path.join(os.getcwd(), PIPERIDER_WORKSPACE_NAME)
+
+
+class FileSystem:
+
+    def __init__(self, **kwargs):
+        config = Configuration.load()
+        self.report_dir = config.report_dir
+        if kwargs.get('report_dir', None) is not None:
+            self.report_dir = self._to_report_dir(kwargs.get('report_dir'))
+
+        raise_exception_when_directory_not_writable(self.report_dir)
+
+    def _to_report_dir(self, dirname: str):
+        """
+        the "." always refer to `.piperider` not the current working directory
+        """
+        if dirname is None or dirname.strip() == '':
+            dirname = '.'
+        if dirname.startswith('.'):
+            return os.path.abspath(os.path.join(os.getcwd(), PIPERIDER_WORKSPACE_NAME, dirname))
+        return os.path.abspath(dirname)
+
+    def get_output_dir(self):
+        if self.report_dir is None:
+            return os.path.join(piperider_default_report_dir, 'outputs')
+        return os.path.join(self.report_dir, 'outputs')
+
+    def get_comparison_dir(self):
+        if self.report_dir is None:
+            return os.path.join(piperider_default_report_dir, 'comparisons')
+        return os.path.join(self.report_dir, 'comparisons')
+
+    def get_report_dir(self):
+        return self.report_dir


### PR DESCRIPTION
**PR checklist**

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed

**What type of PR is this?**

feature

**What this PR does / why we need it**:

Make the `report_dir` configurable, the `report_dir` is the parent path of `outputs` and `comparisons`
By default, they are located at `.piperider`.



**Which issue(s) this PR fixes**:

sc-27845

**Special notes for your reviewer**:

In this PR, we also remove the variables and introduce `FileSystem` object to handle the directory configurable:

* PIPERIDER_OUTPUT_PATH
* PIPERIDER_COMPARISON_PATH
* PIPERIDER_REPORT_PATH (never used)

## Notes

```yaml
dataSources:
- name: demo
  type: sqlite

report_dir: ./foo/bar
```

Users could configure the `report_dir` in their `config.yml`. The `.` relative directory always refer to `.piperider` itself.

For example:
* `.` will be `$CWD/.piperider` (default behavior)
* `./foor/bar` will be `$CWD/.piperider/foor/bar`
* `../foobar` will be `$CWD/.piperider/../foor/bar` -> will be `$CWD/foor/bar`
* `/home/foo/bar` will be `/home/foo/bar`
* `foobar` will be `$CWD/foobar` (it doesn't start with `.` not refer to `.piperider`)

There are 4 commands with `--report-dir` sharing the same behavior:
* run
* generate-report
* compare-reports
* generate-assertions