### PR TITLE
[Feature] Add table profiling rows limit

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -1,0 +1,83 @@
+# PipeRider Project Configuration
+
+
+## Data Sources
+A PipeRider project can contain a few data sources. PipeRider will help you finish these settings after initialization.
+
+Multiple data sources are allowed and `piperider run` provides an options `--datasource` to specify which data source to profile.
+
+| Field | Description |
+| --- | --- |
+| name | Name of data source |
+| type | Type of the data source |
+| dbpath *\** | Path of sqlite db |
+
+*\* dbpath is only available for sqlite type data source*
+
+Example
+```
+  dataSources:
+  - name: my_data_source
+    type: sqlite
+    dbpath: ./data/my-sqlite.db
+```
+
+## Profiler
+PipeRider provides a row-limited setting to help with profiling partial of a large dataset and gives you quick navigation.
+
+| Field | type | Description | Default |
+| --- | --- | --- | --- |
+| limit | integer | the maximum row count to profile | all rows |
+
+Example
+```
+profiler:
+  table:
+    # the maximum row count to profile (Default unlimited)
+    limit: 1000000
+```
+
+## Tables
+Tables provide a structure to describe tables and columns in the data source.
+
+| Field | type | Description | Default |
+| --- | --- | --- | --- |
+| description | string | the maximum row count to profile | empty string |
+
+Example
+```
+tables:
+  my-table-name:
+    # description of the table
+    description: "this is a table description"
+    columns:
+      my-col-name:
+        # description of the column
+        description: "this is a column description"
+```
+
+## Inclusion/Exclusion
+There would be plenty of tables in the data source. PipeRider provides a allowlist and a blocklist for your to specify which tables to profile.
+
+PipeRider includes tables in the allowlist first then excludes tables in the blocklist.
+
+| Field | type | Description | Default |
+| --- | --- | --- | --- |
+| includes | array | list of tables allowing to profile | empty array |
+| excludes | array | list of tables blocking to profile | empty array |
+
+Example
+```
+# The tables to include/exclude
+includes: []
+excludes: []
+```
+
+## Telemetry
+This is the anonymous project id that was created when initialization for telemetry usage.
+
+Example
+```
+telemetry:
+  id: xxx
+```

--- a/piperider_cli/configuration.py
+++ b/piperider_cli/configuration.py
@@ -33,6 +33,7 @@ class Configuration(object):
 
     def __init__(self, dataSources: List[DataSource], **kwargs):
         self.dataSources: List[DataSource] = dataSources
+        self.profiler_config = kwargs.get('profiler', {})
         self.tables = kwargs.get('tables', {})
         self.telemetry_id = kwargs.get('telemetry_id', None)
         if self.telemetry_id is None:
