### PR TITLE
[Bug] iterate table.columns instead of assertions to display columns

### DIFF
--- a/static_report/package.json
+++ b/static_report/package.json
@@ -19,6 +19,7 @@
     "chart.js": "^3.9.1",
     "chartjs-adapter-date-fns": "^2.0.0",
     "date-fns": "^2.28.0",
+    "date-fns-tz": "^1.3.6",
     "framer-motion": "^6.3.4",
     "inter-ui": "^3.19.3",
     "lodash": "^4.17.21",

--- a/static_report/src/components/ComparisonReport/CRTableList/CRTableListColumnList.tsx
+++ b/static_report/src/components/ComparisonReport/CRTableList/CRTableListColumnList.tsx
@@ -1,3 +1,5 @@
+import get from 'lodash/get';
+
 import { CRTableListColumnItem } from './CRTableListColumnItem';
 import {
   getIconForColumnType,
@@ -15,52 +17,55 @@ export function CRTableListColumnList({
   baseTableDatum: TableSchema;
   targetTableDatum: TableSchema;
 }) {
-  const mergedAssertionColumns = Object.keys(
-    baseTableDatum.piperider_assertion_result?.columns || {},
-  ).map((colName) => {
-    const mergedBaseColAssertions = [
-      ...(baseTableDatum.piperider_assertion_result?.columns?.[colName] || []),
-      ...(baseTableDatum.dbt_assertion_result?.columns?.[colName] || []),
-    ];
+  const transformedData = transformAsNestedBaseTargetRecord<
+    TableSchema['columns'],
+    ColumnSchema
+  >(baseTableDatum.columns, targetTableDatum.columns);
 
-    const mergedTargetColAssertions = [
-      ...(targetTableDatum.piperider_assertion_result?.columns?.[colName] ||
-        []),
-      ...(targetTableDatum.dbt_assertion_result?.columns?.[colName] || []),
-    ];
-
+  const columns = Object.keys(targetTableDatum.columns).map((colName) => {
     const { icon: colIcon } = getIconForColumnType(
       targetTableDatum.columns[colName],
     );
 
-    const transformedData = transformAsNestedBaseTargetRecord<
-      TableSchema['columns'],
-      ColumnSchema
-    >(baseTableDatum.columns, targetTableDatum.columns);
+    const mergedBaseColAssertions = [
+      ...get(
+        baseTableDatum,
+        `piperider_assertion_result.columns[${colName}]`,
+        [],
+      ),
+      ...get(baseTableDatum, `dbt_assertion_result.columns[${colName}]`, []),
+    ];
+
+    const mergedTargetColAssertions = [
+      ...get(
+        targetTableDatum,
+        `piperider_assertion_result.columns[${colName}]`,
+        [],
+      ),
+      ...get(targetTableDatum, `dbt_assertion_result.columns[${colName}]`, []),
+    ];
 
     return {
       colName,
+      colIcon,
       mergedBaseColAssertions,
       mergedTargetColAssertions,
-      colIcon,
-      data: transformedData[colName],
     };
   });
 
   return (
     <>
-      {mergedAssertionColumns.map(
+      {columns.map(
         ({
           colName,
           colIcon,
-          data,
           mergedBaseColAssertions,
           mergedTargetColAssertions,
         }) => (
           <CRTableListColumnItem
             key={colName}
             name={colName}
-            columnDatum={data}
+            columnDatum={transformedData[colName]}
             icon={colIcon}
             baseColAssertions={mergedBaseColAssertions}
             targetColAssertions={mergedTargetColAssertions}

--- a/static_report/src/components/ComparisonReport/CRTableList/CRTableListColumnList.tsx
+++ b/static_report/src/components/ComparisonReport/CRTableList/CRTableListColumnList.tsx
@@ -1,5 +1,3 @@
-import get from 'lodash/get';
-
 import { CRTableListColumnItem } from './CRTableListColumnItem';
 import {
   getIconForColumnType,
@@ -28,21 +26,13 @@ export function CRTableListColumnList({
     );
 
     const mergedBaseColAssertions = [
-      ...get(
-        baseTableDatum,
-        `piperider_assertion_result.columns[${colName}]`,
-        [],
-      ),
-      ...get(baseTableDatum, `dbt_assertion_result.columns[${colName}]`, []),
+      ...(baseTableDatum.piperider_assertion_result?.columns[colName] || []),
+      ...(baseTableDatum.dbt_assertion_result?.columns[colName] || []),
     ];
 
     const mergedTargetColAssertions = [
-      ...get(
-        targetTableDatum,
-        `piperider_assertion_result.columns[${colName}]`,
-        [],
-      ),
-      ...get(targetTableDatum, `dbt_assertion_result.columns[${colName}]`, []),
+      ...(targetTableDatum.piperider_assertion_result?.columns[colName] || []),
+      ...(targetTableDatum.dbt_assertion_result?.columns[colName] || []),
     ];
 
     return {

--- a/static_report/src/components/SingleReport/SRTableList/SRTableListColumnList.tsx
+++ b/static_report/src/components/SingleReport/SRTableList/SRTableListColumnList.tsx
@@ -1,5 +1,3 @@
-import get from 'lodash/get';
-
 import { TableSchema } from '../../../sdlc/single-report-schema';
 import { getIconForColumnType } from '../../../utils/transformers';
 import { SRTableListColumnItem } from './SRTableListColumnItem';
@@ -9,8 +7,8 @@ export function SRTableListColumnList({ table }: { table: TableSchema }) {
     const { icon: colIcon } = getIconForColumnType(table.columns[colName]);
     const columnDatum = table.columns[colName];
     const mergedColAssertions = [
-      ...get(table, `piperider_assertion_result.columns[${colName}]`, []),
-      ...get(table, `dbt_assertion_result.columns[${colName}]`, []),
+      ...(table.piperider_assertion_result?.columns[colName] || []),
+      ...(table.dbt_assertion_result?.columns[colName] || []),
     ];
 
     return {

--- a/static_report/src/components/SingleReport/SRTableList/SRTableListColumnList.tsx
+++ b/static_report/src/components/SingleReport/SRTableList/SRTableListColumnList.tsx
@@ -1,38 +1,37 @@
+import get from 'lodash/get';
+
 import { TableSchema } from '../../../sdlc/single-report-schema';
 import { getIconForColumnType } from '../../../utils/transformers';
 import { SRTableListColumnItem } from './SRTableListColumnItem';
 
 export function SRTableListColumnList({ table }: { table: TableSchema }) {
-  const mergedAssertionColumns = Object.keys(
-    table.piperider_assertion_result?.columns || {},
-  ).map((colName) => {
-    const mergedColAssertions = [
-      ...(table.piperider_assertion_result?.columns?.[colName] || []),
-      ...(table.dbt_assertion_result?.columns?.[colName] || []),
-    ];
-
+  const columns = Object.keys(table.columns).map((colName) => {
     const { icon: colIcon } = getIconForColumnType(table.columns[colName]);
+    const columnDatum = table.columns[colName];
+    const mergedColAssertions = [
+      ...get(table, `piperider_assertion_result.columns[${colName}]`, []),
+      ...get(table, `dbt_assertion_result.columns[${colName}]`, []),
+    ];
 
     return {
       colName,
-      mergedColAssertions,
       colIcon,
+      columnDatum,
+      mergedColAssertions,
     };
   });
 
   return (
     <>
-      {mergedAssertionColumns.map(
-        ({ colName, colIcon, mergedColAssertions }) => (
-          <SRTableListColumnItem
-            key={colName}
-            name={colName}
-            columnDatum={table.columns[colName]}
-            colAssertions={mergedColAssertions}
-            icon={colIcon}
-          />
-        ),
-      )}
+      {columns.map(({ colName, colIcon, mergedColAssertions }) => (
+        <SRTableListColumnItem
+          key={colName}
+          name={colName}
+          columnDatum={table.columns[colName]}
+          colAssertions={mergedColAssertions}
+          icon={colIcon}
+        />
+      ))}
     </>
   );
 }

--- a/static_report/src/utils/formatters.tsx
+++ b/static_report/src/utils/formatters.tsx
@@ -1,5 +1,6 @@
 import { Text } from '@chakra-ui/react';
-import { format, isValid, parseISO } from 'date-fns';
+import { format, isValid } from 'date-fns';
+import { formatInTimeZone } from 'date-fns-tz';
 import { NO_VALUE } from '../components/shared/ColumnCard/ColumnTypeDetail/constants';
 
 import type { ColumnSchema } from '../sdlc/single-report-schema';
@@ -13,18 +14,10 @@ import type { ColumnSchema } from '../sdlc/single-report-schema';
  * @returns a formatted date string in 'yyyy/MM/dd HH:mm:ss'
  */
 export function formatReportTime(dateStr: string) {
-  const adjustForUTCOffset = (date) => {
-    return new Date(
-      date.getUTCFullYear(),
-      date.getUTCMonth(),
-      date.getUTCDate(),
-      date.getUTCHours(),
-      date.getUTCMinutes(),
-      date.getUTCSeconds(),
-    );
-  };
+  const date = new Date(dateStr);
+  const userTimezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
 
-  return format(adjustForUTCOffset(parseISO(dateStr)), 'yyyy-MM-dd HH:mm:ss');
+  return formatInTimeZone(date, userTimezone, 'yyyy-MM-dd HH:mm:ss zzz');
 }
 
 /**

--- a/static_report/yarn.lock
+++ b/static_report/yarn.lock
@@ -7032,6 +7032,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"date-fns-tz@npm:^1.3.6":
+  version: 1.3.6
+  resolution: "date-fns-tz@npm:1.3.6"
+  peerDependencies:
+    date-fns: ">=2.0.0"
+  checksum: b706097dea9b5fbf15011aab781a6733eeb7c593a6e8dc07e5b8e2c3c1cdf243754ec321431de72cec1b9c7e4adfa03fb612ca2a3fcaafe0788ffdff76cf773f
+  languageName: node
+  linkType: hard
+
 "date-fns@npm:^2.28.0":
   version: 2.28.0
   resolution: "date-fns@npm:2.28.0"
@@ -13095,6 +13104,7 @@ __metadata:
     craco-esbuild: ^0.5.1
     cypress: ^10.3.0
     date-fns: ^2.28.0
+    date-fns-tz: ^1.3.6
     dotenv-cli: ^6.0.0
     eslint: ^8.17.0
     eslint-config-prettier: ^8.5.0


### PR DESCRIPTION
## Screenshots

**Columns**
<img width="1495" alt="截圖 2022-08-29 09 56 40" src="https://user-images.githubusercontent.com/10325111/187108230-26714e01-91b7-48a5-9541-fcf836249e44.png">

**Generated time with timezone**
<img width="758" alt="截圖 2022-08-29 09 49 58" src="https://user-images.githubusercontent.com/10325111/187108245-85ed183a-2dbd-4f21-8088-4cfac9612e93.png">

## Descriptions

- When assertions equal to 0, still need to display information of columns
- Enhancement of the report generated time with user's current timezone

Signed-off-by: Jie Peng <im@jiepeng.me><!--  Thanks for sending a pull request!  Here are some check items for you: -->

**PR checklist**

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed