### PR TITLE
[Bug] Add column alias for duplicate row query

### DIFF
--- a/piperider_cli/profiler/profiler.py
+++ b/piperider_cli/profiler/profiler.py
@@ -249,7 +249,7 @@ class Profiler:
             return
 
         limit = self.config.profiler_config.get('table', {}).get('limit', 0)
-        columns = [column for column in table.columns]
+        columns = [column.label(f'_{column.name}') for column in table.columns]
 
         with self.engine.connect() as conn:
             if self.engine.url.get_backend_name() == 'snowflake':


### PR DESCRIPTION
Signed-off-by: Wei-Chun, Chang <wcchang@infuseai.io>

<!--  Thanks for sending a pull request!  Here are some check items for you: -->

**PR checklist**

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed

**What type of PR is this?**
bug

**What this PR does / why we need it**:
bigquery treated SELECT list alias as table name and threw out "cannot `GROUP BY` field references from SELECT list alias"

**Which issue(s) this PR fixes**:
sc-28939

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
NONE