### PR TITLE
[Bug] sc-28110 fix gcloud command can not execute by copy past

### DIFF
--- a/piperider_cli/datasource/bigquery.py
+++ b/piperider_cli/datasource/bigquery.py
@@ -42,10 +42,10 @@ class BigQueryDataSource(DataSource):
                     f'Default Credential file {DEFAULT_GCP_CREDENTIALS} is not found.\n'
                     'Please execute the following command to generate it.\n'
                     '[green]'
-                    '    gcloud auth application-default login \\\n'
-                    '        --scopes=https://www.googleapis.com/auth/bigquery, \\\n'
-                    '        https://www.googleapis.com/auth/drive.readonly, \\\n'
-                    '        https://www.googleapis.com/auth/iam.test'
+                    'gcloud auth application-default login \\\n'
+                    '--scopes=https://www.googleapis.com/auth/bigquery,\\\n'
+                    'https://www.googleapis.com/auth/drive.readonly,\\\n'
+                    'https://www.googleapis.com/auth/iam.test'
                     '[/green]')
         if method == AUTH_METHOD_SERVICE_ACCOUNT:
             if self.credential.get('keyfile') is None:


### PR DESCRIPTION
Signed-off-by: Kent Huang <kent@infuseai.io>
Co-authored-by: Even Wei <evenwei@infuseai.io>

<!--  Thanks for sending a pull request!  Here are some check items for you: -->

**PR checklist**

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed

**What type of PR is this?**
Bugfix

**What this PR does / why we need it**:
Fix gcloud command can not execute by copy past

**Which issue(s) this PR fixes**:
sc-28110

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
