### PR TITLE
[Bug] Use built-in stddev in all data sources except sqlite

### DIFF
--- a/piperider_cli/profiler/profiler.py
+++ b/piperider_cli/profiler/profiler.py
@@ -452,28 +452,26 @@ class StringColumnProfiler(BaseColumnProfiler):
             ]
 
             if self._get_database_backend() == 'sqlite':
-                columns.append(func.avg(func.cast(cte.c.len, Float) * func.cast(cte.c.len, Float)).label("_square_avg"))
+                columns.append((func.count(cte.c.len) * func.sum(
+                    func.cast(cte.c.len, Float) * func.cast(cte.c.len, Float)) - func.sum(cte.c.len) * func.sum(
+                    cte.c.len)) / ((func.count(cte.c.len) - 1) * func.count(cte.c.len)).label('_variance'))
                 stmt = select(columns)
                 result = conn.execute(stmt).fetchone()
-                _total, _non_nulls, _valids, _zero_length, _distinct, _sum, _avg, _min, _max, _square_avg = result
-                _square_avg = dtof(_square_avg)
+                _total, _non_nulls, _valids, _zero_length, _distinct, _sum, _avg, _min, _max, _variance = result
                 _stddev = None
-                if _square_avg is not None and _avg is not None:
-                    try:
-                        _stddev = math.sqrt(_square_avg - _avg * _avg)
-                    except ValueError:
-                        pass
+                if _variance is not None:
+                    _stddev = math.sqrt(_variance)
             else:
                 columns.append(func.stddev(cte.c.len).label("_stddev"))
                 stmt = select(columns)
                 result = conn.execute(stmt).fetchone()
                 _total, _non_nulls, _valids, _zero_length, _distinct, _sum, _avg, _min, _max, _stddev = result
-                _stddev = dtof(_stddev)
 
             _sum = dtof(_sum)
             _min = dtof(_min)
             _max = dtof(_max)
             _avg = dtof(_avg)
+            _stddev = dtof(_stddev)
 
             result = {
                 'total': _total,
@@ -570,28 +568,26 @@ class NumericColumnProfiler(BaseColumnProfiler):
             ]
 
             if self._get_database_backend() == 'sqlite':
-                columns.append(func.avg(func.cast(cte.c.c, Float) * func.cast(cte.c.c, Float)).label("_square_avg"))
+                columns.append((func.count(cte.c.c) * func.sum(
+                    func.cast(cte.c.c, Float) * func.cast(cte.c.c, Float)) - func.sum(cte.c.c) * func.sum(cte.c.c)) / (
+                    (func.count(cte.c.c) - 1) * func.count(cte.c.c)).label('_variance'))
                 stmt = select(columns)
                 result = conn.execute(stmt).fetchone()
-                _total, _non_nulls, _valids, _zeros, _negatives, _distinct, _sum, _avg, _min, _max, _square_avg = result
-                _square_avg = dtof(_square_avg)
+                _total, _non_nulls, _valids, _zeros, _negatives, _distinct, _sum, _avg, _min, _max, _variance = result
                 _stddev = None
-                if _square_avg is not None and _avg is not None:
-                    try:
-                        _stddev = math.sqrt(_square_avg - _avg * _avg)
-                    except ValueError:
-                        pass
+                if _variance is not None:
+                    _stddev = math.sqrt(_variance)
             else:
                 columns.append(func.stddev(cte.c.c).label("_stddev"))
                 stmt = select(columns)
                 result = conn.execute(stmt).fetchone()
                 _total, _non_nulls, _valids, _zeros, _negatives, _distinct, _sum, _avg, _min, _max, _stddev = result
-                _stddev = dtof(_stddev)
 
             _sum = dtof(_sum)
             _min = dtof(_min)
             _max = dtof(_max)
             _avg = dtof(_avg)
+            _stddev = dtof(_stddev)
 
             result = {
                 'total': _total,

--- a/tests/profiler/test_profiler.py
+++ b/tests/profiler/test_profiler.py
@@ -154,7 +154,7 @@ class TestProfiler:
 
         result = profiler.profile()["tables"]["test"]['columns']["col"]
         assert result['avg'] == 472.0
-        assert almost_equal(result['stddev'], 376.47)
+        assert almost_equal(result['stddev'], 420.91)
         assert result['sum'] == 2360
         assert result['min'] == 10
         assert result['p5'] == 10
@@ -215,7 +215,7 @@ class TestProfiler:
         assert result["positives"] == 1
 
         assert result['avg'] == 0
-        assert almost_equal(result['stddev'], 16.33)
+        assert almost_equal(result['stddev'], 20)
         assert result['sum'] == 0
         assert result['min'] == -20
         assert result['p5'] == -20
@@ -265,7 +265,7 @@ class TestProfiler:
 
         result = profiler.profile()["tables"]["test"]['columns']["col"]
         assert result['avg'] == 448
-        assert almost_equal(result['stddev'], 407.69)
+        assert almost_equal(result['stddev'], 455.82)
         assert result['sum'] == 2240
         assert result['min'] == -110
         assert result['p5'] == -110
@@ -350,7 +350,7 @@ class TestProfiler:
         assert result["min"] == 0
         assert result["max"] == 11
         assert almost_equal(result["avg"], 5.57)
-        assert almost_equal(result["stddev"], 3.54)
+        assert almost_equal(result["stddev"], 3.82)
         assert result["histogram"]["counts"][0] == 1
         assert result["histogram"]["counts"][-1] == 1
         assert result["topk"]["counts"][0] == 2


### PR DESCRIPTION
Signed-off-by: Wei-Chun, Chang <wcchang@infuseai.io>

<!--  Thanks for sending a pull request!  Here are some check items for you: -->

**PR checklist**

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed

**What type of PR is this?**
bug

**What this PR does / why we need it**:
overflow may happen during calculating `stddev`

**Which issue(s) this PR fixes**:
sc-28645

**Special notes for your reviewer**:
And we use built-in `sample stddev` for data sources other than sqlite.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
NONE