### PR TITLE
[Bug] : add props events to propogate state for tab-index reset (Chakra …

### DIFF
--- a/static_report/src/components/shared/Columns/ColumnDetailMasterList/index.tsx
+++ b/static_report/src/components/shared/Columns/ColumnDetailMasterList/index.tsx
@@ -13,12 +13,12 @@ import { useState } from 'react';
 import { Link, useLocation } from 'wouter';
 
 import { ColumnSchema } from '../../../../sdlc/single-report-schema';
-import { SaferTableSchema } from '../../../../types';
+import { SaferTableSchema, Selectable } from '../../../../types';
 import { transformAsNestedBaseTargetRecord } from '../../../../utils/transformers';
 import { ColumnDetailListItem } from './ColumnDetailListItem';
 
 type ProfilerGenericTypes = ColumnSchema['type'];
-interface Props {
+interface Props extends Selectable {
   baseDataColumns?: SaferTableSchema['columns'];
   targetDataColumns?: SaferTableSchema['columns'];
   currentReport: string;
@@ -35,9 +35,10 @@ export function ColumnDetailsMasterList({
   currentReport,
   currentColumn,
   hasSplitView,
+  onSelect,
 }: Props) {
   const [filterString, setFilterString] = useState<string>('');
-  const [location, setLocation] = useLocation();
+  const [location] = useLocation();
   const [filterState, setFilterState] = useState<
     Map<ProfilerGenericTypes | undefined, boolean>
   >(
@@ -58,6 +59,7 @@ export function ColumnDetailsMasterList({
   const combinedColumnEntries = Object.entries(combinedColumnRecord);
 
   const quickFilters = Array.from(filterState.keys());
+  //FIXME: Temporary implementation!
   const parentRoute = location.slice(0, location.indexOf('/columns'));
 
   return (
@@ -151,7 +153,7 @@ export function ColumnDetailsMasterList({
               baseColumnDatum={base}
               targetColumnDatum={target}
               onSelect={(name) => {
-                setLocation(`/tables/${currentReport}/columns/${name}`);
+                onSelect({ tableName: currentReport, columnName: name });
               }}
               hasSplitView={hasSplitView}
               p={3}

--- a/static_report/src/components/shared/Widgets/ChartTabsWidget.tsx
+++ b/static_report/src/components/shared/Widgets/ChartTabsWidget.tsx
@@ -17,6 +17,8 @@ import { ColumnCardDataVisualContainer } from '../Columns/ColumnCard/ColumnCardD
 import { TEXTLENGTH } from '../Columns/constants';
 
 interface Props {
+  tabIndex: number;
+  onSelectTab: (index: number) => void;
   hasSplitView?: boolean;
   hasAnimation?: boolean;
   baseColumnDatum?: ColumnSchema;
@@ -27,6 +29,8 @@ export function ChartTabsWidget({
   hasSplitView,
   baseColumnDatum,
   targetColumnDatum,
+  tabIndex,
+  onSelectTab,
 }: Props) {
   const {
     type: baseType,
@@ -63,7 +67,7 @@ export function ChartTabsWidget({
     <Box height={'100%'}>
       <Text fontSize={'xl'}>Visualizations</Text>
       {hasAny ? (
-        <Tabs>
+        <Tabs isLazy index={tabIndex} onChange={(i) => onSelectTab(i)}>
           <TabList>
             {hasTopk && <Tab>Top Categories</Tab>}
             {hasHistogram && <Tab>{histogramLabel}</Tab>}

--- a/static_report/src/pages/CRColumnDetailsPage.tsx
+++ b/static_report/src/pages/CRColumnDetailsPage.tsx
@@ -1,5 +1,5 @@
 import { Flex, Grid, GridItem, Text } from '@chakra-ui/react';
-import { useRoute } from 'wouter';
+import { useLocation, useRoute } from 'wouter';
 import { ColumnTypeHeader } from '../components/shared/Columns/ColumnTypeHeader';
 import { Main } from '../components/shared/Main';
 import { formatReportTime } from '../utils/formatters';
@@ -14,6 +14,7 @@ import {
   containsColumnQuantile,
   containsDataSummary,
 } from '../utils/transformers';
+import { useState } from 'react';
 interface Props {
   data: ComparisonReportSchema;
 }
@@ -23,8 +24,9 @@ export function CRColumnDetailsPage({
     input: { tables: targetTables, created_at: targetTime },
   },
 }: Props) {
-  // eslint-disable-next-line
-  const [_, params] = useRoute('/tables/:reportName/columns/:columnName');
+  const [, params] = useRoute('/tables/:reportName/columns/:columnName');
+  const [, setLocation] = useLocation();
+  const [tabIndex, setTabIndex] = useState<number>(0);
 
   const time = `${formatReportTime(baseTime)} -> ${formatReportTime(
     targetTime,
@@ -66,6 +68,10 @@ export function CRColumnDetailsPage({
             currentReport={decodedTableName}
             currentColumn={decodedColName}
             hasSplitView
+            onSelect={({ tableName, columnName }) => {
+              setTabIndex(0); //reset tabs
+              setLocation(`/tables/${tableName}/columns/${columnName}`);
+            }}
           />
         </GridItem>
         {/* Detail Area */}
@@ -127,6 +133,8 @@ export function CRColumnDetailsPage({
               targetColumnDatum={targetColumnDatum}
               hasSplitView
               hasAnimation
+              tabIndex={tabIndex}
+              onSelectTab={(i) => setTabIndex(i)}
             />
           </GridItem>
           {/* Data Summary Block (avg, stddev, ...) */}

--- a/static_report/src/pages/SRColumnDetailsPage.tsx
+++ b/static_report/src/pages/SRColumnDetailsPage.tsx
@@ -1,5 +1,6 @@
 import { Divider, Flex, Grid, GridItem, Text } from '@chakra-ui/react';
-import { useRoute } from 'wouter';
+import { useLocation, useRoute } from 'wouter';
+import { useState } from 'react';
 import { ColumnTypeHeader } from '../components/shared/Columns/ColumnTypeHeader';
 import { Main } from '../components/shared/Main';
 import { SingleReportSchema } from '../sdlc/single-report-schema';
@@ -20,6 +21,8 @@ interface Props {
 export function SRColumnDetailsPage({ data: { tables, created_at } }: Props) {
   // eslint-disable-next-line
   const [_, params] = useRoute('/tables/:reportName/columns/:columnName');
+  const [, setLocation] = useLocation();
+  const [tabIndex, setTabIndex] = useState<number>(0);
   const time = formatReportTime(created_at);
 
   if (!params?.columnName) {
@@ -52,6 +55,10 @@ export function SRColumnDetailsPage({ data: { tables, created_at } }: Props) {
             baseDataColumns={dataColumns}
             currentReport={decodedTableName}
             currentColumn={decodedColName}
+            onSelect={({ tableName, columnName }) => {
+              setTabIndex(0); //resets tabs
+              setLocation(`/tables/${tableName}/columns/${columnName}`);
+            }}
           />
         </GridItem>
 
@@ -79,7 +86,12 @@ export function SRColumnDetailsPage({ data: { tables, created_at } }: Props) {
           </GridItem>
           {/* Chart Block - toggleable tabs */}
           <GridItem gridRow={'span 1'} minWidth={0} p={9} bg={'gray.50'}>
-            <ChartTabsWidget baseColumnDatum={columnDatum} hasAnimation />
+            <ChartTabsWidget
+              baseColumnDatum={columnDatum}
+              hasAnimation
+              tabIndex={tabIndex}
+              onSelectTab={(i) => setTabIndex(i)}
+            />
           </GridItem>
           <GridItem
             gridRow={'span 1'}

--- a/static_report/src/types/index.ts
+++ b/static_report/src/types/index.ts
@@ -87,3 +87,13 @@ export const ZSingleSchema = singleReportSchemaSchema.merge(
 //TODO: temp bypass flag until `input` -> `target` on schema.json
 export const ZComparisonSchema = (flag?: boolean) =>
   zWrapForComparison(ZSingleSchema, ZSingleSchema, flag);
+
+export type Selectable = {
+  onSelect: ({
+    tableName,
+    columnName,
+  }: {
+    tableName?: string;
+    columnName?: string;
+  }) => void;
+};


### PR DESCRIPTION
…Tabs issue)

<!--  Thanks for sending a pull request!  Here are some check items for you: -->

**PR checklist**

- [X] Ensure you have added or ran the appropriate tests for your PR.
- [X ] DCO signed

**What type of PR is this?**
feature fix
**What this PR does / why we need it**:
missing chart render behavior
**Which issue(s) this PR fixes**:
28454
**Special notes for your reviewer**:
https://www.loom.com/share/f49db0912ff541ce949148830be049b5
**Does this PR introduce a user-facing change?**: yes
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
Fix issue where chart tabs in column details page does not auto select available first chart, when navigating to different columns. (blank chart area)