### PR TITLE
[Bug] Fix custom assertion exception when falsy actual field given

### DIFF
--- a/piperider_cli/assertion_engine/assertion.py
+++ b/piperider_cli/assertion_engine/assertion.py
@@ -223,14 +223,14 @@ class AssertionResult:
         return self
 
     def success(self, actual=None):
-        if actual:
+        if actual is not None:
             self.actual = actual
 
         self._success = True
         return self
 
     def fail(self, actual=None):
-        if actual:
+        if actual is not None:
             self.actual = actual
 
         self._success = False


### PR DESCRIPTION
Signed-off-by: Wei-Chun, Chang <wcchang@infuseai.io>

<!--  Thanks for sending a pull request!  Here are some check items for you: -->

**PR checklist**

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed

**What type of PR is this?**
Bug

**What this PR does / why we need it**:
Custom assertion cannot be assigned a falsy 'actual' field, 
then causes `IllegalStateAssertionError('Assertion Function should fill 'actual' and 'expected' fields.')`

**Which issue(s) this PR fixes**:
sc-28398

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
NONE