@@ -162,6 +163,7 @@ class Configuration(object):
 
         return cls(
             dataSources=data_sources,
+            profiler=config.get('profiler', {}),
             tables=config.get('tables', {}),
             telemetry_id=config.get('telemetry', {}).get('id'),
             report_dir=config.get('report_dir', '.')

--- a/piperider_cli/configuration.py
+++ b/piperider_cli/configuration.py
@@ -5,6 +5,7 @@ from typing import List
 
 import inquirer
 from ruamel import yaml
+from ruamel.yaml import CommentedMap
 
 from piperider_cli.datasource import DATASOURCE_PROVIDERS, DataSource
 from piperider_cli.error import \
@@ -177,7 +178,6 @@ class Configuration(object):
         """
         config = dict(
             dataSources=[],
-            tables={},
             telemetry=dict(id=self.telemetry_id)
         )
 
@@ -190,8 +190,31 @@ class Configuration(object):
                 datasource['dbt'] = d.args.get('dbt')
             config['dataSources'].append(datasource)
 
+        template = '''
+profiler:
+  table:
+    # the maximum row count to profile. (Default unlimited)
+    limit: 1000000
+
+The tables to include/exclude
+includes: []
+excludes: []
+
+tables:
+  my-table-name:
+    # description of the table
+    description: "this is a table description"
+    columns:
+      my-col-name:
+        # description of the column
+        description: "this is a column description"\n
+'''
+
+        config_yaml = CommentedMap(config)
+        config_yaml.yaml_set_comment_before_after_key('telemetry', before=template)
+
         with open(path, 'w') as fd:
-            yaml.round_trip_dump(config, fd)
+            yaml.YAML().dump(config_yaml, fd)
 
     def dump_credentials(self, path, after_init_config=False):
         """

--- a/piperider_cli/profiler/profiler.py
+++ b/piperider_cli/profiler/profiler.py
@@ -349,8 +349,8 @@ class BaseColumnProfiler:
         if limit <= 0:
             return t, c
         else:
-            cte = select([c.label("c")]).select_from(t).limit(limit).cte()
-            return cte, cte.columns[0]
+            cte = select([c.label('c')]).select_from(t).limit(limit).cte()
+            return cte, cte.c.c
 
     def _get_table_cte(self) -> CTE:
         """

--- a/piperider_cli/profiler/profiler.py
+++ b/piperider_cli/profiler/profiler.py
@@ -72,10 +72,12 @@ class Profiler:
     inspector: Inspector = None
     event_handler: ProfilerEventHandler
 
-    def __init__(self, engine: Engine, event_handler: ProfilerEventHandler = DefaultProfilerEventHandler()):
+    def __init__(self, engine: Engine, event_handler: ProfilerEventHandler = DefaultProfilerEventHandler(),
+                 profiler_config: dict = None):
         self.engine = engine
         self.inspector = inspect(self.engine) if self.engine else None
         self.event_handler = event_handler
+        self.config = profiler_config if profiler_config else {}
 
     def profile(self, tables: List[str] = None) -> dict:
         """
@@ -89,7 +91,7 @@ class Profiler:
         - boolean
         - Other
 
-        :param tables: optinoal, the tables to profile
+        :param tables: optional, the tables to profile
         :return: the profile results
         """
 
@@ -267,33 +269,33 @@ class Profiler:
             # TEXT
             # CLOB
             generic_type = "string"
-            profiler = StringColumnProfiler(self.engine, table, column)
+            profiler = StringColumnProfiler(self.engine, self.config, table, column)
         elif isinstance(column.type, Integer):
             # INTEGER
             # BIGINT
             # SMALLINT
             generic_type = "integer"
-            profiler = NumericColumnProfiler(self.engine, table, column, is_integer=True)
+            profiler = NumericColumnProfiler(self.engine, self.config, table, column, is_integer=True)
         elif isinstance(column.type, Numeric):
             # NUMERIC
             # DECIMAL
             # FLOAT
             generic_type = "numeric"
-            profiler = NumericColumnProfiler(self.engine, table, column, is_integer=False)
+            profiler = NumericColumnProfiler(self.engine, self.config, table, column, is_integer=False)
         elif isinstance(column.type, Date) or isinstance(column.type, DateTime) or \
             (self.engine.url.get_backend_name() == 'snowflake' and str(column.type).startswith('TIMESTAMP')):
             # DATE
             # DATETIME
             # TIMEZONE_NTZ
             generic_type = "datetime"
-            profiler = DatetimeColumnProfiler(self.engine, table, column)
+            profiler = DatetimeColumnProfiler(self.engine, self.config, table, column)
         elif isinstance(column.type, Boolean):
             # BOOLEAN
             generic_type = "boolean"
-            profiler = BooleanColumnProfiler(self.engine, table, column)
+            profiler = BooleanColumnProfiler(self.engine, self.config, table, column)
         else:
             generic_type = "other"
-            profiler = BaseColumnProfiler(self.engine, table, column)
+            profiler = BaseColumnProfiler(self.engine, self.config, table, column)
 
         result = {
             "name": column.name,
@@ -323,11 +325,13 @@ class BaseColumnProfiler:
     """
 
     engine: Engine = None
+    config: dict = None
     table: Table = None
     column: Column = None
 
-    def __init__(self, engine: Engine, table: Table, column: Column):
+    def __init__(self, engine: Engine, config: dict, table: Table, column: Column):
         self.engine = engine
+        self.config = config
         self.table = table
         self.column = column
 
@@ -337,6 +341,16 @@ class BaseColumnProfiler:
         :return:
         """
         return self.engine.url.get_backend_name()
+
+    def _get_limited_table_cte(self):
+        t = self.table
+        c = self.column
+        limit = self.config.get('table', {}).get('limit', 0)
+        if limit <= 0:
+            return t, c
+        else:
+            cte = select([c.label("c")]).select_from(t).limit(limit).cte()
+            return cte, cte.columns[0]
 
     def _get_table_cte(self) -> CTE:
         """
@@ -359,8 +373,7 @@ class BaseColumnProfiler:
 
         :return: CTE
         """
-        t = self.table
-        c = self.column
+        t, c = self._get_limited_table_cte()
 
         return select([c.label("c")]).select_from(t).cte()
 
@@ -391,12 +404,11 @@ class BaseColumnProfiler:
 
 
 class StringColumnProfiler(BaseColumnProfiler):
-    def __init__(self, engine: Engine, table: Table, column: Column):
-        super().__init__(engine, table, column)
+    def __init__(self, engine: Engine, config: dict, table: Table, column: Column):
+        super().__init__(engine, config, table, column)
 
     def _get_table_cte(self) -> CTE:
-        t = self.table
-        c = self.column
+        t, c = self._get_limited_table_cte()
         if self._get_database_backend() != 'sqlite':
             cte = select([
                 c.label("c"),
@@ -498,13 +510,12 @@ class StringColumnProfiler(BaseColumnProfiler):
 class NumericColumnProfiler(BaseColumnProfiler):
     is_integer: bool
 
-    def __init__(self, engine: Engine, table: Table, column: Column, is_integer: bool):
-        super().__init__(engine, table, column)
+    def __init__(self, engine: Engine, config: dict, table: Table, column: Column, is_integer: bool):
+        super().__init__(engine, config, table, column)
         self.is_integer = is_integer
 
     def _get_table_cte(self) -> CTE:
-        t = self.table
-        c = self.column
+        t, c = self._get_limited_table_cte()
         if self._get_database_backend() != 'sqlite':
             cte = select([
                 c.label("c"),
@@ -840,12 +851,11 @@ class NumericColumnProfiler(BaseColumnProfiler):
 
 
 class DatetimeColumnProfiler(BaseColumnProfiler):
-    def __init__(self, engine, table: Table, column: Column):
-        super().__init__(engine, table, column)
+    def __init__(self, engine: Engine, config: dict, table: Table, column: Column):
+        super().__init__(engine, config, table, column)
 
     def _get_table_cte(self) -> CTE:
-        t = self.table
-        c = self.column
+        t, c = self._get_limited_table_cte()
         if self._get_database_backend() != 'sqlite':
             cte = select([
                 c.label("c"),
@@ -1033,12 +1043,11 @@ class DatetimeColumnProfiler(BaseColumnProfiler):
 
 
 class BooleanColumnProfiler(BaseColumnProfiler):
-    def __init__(self, engine: Engine, table: Table, column: Column):
-        super().__init__(engine, table, column)
+    def __init__(self, engine: Engine, config: dict, table: Table, column: Column):
+        super().__init__(engine, config, table, column)
 
     def _get_table_cte(self) -> CTE:
-        t = self.table
-        c = self.column
+        t, c = self._get_limited_table_cte()
         if self._get_database_backend() != 'sqlite':
             cte = select([
                 c.label("c"),

--- a/piperider_cli/runner.py
+++ b/piperider_cli/runner.py
@@ -579,7 +579,8 @@ class Runner():
         run_id = uuid.uuid4().hex
         created_at = datetime.utcnow()
         engine = ds.create_engine()
-        profiler = Profiler(engine, RichProfilerEventHandler(tables if tables else available_tables))
+        profiler = Profiler(engine, RichProfilerEventHandler(tables if tables else available_tables),
+                            configuration.profiler_config)
         try:
             profile_result = profiler.profile(tables)
             decorate_with_metadata(profile_result)

--- a/tests/profiler/test_profiler.py
+++ b/tests/profiler/test_profiler.py
@@ -599,3 +599,4 @@ class TestProfiler:
         assert result["tables"]["test"]['columns']["num"]["avg"] == 1.5
         assert result["tables"]["test"]['columns']["num"]["total"] == 3
         assert result["tables"]["test"]['columns']["num"]["nulls"] == 1
+        assert result["tables"]["test"]['row_count'] == 5

--- a/tests/profiler/test_profiler.py
+++ b/tests/profiler/test_profiler.py
@@ -578,3 +578,24 @@ class TestProfiler:
         assert result["tables"]["test"]['columns']["str"]["topk"]["counts"][0] == 1
         assert result["tables"]["test"]['columns']["num_empty"]["histogram"] == None
         assert result["tables"]["test"]['columns']["num_empty"]["topk"] == None
+
+    def test_limited_row_table(self):
+        engine = self.engine = create_engine('sqlite://')
+
+        data = [
+            ("num",),
+            (1.0,),
+            (2.0,),
+            (None,),
+            (4.0,),
+            (5.0,)
+        ]
+        self.create_table("test", data)
+
+        profiler = Profiler(engine, profiler_config={'table': {'limit': 3}})
+        result = profiler.profile()
+        assert result["tables"]["test"]['columns']["num"]["min"] == 1.0
+        assert result["tables"]["test"]['columns']["num"]["max"] == 2.0
+        assert result["tables"]["test"]['columns']["num"]["avg"] == 1.5
+        assert result["tables"]["test"]['columns']["num"]["total"] == 3
+        assert result["tables"]["test"]['columns']["num"]["nulls"] == 1


### PR DESCRIPTION
Signed-off-by: Wei-Chun, Chang <wcchang@infuseai.io>

<!--  Thanks for sending a pull request!  Here are some check items for you: -->

**PR checklist**

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed

**What type of PR is this?**
Feature

**What this PR does / why we need it**:
to enhance the profiling of large datasets with a limited number of rows for quick navigation.

**Which issue(s) this PR fixes**:
#400
sc-28353

**Special notes for your reviewer**:

In the `.piperider/config.yml`, add this configuration.

```
profiler:
  table:
     limit: 1000000
```
**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
NONE