### PR TITLE
[Feature] simple breadcrumb nav 2

### DIFF
--- a/static_report/src/App.tsx
+++ b/static_report/src/App.tsx
@@ -1,6 +1,6 @@
 import * as Sentry from '@sentry/browser';
 import { Suspense, lazy } from 'react';
-import { Switch, Route, Router, BaseLocationHook, type Params } from 'wouter';
+import { Switch, Route, Router, BaseLocationHook } from 'wouter';
 import { BrowserTracing } from '@sentry/tracing';
 
 import { Loading } from './components/shared/Loading';
@@ -8,6 +8,10 @@ import { NotFound } from './components/shared/NotFound';
 import { SRTablesListPage } from './pages/SRTablesListPage';
 import { CRTablesListPage } from './pages/CRTablesListPage';
 import { useHashLocation } from './hooks/useHashLcocation';
+import {
+  COLUMN_DETAILS_ROUTE_PATH,
+  TABLE_DETAILS_ROUTE_PATH,
+} from './utils/routes';
 
 const sentryDns = window.PIPERIDER_METADATA.sentry_dns;
 if (sentryDns) {
@@ -45,17 +49,23 @@ function AppSingle() {
             )}
           />
 
-          <Route path="/tables/:reportName">
-            {(params: Params<{ reportName: string }>) => (
+          <Route path={TABLE_DETAILS_ROUTE_PATH}>
+            {({ tableName }) => (
               <SRTableDetailsPage
-                name={decodeURIComponent(params.reportName)}
+                tableName={decodeURIComponent(tableName)}
                 data={window.PIPERIDER_SINGLE_REPORT_DATA}
               />
             )}
           </Route>
 
-          <Route path="/tables/:reportName/columns/:columnName">
-            <SRColumnDetailsPage data={window.PIPERIDER_SINGLE_REPORT_DATA} />
+          <Route path={COLUMN_DETAILS_ROUTE_PATH}>
+            {({ tableName, columnName }) => (
+              <SRColumnDetailsPage
+                tableName={decodeURIComponent(tableName)}
+                columnName={decodeURIComponent(columnName)}
+                data={window.PIPERIDER_SINGLE_REPORT_DATA}
+              />
+            )}
           </Route>
 
           <Route>
@@ -81,18 +91,23 @@ function AppComparison() {
             )}
           />
 
-          <Route path="/tables/:reportName">
-            {(params: Params<{ reportName: string }>) => (
+          <Route path={TABLE_DETAILS_ROUTE_PATH}>
+            {({ tableName }) => (
               <CRTableDetailsPage
-                name={decodeURIComponent(params.reportName)}
+                tableName={decodeURIComponent(tableName)}
                 data={window.PIPERIDER_COMPARISON_REPORT_DATA}
               />
             )}
           </Route>
-          <Route path="/tables/:reportName/columns/:columnName">
-            <CRColumnDetailsPage
-              data={window.PIPERIDER_COMPARISON_REPORT_DATA}
-            />
+
+          <Route path={COLUMN_DETAILS_ROUTE_PATH}>
+            {({ tableName, columnName }) => (
+              <CRColumnDetailsPage
+                tableName={decodeURIComponent(tableName)}
+                columnName={decodeURIComponent(columnName)}
+                data={window.PIPERIDER_COMPARISON_REPORT_DATA}
+              />
+            )}
           </Route>
           <Route>
             <NotFound />

--- a/static_report/src/components/shared/BreadcrumbNav.tsx
+++ b/static_report/src/components/shared/BreadcrumbNav.tsx
@@ -55,7 +55,7 @@ export function SimpleBreadcrumbNavbar({
   );
 
   return (
-    <Flex alignItems={'center'} h={`${height}px`} bg={'gray.200'} {...props}>
+    <Flex alignItems={'center'} h={`${height}px`} {...props}>
       <Breadcrumb
         fontSize="lg"
         separator={<ChevronRightIcon color="gray.500" boxSize={6} />}
@@ -70,7 +70,7 @@ export function SimpleBreadcrumbNavbar({
                 display={'flex'}
                 alignItems={'center'}
               >
-                {label}
+                {decodeURIComponent(label)}
               </BreadcrumbLink>
             </BreadcrumbItem>
           );

--- a/static_report/src/components/shared/BreadcrumbNav.tsx
+++ b/static_report/src/components/shared/BreadcrumbNav.tsx
@@ -27,7 +27,7 @@ interface Props {
  *
  * FUTURE?: or by config provision (custom route logic)?
  */
-export function SimpleBreadcrumbNavbar({
+export function SimpleBreadcrumbNav({
   routePathToMatch,
   height = breadcrumbHeight,
   ...props

--- a/static_report/src/components/shared/BreadcrumbNav.tsx
+++ b/static_report/src/components/shared/BreadcrumbNav.tsx
@@ -1,0 +1,81 @@
+import { ChevronRightIcon } from '@chakra-ui/icons';
+import {
+  Breadcrumb,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  Flex,
+  FlexProps,
+} from '@chakra-ui/react';
+import { Link, useLocation } from 'wouter';
+import { breadcrumbHeight } from '../../utils/layout';
+
+interface BreadcrumbMetaItem {
+  path: string;
+  label: string;
+}
+interface Props {
+  routePathToMatch: string;
+  height?: number;
+}
+/**
+ * A breadcrumb UI that will use browser location to render breadcrumbs based on the route-params manually provided.
+ * FULL_URL1: `/tables/ACTION`
+ * BREADCRUMB: `['/', '/tables/ACTION']
+ *
+ * FULL_URL2: `/tables/ACTION/columns/FOO`
+ * BREADCRUMB: `['/', '/tables/ACTION', '/tables/ACTION/columns/FOO']
+ *
+ * FUTURE?: or by config provision (custom route logic)?
+ */
+export function SimpleBreadcrumbNavbar({
+  routePathToMatch,
+  height = breadcrumbHeight,
+  ...props
+}: Props & FlexProps) {
+  const [location] = useLocation();
+
+  //check if matching params are in location parts,
+  const urlSegments = location.split('/');
+
+  const matcherSegments = routePathToMatch.split('/');
+
+  // routable paths by alternate ordering between path_name and path_param (posts/:id)
+  const breadcrumbList = urlSegments.reduce<BreadcrumbMetaItem[]>(
+    (prev, curr, index) => {
+      const matcherItem = matcherSegments[index];
+      const isCurrentParam = matcherItem.includes(':');
+      if (isCurrentParam) {
+        // get breadcrumbUrl (from root to param)
+        const breadcrumbUrl = urlSegments.slice(0, index + 1).join('/');
+        return [...prev, { path: breadcrumbUrl, label: curr }];
+      }
+      return prev; // else keep going
+    },
+    [{ path: '/', label: 'Home' }],
+  );
+
+  return (
+    <Flex alignItems={'center'} h={`${height}px`} bg={'gray.200'} {...props}>
+      <Breadcrumb
+        fontSize="lg"
+        separator={<ChevronRightIcon color="gray.500" boxSize={6} />}
+      >
+        {breadcrumbList.map(({ label, path }, i) => {
+          return (
+            <BreadcrumbItem key={i} isCurrentPage={location === path}>
+              <BreadcrumbLink
+                to={path}
+                as={Link}
+                cursor={'pointer'}
+                display={'flex'}
+                alignItems={'center'}
+              >
+                {label}
+              </BreadcrumbLink>
+            </BreadcrumbItem>
+          );
+        })}
+      </Breadcrumb>
+    </Flex>
+  );
+}

--- a/static_report/src/components/shared/BreadcrumbNav.tsx
+++ b/static_report/src/components/shared/BreadcrumbNav.tsx
@@ -56,7 +56,7 @@ export function BreadcrumbNav({
   );
 
   return (
-    <Flex alignItems={'center'} h={`${height}px`} {...props}>
+    <Flex alignItems={'center'} h={`${height}px`} px={3} {...props}>
       <Breadcrumb
         fontSize="lg"
         separator={<ChevronRightIcon color="gray.500" boxSize={6} />}

--- a/static_report/src/components/shared/BreadcrumbNav.tsx
+++ b/static_report/src/components/shared/BreadcrumbNav.tsx
@@ -27,7 +27,7 @@ interface Props {
  *
  * FUTURE?: or by config provision (custom route logic)?
  */
-export function SimpleBreadcrumbNav({
+export function BreadcrumbNav({
   routePathToMatch,
   height = breadcrumbHeight,
   ...props
@@ -40,9 +40,10 @@ export function SimpleBreadcrumbNav({
   const matcherSegments = routePathToMatch.split('/');
 
   // routable paths by alternate ordering between path_name and path_param (posts/:id)
+
   const breadcrumbList = urlSegments.reduce<BreadcrumbMetaItem[]>(
     (prev, curr, index) => {
-      const matcherItem = matcherSegments[index];
+      const matcherItem = matcherSegments[index] || '';
       const isCurrentParam = matcherItem.includes(':');
       if (isCurrentParam) {
         // get breadcrumbUrl (from root to param)

--- a/static_report/src/components/shared/Tables/TableActionBar.tsx
+++ b/static_report/src/components/shared/Tables/TableActionBar.tsx
@@ -6,6 +6,7 @@ import {
   ButtonGroup,
   Tooltip,
 } from '@chakra-ui/react';
+import { ReactNode } from 'react';
 import {
   FiDatabase,
   FiCreditCard,
@@ -20,6 +21,7 @@ type Props = {
   toggleView: (view: TableActionBarView) => void;
   sourceName: string;
   sourceType: string;
+  children?: ReactNode;
 };
 
 export function TableActionBar({
@@ -27,6 +29,7 @@ export function TableActionBar({
   toggleView,
   sourceName,
   sourceType,
+  children,
 }: Props) {
   return (
     <Flex
@@ -48,6 +51,7 @@ export function TableActionBar({
         >
           <Icon as={FiAlertCircle} />
         </Tooltip>
+        {children}
       </Flex>
 
       <ButtonGroup

--- a/static_report/src/components/shared/Tables/TableList/CRTableListItem/CRTableListAssertions.tsx
+++ b/static_report/src/components/shared/Tables/TableList/CRTableListItem/CRTableListAssertions.tsx
@@ -24,19 +24,19 @@ const getAssertionValue = partial((value: string | number) =>
 
 export function CRTableListAssertions({
   data,
-  reportName,
+  tableName,
 }: {
   data: ComparisonReportSchema;
-  reportName: string;
+  tableName: string;
 }) {
   const [baseOverview, targetOverview] = getComparisonAssertions({
     data,
-    reportName,
+    tableName,
     type: 'piperider',
   });
   const [dbtBaseOverview, dbtTargetOverview] = getComparisonAssertions({
     data,
-    reportName,
+    tableName,
     type: 'dbt',
   });
 

--- a/static_report/src/pages/CRColumnDetailsPage.tsx
+++ b/static_report/src/pages/CRColumnDetailsPage.tsx
@@ -1,5 +1,5 @@
 import { Flex, Grid, GridItem, Text } from '@chakra-ui/react';
-import { useLocation, useRoute } from 'wouter';
+import { useLocation } from 'wouter';
 import { useState } from 'react';
 
 import { ColumnTypeHeader } from '../components/shared/Columns/ColumnTypeHeader';
@@ -18,8 +18,13 @@ import {
 } from '../utils/transformers';
 
 import type { ComparisonReportSchema } from '../types';
+import { SimpleBreadcrumbNavbar } from '../components/shared/BreadcrumbNav';
+import { COLUMN_DETAILS_ROUTE_PATH } from '../utils/routes';
+import { NoData } from '../components/shared/NoData';
 interface Props {
   data: ComparisonReportSchema;
+  columnName: string;
+  tableName: string;
 }
 
 export default function CRColumnDetailsPage({
@@ -27,27 +32,25 @@ export default function CRColumnDetailsPage({
     base: { tables: baseTables, created_at: baseTime },
     input: { tables: targetTables, created_at: targetTime },
   },
+  columnName,
+  tableName,
 }: Props) {
-  const [, params] = useRoute('/tables/:reportName/columns/:columnName');
   const [, setLocation] = useLocation();
   const [tabIndex, setTabIndex] = useState<number>(0);
 
   const time = `${formatReportTime(baseTime)} -> ${formatReportTime(
     targetTime,
   )}`;
-  if (!params?.columnName) {
+  if (!columnName || !tableName) {
     return (
       <Main isSingleReport={false} time={time}>
-        <Flex justifyContent="center" alignItems="center" minHeight="100vh">
-          No profile column data found.
-        </Flex>
+        <NoData text="No profile data found." />
       </Main>
     );
   }
 
-  const { reportName, columnName } = params;
   const decodedColName = decodeURIComponent(columnName);
-  const decodedTableName = decodeURIComponent(reportName);
+  const decodedTableName = decodeURIComponent(tableName);
 
   const baseDataColumns = baseTables[decodedTableName]?.columns || {};
   const targetDataColumns = targetTables[decodedTableName]?.columns || {};
@@ -64,6 +67,11 @@ export default function CRColumnDetailsPage({
   return (
     <Main isSingleReport={false} time={time} maxHeight={mainContentAreaHeight}>
       <Grid width={'inherit'} templateColumns={'1fr 2fr'}>
+        <GridItem colSpan={3}>
+          <SimpleBreadcrumbNavbar
+            routePathToMatch={COLUMN_DETAILS_ROUTE_PATH}
+          />
+        </GridItem>
         {/* Master Area */}
         <GridItem overflowY={'scroll'} maxHeight={mainContentAreaHeight}>
           <ColumnDetailsMasterList

--- a/static_report/src/pages/CRColumnDetailsPage.tsx
+++ b/static_report/src/pages/CRColumnDetailsPage.tsx
@@ -18,7 +18,7 @@ import {
 } from '../utils/transformers';
 
 import type { ComparisonReportSchema } from '../types';
-import { SimpleBreadcrumbNavbar } from '../components/shared/BreadcrumbNav';
+import { SimpleBreadcrumbNav } from '../components/shared/BreadcrumbNav';
 import { COLUMN_DETAILS_ROUTE_PATH } from '../utils/routes';
 import { NoData } from '../components/shared/NoData';
 interface Props {
@@ -68,9 +68,7 @@ export default function CRColumnDetailsPage({
     <Main isSingleReport={false} time={time} maxHeight={mainContentAreaHeight}>
       <Grid width={'inherit'} templateColumns={'1fr 2fr'}>
         <GridItem colSpan={3}>
-          <SimpleBreadcrumbNavbar
-            routePathToMatch={COLUMN_DETAILS_ROUTE_PATH}
-          />
+          <SimpleBreadcrumbNav routePathToMatch={COLUMN_DETAILS_ROUTE_PATH} />
         </GridItem>
         {/* Master Area */}
         <GridItem overflowY={'scroll'} maxHeight={mainContentAreaHeight}>

--- a/static_report/src/pages/CRColumnDetailsPage.tsx
+++ b/static_report/src/pages/CRColumnDetailsPage.tsx
@@ -18,7 +18,7 @@ import {
 } from '../utils/transformers';
 
 import type { ComparisonReportSchema } from '../types';
-import { SimpleBreadcrumbNav } from '../components/shared/BreadcrumbNav';
+import { BreadcrumbNav } from '../components/shared/BreadcrumbNav';
 import { COLUMN_DETAILS_ROUTE_PATH } from '../utils/routes';
 import { NoData } from '../components/shared/NoData';
 interface Props {
@@ -68,7 +68,7 @@ export default function CRColumnDetailsPage({
     <Main isSingleReport={false} time={time} maxHeight={mainContentAreaHeight}>
       <Grid width={'inherit'} templateColumns={'1fr 2fr'}>
         <GridItem colSpan={3}>
-          <SimpleBreadcrumbNav routePathToMatch={COLUMN_DETAILS_ROUTE_PATH} />
+          <BreadcrumbNav routePathToMatch={COLUMN_DETAILS_ROUTE_PATH} />
         </GridItem>
         {/* Master Area */}
         <GridItem overflowY={'scroll'} maxHeight={mainContentAreaHeight}>

--- a/static_report/src/pages/CRTableDetailsPage.tsx
+++ b/static_report/src/pages/CRTableDetailsPage.tsx
@@ -21,7 +21,7 @@ import { TableOverview } from '../components/shared/Tables/TableOverview';
 import { formatReportTime } from '../utils/formatters';
 import { CollapseContent } from '../components/shared/CollapseContent';
 import { CRAssertionDetailsWidget } from '../components/shared/Widgets/CRAssertionDetailsWidget';
-import { SimpleBreadcrumbNavbar } from '../components/shared/BreadcrumbNav';
+import { SimpleBreadcrumbNav } from '../components/shared/BreadcrumbNav';
 import { TABLE_DETAILS_ROUTE_PATH } from '../utils/routes';
 import { NoData } from '../components/shared/NoData';
 
@@ -84,7 +84,7 @@ export default function CRTableDetailsPage({ data, tableName }: Props) {
       )}`}
     >
       <Flex direction="column" width="inherit">
-        <SimpleBreadcrumbNavbar routePathToMatch={TABLE_DETAILS_ROUTE_PATH} />
+        <SimpleBreadcrumbNav routePathToMatch={TABLE_DETAILS_ROUTE_PATH} />
 
         <Flex
           border="1px solid"

--- a/static_report/src/pages/CRTableDetailsPage.tsx
+++ b/static_report/src/pages/CRTableDetailsPage.tsx
@@ -1,14 +1,6 @@
-import {
-  Breadcrumb,
-  BreadcrumbItem,
-  BreadcrumbLink,
-  Flex,
-  Heading,
-  useDisclosure,
-} from '@chakra-ui/react';
-import { Link, useLocation } from 'wouter';
+import { Flex, Heading, useDisclosure } from '@chakra-ui/react';
+import { useLocation } from 'wouter';
 import { useState } from 'react';
-import { FiDatabase, FiGrid } from 'react-icons/fi';
 
 import { Main } from '../components/shared/Main';
 import { getComparisonAssertions } from '../utils/assertion';
@@ -29,36 +21,47 @@ import { TableOverview } from '../components/shared/Tables/TableOverview';
 import { formatReportTime } from '../utils/formatters';
 import { CollapseContent } from '../components/shared/CollapseContent';
 import { CRAssertionDetailsWidget } from '../components/shared/Widgets/CRAssertionDetailsWidget';
+import { SimpleBreadcrumbNavbar } from '../components/shared/BreadcrumbNav';
+import { TABLE_DETAILS_ROUTE_PATH } from '../utils/routes';
+import { NoData } from '../components/shared/NoData';
 
 type Props = {
   data: ComparisonReportSchema;
-  name: string;
+  tableName: string;
 };
-export default function CRTableDetailsPage({ data, name: reportName }: Props) {
+export default function CRTableDetailsPage({ data, tableName }: Props) {
   const [testDetail, setTestDetail] = useState<TestDetail | null>(null);
   const modal = useDisclosure();
   const [assertionsVisible, setAssertionsVisible] = useState(false);
   const [columnsVisible, setColumnsVisible] = useState(false);
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const [location, setLocation] = useLocation();
+  const [, setLocation] = useLocation();
+  useDocumentTitle(tableName);
+
+  if (!data || !tableName) {
+    return (
+      <Main isSingleReport time="-">
+        <NoData text="No profile data found." />
+      </Main>
+    );
+  }
 
   const { base, input: target } = data;
   zReport(ZComparisonSchema(true).safeParse(data));
 
-  const baseTable = base.tables[reportName];
-  const targetTable = target.tables[reportName];
+  const baseTable = base.tables[tableName];
+  const targetTable = target.tables[tableName];
 
   zReport(ZTableSchema.safeParse(baseTable));
   zReport(ZTableSchema.safeParse(targetTable));
 
   const [baseOverview, targetOverview] = getComparisonAssertions({
     data,
-    reportName,
+    tableName,
     type: 'piperider',
   });
   const [dbtBaseOverview, dbtTargetOverview] = getComparisonAssertions({
     data,
-    reportName,
+    tableName,
     type: 'dbt',
   });
 
@@ -73,8 +76,6 @@ export default function CRTableDetailsPage({ data, name: reportName }: Props) {
   const isAssertionsEmpty =
     piperiderAssertions.length === 0 && dbtAssertions.length === 0;
 
-  useDocumentTitle(reportName);
-
   return (
     <Main
       isSingleReport={false}
@@ -83,28 +84,7 @@ export default function CRTableDetailsPage({ data, name: reportName }: Props) {
       )}`}
     >
       <Flex direction="column" width="inherit">
-        <Flex mx="5%" mt={4}>
-          <Breadcrumb fontSize="lg">
-            <BreadcrumbItem>
-              <Link href="/">
-                <BreadcrumbLink href="/" data-cy="cr-report-breadcrumb-back">
-                  <Flex alignItems="center" gap={1}>
-                    <FiDatabase /> Tables
-                  </Flex>
-                </BreadcrumbLink>
-              </Link>
-            </BreadcrumbItem>
-
-            <BreadcrumbItem isCurrentPage>
-              <BreadcrumbLink href="#">
-                <Flex alignItems="center" gap={1}>
-                  <FiGrid />
-                  {reportName}
-                </Flex>
-              </BreadcrumbLink>
-            </BreadcrumbItem>
-          </Breadcrumb>
-        </Flex>
+        <SimpleBreadcrumbNavbar routePathToMatch={TABLE_DETAILS_ROUTE_PATH} />
 
         <Flex
           border="1px solid"

--- a/static_report/src/pages/CRTableDetailsPage.tsx
+++ b/static_report/src/pages/CRTableDetailsPage.tsx
@@ -21,7 +21,7 @@ import { TableOverview } from '../components/shared/Tables/TableOverview';
 import { formatReportTime } from '../utils/formatters';
 import { CollapseContent } from '../components/shared/CollapseContent';
 import { CRAssertionDetailsWidget } from '../components/shared/Widgets/CRAssertionDetailsWidget';
-import { SimpleBreadcrumbNav } from '../components/shared/BreadcrumbNav';
+import { BreadcrumbNav } from '../components/shared/BreadcrumbNav';
 import { TABLE_DETAILS_ROUTE_PATH } from '../utils/routes';
 import { NoData } from '../components/shared/NoData';
 
@@ -84,7 +84,7 @@ export default function CRTableDetailsPage({ data, tableName }: Props) {
       )}`}
     >
       <Flex direction="column" width="inherit">
-        <SimpleBreadcrumbNav routePathToMatch={TABLE_DETAILS_ROUTE_PATH} />
+        <BreadcrumbNav routePathToMatch={TABLE_DETAILS_ROUTE_PATH} />
 
         <Flex
           border="1px solid"

--- a/static_report/src/pages/CRTablesListPage.tsx
+++ b/static_report/src/pages/CRTablesListPage.tsx
@@ -24,6 +24,7 @@ import {
   Accordion,
   AccordionItem,
   AccordionPanel,
+  Divider,
   Flex,
   Grid,
   Stack,
@@ -34,6 +35,7 @@ import { CRTableListColumnList } from '../components/shared/Tables/TableList/CRT
 import { CRTableSchemaDetails } from '../components/shared/Tables/TableList/CRTableListItem/CRTableSchemaDetails';
 import { useLocation } from 'wouter';
 import { CRTableListAssertions } from '../components/shared/Tables/TableList/CRTableListItem/CRTableListAssertions';
+import { SimpleBreadcrumbNavbar } from '../components/shared/BreadcrumbNav';
 
 type Props = { data: ComparisonReportSchema };
 
@@ -68,7 +70,12 @@ export function CRTablesListPage({ data }: Props) {
         toggleView={(nextView) => {
           setView(nextView);
         }}
-      />
+      >
+        <>
+          <Divider orientation="vertical" mx={3} />
+          <SimpleBreadcrumbNavbar routePathToMatch="/" />
+        </>
+      </TableActionBar>
 
       <Flex direction="column" width="900px" minHeight="650px">
         <Grid templateColumns="218px 2fr 1.5fr" px={4} my={6}>

--- a/static_report/src/pages/CRTablesListPage.tsx
+++ b/static_report/src/pages/CRTablesListPage.tsx
@@ -93,7 +93,7 @@ export function CRTablesListPage({ data }: Props) {
                         targetTableDatum={table.target}
                         onSelect={() => setLocation(`/tables/${key}`)}
                       >
-                        <CRTableListAssertions data={data} reportName={key} />
+                        <CRTableListAssertions data={data} tableName={key} />
                       </CRTableListItem>
                       {/* Accordion Children Types */}
                       <AccordionPanel bgColor="white">

--- a/static_report/src/pages/CRTablesListPage.tsx
+++ b/static_report/src/pages/CRTablesListPage.tsx
@@ -35,7 +35,7 @@ import { CRTableListColumnList } from '../components/shared/Tables/TableList/CRT
 import { CRTableSchemaDetails } from '../components/shared/Tables/TableList/CRTableListItem/CRTableSchemaDetails';
 import { useLocation } from 'wouter';
 import { CRTableListAssertions } from '../components/shared/Tables/TableList/CRTableListItem/CRTableListAssertions';
-import { SimpleBreadcrumbNavbar } from '../components/shared/BreadcrumbNav';
+import { SimpleBreadcrumbNav } from '../components/shared/BreadcrumbNav';
 
 type Props = { data: ComparisonReportSchema };
 
@@ -73,7 +73,7 @@ export function CRTablesListPage({ data }: Props) {
       >
         <>
           <Divider orientation="vertical" mx={3} />
-          <SimpleBreadcrumbNavbar routePathToMatch="/" />
+          <SimpleBreadcrumbNav routePathToMatch="/" />
         </>
       </TableActionBar>
 

--- a/static_report/src/pages/CRTablesListPage.tsx
+++ b/static_report/src/pages/CRTablesListPage.tsx
@@ -35,7 +35,7 @@ import { CRTableListColumnList } from '../components/shared/Tables/TableList/CRT
 import { CRTableSchemaDetails } from '../components/shared/Tables/TableList/CRTableListItem/CRTableSchemaDetails';
 import { useLocation } from 'wouter';
 import { CRTableListAssertions } from '../components/shared/Tables/TableList/CRTableListItem/CRTableListAssertions';
-import { SimpleBreadcrumbNav } from '../components/shared/BreadcrumbNav';
+import { BreadcrumbNav } from '../components/shared/BreadcrumbNav';
 
 type Props = { data: ComparisonReportSchema };
 
@@ -73,7 +73,7 @@ export function CRTablesListPage({ data }: Props) {
       >
         <>
           <Divider orientation="vertical" mx={3} />
-          <SimpleBreadcrumbNav routePathToMatch="/" />
+          <BreadcrumbNav routePathToMatch="/" />
         </>
       </TableActionBar>
 

--- a/static_report/src/pages/SRColumnDetailsPage.tsx
+++ b/static_report/src/pages/SRColumnDetailsPage.tsx
@@ -18,7 +18,7 @@ import { formatReportTime } from '../utils/formatters';
 import type { SingleReportSchema } from '../sdlc/single-report-schema';
 import { DataSummaryWidget } from '../components/shared/Widgets/DataSummaryWidget';
 import { NoData } from '../components/shared/NoData';
-import { SimpleBreadcrumbNav } from '../components/shared/BreadcrumbNav';
+import { BreadcrumbNav } from '../components/shared/BreadcrumbNav';
 import { COLUMN_DETAILS_ROUTE_PATH } from '../utils/routes';
 interface Props {
   data: SingleReportSchema;
@@ -56,7 +56,7 @@ export default function SRColumnDetailsPage({
     <Main isSingleReport time={time} maxHeight={mainContentAreaHeight}>
       <Grid width={'inherit'} templateColumns={'1fr 2fr'}>
         <GridItem colSpan={3}>
-          <SimpleBreadcrumbNav routePathToMatch={COLUMN_DETAILS_ROUTE_PATH} />
+          <BreadcrumbNav routePathToMatch={COLUMN_DETAILS_ROUTE_PATH} />
         </GridItem>
         {/* Master Area */}
         <GridItem overflowY={'scroll'} maxHeight={mainContentAreaHeight}>

--- a/static_report/src/pages/SRColumnDetailsPage.tsx
+++ b/static_report/src/pages/SRColumnDetailsPage.tsx
@@ -18,7 +18,7 @@ import { formatReportTime } from '../utils/formatters';
 import type { SingleReportSchema } from '../sdlc/single-report-schema';
 import { DataSummaryWidget } from '../components/shared/Widgets/DataSummaryWidget';
 import { NoData } from '../components/shared/NoData';
-import { SimpleBreadcrumbNavbar } from '../components/shared/BreadcrumbNav';
+import { SimpleBreadcrumbNav } from '../components/shared/BreadcrumbNav';
 import { COLUMN_DETAILS_ROUTE_PATH } from '../utils/routes';
 interface Props {
   data: SingleReportSchema;
@@ -56,9 +56,7 @@ export default function SRColumnDetailsPage({
     <Main isSingleReport time={time} maxHeight={mainContentAreaHeight}>
       <Grid width={'inherit'} templateColumns={'1fr 2fr'}>
         <GridItem colSpan={3}>
-          <SimpleBreadcrumbNavbar
-            routePathToMatch={COLUMN_DETAILS_ROUTE_PATH}
-          />
+          <SimpleBreadcrumbNav routePathToMatch={COLUMN_DETAILS_ROUTE_PATH} />
         </GridItem>
         {/* Master Area */}
         <GridItem overflowY={'scroll'} maxHeight={mainContentAreaHeight}>

--- a/static_report/src/pages/SRColumnDetailsPage.tsx
+++ b/static_report/src/pages/SRColumnDetailsPage.tsx
@@ -1,5 +1,5 @@
-import { Flex, Grid, GridItem } from '@chakra-ui/react';
-import { useLocation, useRoute } from 'wouter';
+import { Grid, GridItem } from '@chakra-ui/react';
+import { useLocation } from 'wouter';
 import { useState } from 'react';
 import { ColumnTypeHeader } from '../components/shared/Columns/ColumnTypeHeader';
 import { Main } from '../components/shared/Main';
@@ -17,30 +17,33 @@ import { formatReportTime } from '../utils/formatters';
 
 import type { SingleReportSchema } from '../sdlc/single-report-schema';
 import { DataSummaryWidget } from '../components/shared/Widgets/DataSummaryWidget';
+import { NoData } from '../components/shared/NoData';
+import { SimpleBreadcrumbNavbar } from '../components/shared/BreadcrumbNav';
+import { COLUMN_DETAILS_ROUTE_PATH } from '../utils/routes';
 interface Props {
   data: SingleReportSchema;
+  columnName: string;
+  tableName: string;
 }
 export default function SRColumnDetailsPage({
   data: { tables, created_at },
+  columnName,
+  tableName,
 }: Props) {
-  const [, params] = useRoute('/tables/:reportName/columns/:columnName');
   const [, setLocation] = useLocation();
   const [tabIndex, setTabIndex] = useState<number>(0);
   const time = formatReportTime(created_at);
 
-  if (!params?.columnName) {
+  if (!columnName || !tableName) {
     return (
       <Main isSingleReport time={time}>
-        <Flex justifyContent="center" alignItems="center" minHeight="100vh">
-          No profile column data found.
-        </Flex>
+        <NoData text="No profile data found." />
       </Main>
     );
   }
 
-  const { reportName, columnName } = params;
   const decodedColName = decodeURIComponent(columnName);
-  const decodedTableName = decodeURIComponent(reportName);
+  const decodedTableName = decodeURIComponent(tableName);
 
   const dataColumns = tables[decodedTableName].columns;
   const columnDatum = dataColumns[decodedColName];
@@ -52,6 +55,11 @@ export default function SRColumnDetailsPage({
   return (
     <Main isSingleReport time={time} maxHeight={mainContentAreaHeight}>
       <Grid width={'inherit'} templateColumns={'1fr 2fr'}>
+        <GridItem colSpan={3}>
+          <SimpleBreadcrumbNavbar
+            routePathToMatch={COLUMN_DETAILS_ROUTE_PATH}
+          />
+        </GridItem>
         {/* Master Area */}
         <GridItem overflowY={'scroll'} maxHeight={mainContentAreaHeight}>
           <ColumnDetailsMasterList

--- a/static_report/src/pages/SRTableDetailsPage.tsx
+++ b/static_report/src/pages/SRTableDetailsPage.tsx
@@ -1,12 +1,5 @@
-import {
-  Breadcrumb,
-  BreadcrumbItem,
-  BreadcrumbLink,
-  Flex,
-  Heading,
-} from '@chakra-ui/react';
-import { Link, useLocation } from 'wouter';
-import { FiDatabase, FiGrid } from 'react-icons/fi';
+import { Flex, Heading } from '@chakra-ui/react';
+import { useLocation } from 'wouter';
 import { useState } from 'react';
 import { nanoid } from 'nanoid';
 
@@ -24,32 +17,33 @@ import type {
   TableSchema,
 } from '../sdlc/single-report-schema';
 import { TableOverview } from '../components/shared/Tables/TableOverview';
+import { SimpleBreadcrumbNavbar } from '../components/shared/BreadcrumbNav';
+import { TABLE_DETAILS_ROUTE_PATH } from '../utils/routes';
+import { NoData } from '../components/shared/NoData';
 
 interface Props {
   data: SingleReportSchema;
-  name: string;
+  tableName: string;
 }
 
-export default function SRTableDetailsPage({ data, name }: Props) {
+export default function SRTableDetailsPage({ data, tableName }: Props) {
   const [, setLocation] = useLocation();
   const [assertionsVisible, setAssertionsVisible] = useState(false);
   const [columnsVisible, setColumnsVisible] = useState(false);
 
   const { datasource, tables } = data;
-  const table = tables[name];
+  const table = tables[tableName];
   const isAssertionsEmpty = checkAssertionsIsEmpty(table);
 
   zReport(ZTableSchema.safeParse(table));
   zReport(dataSourceSchema.safeParse(datasource));
 
-  useDocumentTitle(name);
+  useDocumentTitle(tableName);
 
-  if (!data) {
+  if (!data || !tableName) {
     return (
       <Main isSingleReport time="-">
-        <Flex justifyContent="center" alignItems="center" minHeight="100vh">
-          No profile data found.
-        </Flex>
+        <NoData text="No profile data found." />
       </Main>
     );
   }
@@ -57,27 +51,7 @@ export default function SRTableDetailsPage({ data, name }: Props) {
   return (
     <Main isSingleReport time={formatReportTime(data.created_at)}>
       <Flex direction="column" width="100%">
-        <Flex mx="5%" mt={4}>
-          <Breadcrumb fontSize="lg">
-            <BreadcrumbItem>
-              <Link href="/">
-                <BreadcrumbLink href="/" data-cy="sr-report-breadcrumb-back">
-                  <Flex alignItems="center" gap={1}>
-                    <FiDatabase /> {datasource.name}
-                  </Flex>
-                </BreadcrumbLink>
-              </Link>
-            </BreadcrumbItem>
-
-            <BreadcrumbItem isCurrentPage>
-              <BreadcrumbLink href="#">
-                <Flex alignItems="center" gap={1}>
-                  <FiGrid /> {table.name}
-                </Flex>
-              </BreadcrumbLink>
-            </BreadcrumbItem>
-          </Breadcrumb>
-        </Flex>
+        <SimpleBreadcrumbNavbar routePathToMatch={TABLE_DETAILS_ROUTE_PATH} />
 
         <Flex
           border="1px solid"

--- a/static_report/src/pages/SRTableDetailsPage.tsx
+++ b/static_report/src/pages/SRTableDetailsPage.tsx
@@ -17,7 +17,7 @@ import type {
   TableSchema,
 } from '../sdlc/single-report-schema';
 import { TableOverview } from '../components/shared/Tables/TableOverview';
-import { SimpleBreadcrumbNavbar } from '../components/shared/BreadcrumbNav';
+import { SimpleBreadcrumbNav } from '../components/shared/BreadcrumbNav';
 import { TABLE_DETAILS_ROUTE_PATH } from '../utils/routes';
 import { NoData } from '../components/shared/NoData';
 
@@ -51,7 +51,7 @@ export default function SRTableDetailsPage({ data, tableName }: Props) {
   return (
     <Main isSingleReport time={formatReportTime(data.created_at)}>
       <Flex direction="column" width="100%">
-        <SimpleBreadcrumbNavbar routePathToMatch={TABLE_DETAILS_ROUTE_PATH} />
+        <SimpleBreadcrumbNav routePathToMatch={TABLE_DETAILS_ROUTE_PATH} />
 
         <Flex
           border="1px solid"

--- a/static_report/src/pages/SRTableDetailsPage.tsx
+++ b/static_report/src/pages/SRTableDetailsPage.tsx
@@ -17,7 +17,7 @@ import type {
   TableSchema,
 } from '../sdlc/single-report-schema';
 import { TableOverview } from '../components/shared/Tables/TableOverview';
-import { SimpleBreadcrumbNav } from '../components/shared/BreadcrumbNav';
+import { BreadcrumbNav } from '../components/shared/BreadcrumbNav';
 import { TABLE_DETAILS_ROUTE_PATH } from '../utils/routes';
 import { NoData } from '../components/shared/NoData';
 
@@ -51,7 +51,7 @@ export default function SRTableDetailsPage({ data, tableName }: Props) {
   return (
     <Main isSingleReport time={formatReportTime(data.created_at)}>
       <Flex direction="column" width="100%">
-        <SimpleBreadcrumbNav routePathToMatch={TABLE_DETAILS_ROUTE_PATH} />
+        <BreadcrumbNav routePathToMatch={TABLE_DETAILS_ROUTE_PATH} />
 
         <Flex
           border="1px solid"

--- a/static_report/src/pages/SRTablesListPage.tsx
+++ b/static_report/src/pages/SRTablesListPage.tsx
@@ -2,6 +2,7 @@ import {
   Accordion,
   AccordionItem,
   AccordionPanel,
+  Divider,
   Flex,
   Grid,
   Stack,
@@ -25,6 +26,7 @@ import { zReport, ZTableSchema } from '../types';
 import { SRTableListColumnList } from '../components/shared/Tables/TableList/SRTableListItem/SRTableListColumnList';
 import { SRTableListSchemaDetail } from '../components/shared/Tables/TableList/SRTableListItem/SRTableListSchemaDetail';
 import { SRTableListItem } from '../components/shared/Tables/TableList/SRTableListItem';
+import { SimpleBreadcrumbNavbar } from '../components/shared/BreadcrumbNav';
 
 type Props = { data: SingleReportSchema };
 
@@ -48,7 +50,12 @@ export function SRTablesListPage({ data }: Props) {
         toggleView={(nextView) => {
           setView(nextView);
         }}
-      />
+      >
+        <>
+          <Divider orientation="vertical" mx={3} />
+          <SimpleBreadcrumbNavbar routePathToMatch="/" />
+        </>
+      </TableActionBar>
 
       <Flex direction="column" width="900px" minHeight="650px">
         <Grid templateColumns="1fr 2fr 1fr" px={4} my={6}>

--- a/static_report/src/pages/SRTablesListPage.tsx
+++ b/static_report/src/pages/SRTablesListPage.tsx
@@ -26,7 +26,7 @@ import { zReport, ZTableSchema } from '../types';
 import { SRTableListColumnList } from '../components/shared/Tables/TableList/SRTableListItem/SRTableListColumnList';
 import { SRTableListSchemaDetail } from '../components/shared/Tables/TableList/SRTableListItem/SRTableListSchemaDetail';
 import { SRTableListItem } from '../components/shared/Tables/TableList/SRTableListItem';
-import { SimpleBreadcrumbNav } from '../components/shared/BreadcrumbNav';
+import { BreadcrumbNav } from '../components/shared/BreadcrumbNav';
 
 type Props = { data: SingleReportSchema };
 
@@ -53,7 +53,7 @@ export function SRTablesListPage({ data }: Props) {
       >
         <>
           <Divider orientation="vertical" mx={3} />
-          <SimpleBreadcrumbNav routePathToMatch="/" />
+          <BreadcrumbNav routePathToMatch="/" />
         </>
       </TableActionBar>
 

--- a/static_report/src/pages/SRTablesListPage.tsx
+++ b/static_report/src/pages/SRTablesListPage.tsx
@@ -26,7 +26,7 @@ import { zReport, ZTableSchema } from '../types';
 import { SRTableListColumnList } from '../components/shared/Tables/TableList/SRTableListItem/SRTableListColumnList';
 import { SRTableListSchemaDetail } from '../components/shared/Tables/TableList/SRTableListItem/SRTableListSchemaDetail';
 import { SRTableListItem } from '../components/shared/Tables/TableList/SRTableListItem';
-import { SimpleBreadcrumbNavbar } from '../components/shared/BreadcrumbNav';
+import { SimpleBreadcrumbNav } from '../components/shared/BreadcrumbNav';
 
 type Props = { data: SingleReportSchema };
 
@@ -53,7 +53,7 @@ export function SRTablesListPage({ data }: Props) {
       >
         <>
           <Divider orientation="vertical" mx={3} />
-          <SimpleBreadcrumbNavbar routePathToMatch="/" />
+          <SimpleBreadcrumbNav routePathToMatch="/" />
         </>
       </TableActionBar>
 

--- a/static_report/src/utils/assertion.ts
+++ b/static_report/src/utils/assertion.ts
@@ -124,12 +124,12 @@ export function getSingleAssertionStatusCounts(
 
 export type ComparisonAssertions = {
   data: ComparisonReportSchema;
-  reportName: string;
+  tableName: string;
   type: 'piperider' | 'dbt';
 };
 export function getComparisonAssertions({
   data,
-  reportName,
+  tableName,
   type,
 }: ComparisonAssertions) {
   const targets = {
@@ -137,10 +137,10 @@ export function getComparisonAssertions({
     dbt: 'dbt_assertion_result',
   };
 
-  const baseTables = { type: 'base', tables: data.base.tables[reportName] };
+  const baseTables = { type: 'base', tables: data.base.tables[tableName] };
   const targetTables = {
     type: 'target',
-    tables: data.input.tables[reportName], //legacy 'input' key
+    tables: data.input.tables[tableName], //legacy 'input' key
   };
 
   //Warning: targetTables.tables can be undefined when mismatched

--- a/static_report/src/utils/layout.ts
+++ b/static_report/src/utils/layout.ts
@@ -1,2 +1,5 @@
 export const topNavAndFooterHeightOffset = 65;
-export const mainContentAreaHeight = `calc(100vh - ${topNavAndFooterHeightOffset}px)`;
+export const breadcrumbHeight = 36;
+export const mainContentAreaHeight = `calc(100vh - ${
+  topNavAndFooterHeightOffset + breadcrumbHeight
+}px)`;

--- a/static_report/src/utils/routes.ts
+++ b/static_report/src/utils/routes.ts
@@ -1,0 +1,3 @@
+export const TABLE_DETAILS_ROUTE_PATH = '/tables/:tableName';
+export const COLUMN_DETAILS_ROUTE_PATH =
+  '/tables/:tableName/columns/:columnName';


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some check items for you: -->

**PR checklist**

- [ X] Ensure you have added or ran the appropriate tests for your PR.
- [ X] DCO signed

**What type of PR is this?**
Feature
**What this PR does / why we need it**:
Add a simple global breadcrumb for page-level usage (also for library UI)

**Special notes for your reviewer**:
https://www.loom.com/share/37aea0ac81ba4ea9870d68662b2165b2

The breadcrumb logic is very simple. But I think will serve our usage fairly easily (when routing gets more complex in cloud, we can revisit the logic)

```
 * A breadcrumb UI that will use browser location to render breadcrumbs based on the route-params manually provided.
 * FULL_URL1: `/tables/ACTION`
 * BREADCRUMB: `['/', '/tables/ACTION']
 *
 * FULL_URL2: `/tables/ACTION/columns/FOO`
 * BREADCRUMB: `['/', '/tables/ACTION', '/tables/ACTION/columns/FOO']
 ```

**Does this PR introduce a user-facing change?**: yes
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
Add breadcrumb to all report pages, allowing for inter-navigation