### PR TITLE
[Bug] add default values to assertions check

### DIFF
--- a/static_report/src/components/SingleReport/SingleReport.tsx
+++ b/static_report/src/components/SingleReport/SingleReport.tsx
@@ -32,9 +32,9 @@ export default function SingleReport({ data, name }: Props) {
   const [columnsVisible, setColumnsVisible] = useState(false);
 
   const isAssertionsEmpty =
-    table.piperider_assertion_result?.tests.length === 0 &&
+    (table.piperider_assertion_result?.tests || []).length === 0 &&
     Object.keys(table.piperider_assertion_result?.columns || {}).length === 0 &&
-    table.dbt_assertion_result?.tests.length === 0 &&
+    (table.dbt_assertion_result?.tests || []).length === 0 &&
     Object.keys(table.dbt_assertion_result?.columns || {}).length === 0;
 
   zReport(ZTableSchema.safeParse(table));


### PR DESCRIPTION
## Screenshots

<img width="1344" alt="截圖 2022-09-07 18 07 34" src="https://user-images.githubusercontent.com/10325111/188852705-cedf0650-b000-4369-b374-1d9584f17f5c.png">

## Description

- added default values to assertions because if one of values is `undefined`, the statement (`undefined === 0`) will equal to `false`

Signed-off-by: Jie Peng <im@jiepeng.me>

<!--  Thanks for sending a pull request!  Here are some check items for you: -->

**PR checklist**

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed