### PR TITLE
[Chore] Revert snowflake odbc default timeout value

### DIFF
--- a/piperider_cli/datasource/snowflake.py
+++ b/piperider_cli/datasource/snowflake.py
@@ -42,9 +42,7 @@ class SnowflakeDataSource(DataSource):
             "password": password,
             "database": database,
             "schema": schema,
-            "warehouse": warehouse,
-            "login_timeout": self._connect_timeout,
-            "network_timeout": self._connect_timeout,
+            "warehouse": warehouse
         }
 
         if role:


### PR DESCRIPTION
Signed-off-by: Wei-Chun, Chang <wcchang@infuseai.io>
Co-authored-by: popcorny <celu@infuseai.io>

<!--  Thanks for sending a pull request!  Here are some check items for you: -->

**PR checklist**

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed

**What type of PR is this?**
chore

**What this PR does / why we need it**:
timeout setting is too strict for large dataset query

**Which issue(s) this PR fixes**:
sc-27838

**Special notes for your reviewer**:
https://docs.snowflake.com/en/user-guide/odbc-parameters.html#optional-connection-parameters
`login_timeout`: Default is 60 (seconds).
`network_timeout`: Default is no timeout setting.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
NONE