### PR TITLE
[Bug] Fix the quotation of pip install message

### DIFF
--- a/piperider_cli/error.py
+++ b/piperider_cli/error.py
@@ -75,7 +75,7 @@ class PipeRiderInvalidDataSourceError(PipeRiderError):
 class PipeRiderConnectorError(PipeRiderError):
     def __init__(self, err_msg, datasource_name):
         self.message = err_msg
-        self.hint = f'Please run \'pip install piperider[{datasource_name}]\' to get the {datasource_name} connector'
+        self.hint = f'Please run \"pip install \'piperider[{datasource_name}]\'\" to get the {datasource_name} connector'
 
 
 class PipeRiderTableConnectionError(PipeRiderError):


### PR DESCRIPTION
change this message in the CLI:
`Please run 'pip install piperider[csv]' to get the csv connector`
to
`Please run "pip install 'piperider[csv]'" to get the csv connector`

The original one does not work in zsh

**PR checklist**

- [X] Ensure you have added or ran the appropriate tests for your PR.
- [X] DCO signed

**What type of PR is this?**

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
