### PR TITLE
[Bug] Don't collect telemetry event if telemetry id is removed

### DIFF
--- a/piperider_cli/configuration.py
+++ b/piperider_cli/configuration.py
@@ -40,8 +40,6 @@ class Configuration(object):
         self.excludes = kwargs.get('excludes', None)
         self.tables = kwargs.get('tables', {})
         self.telemetry_id = kwargs.get('telemetry_id', None)
-        if self.telemetry_id is None:
-            self.telemetry_id = uuid.uuid4().hex
         self.report_dir = self._to_report_dir(kwargs.get('report_dir', '.'))
 
         self._verify_input_config()
@@ -203,6 +201,10 @@ class Configuration(object):
         :param path:
         :return:
         """
+
+        if self.telemetry_id is None:
+            self.telemetry_id = uuid.uuid4().hex
+
         config = dict(
             dataSources=[],
             telemetry=dict(id=self.telemetry_id)

--- a/piperider_cli/event/__init__.py
+++ b/piperider_cli/event/__init__.py
@@ -116,6 +116,10 @@ def log_event(prop, event_type, **kwargs):
     if kwargs.get('params'):
         ds = kwargs.get('params').get('datasource')
     project_info = _obtain_project_info(datasource=ds)
+
+    if not project_info.get('project_id'):
+        return
+
     payload = dict(
         **project_info,
         **prop,


### PR DESCRIPTION
If the user remove the telemetry id from the `config.yml`, we will not collect the telemetry event.

**PR checklist**

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed

**What type of PR is this?**

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
sc-28960

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
