### PR TITLE
[Feature] Preallocate column profiling result entries

### DIFF
--- a/piperider_cli/profiler/profiler.py
+++ b/piperider_cli/profiler/profiler.py
@@ -317,6 +317,8 @@ class Profiler:
 
             self.event_handler.handle_table_end(result)
         else:
+            for column in candidate_columns:
+                columns[column.name] = None
             with concurrent.futures.ThreadPoolExecutor(max_workers=5) as executor:
                 future_to_profile = {executor.submit(self._profile_column, table, column): column for column in
                                      candidate_columns}


### PR DESCRIPTION
Signed-off-by: Wei-Chun, Chang <wcchang@infuseai.io>

<!--  Thanks for sending a pull request!  Here are some check items for you: -->

**PR checklist**

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed

**What type of PR is this?**
feature

**What this PR does / why we need it**:
To keep columns profile results entries in order when multi-thread profiling

**Which issue(s) this PR fixes**:
sc-28850

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
NONE