### PR TITLE
[Feature] Add column value in set assertion

### DIFF
--- a/docs/assertions-builtin.md
+++ b/docs/assertions-builtin.md
@@ -37,7 +37,9 @@ your_table_name:
 
 ## assert_column_value
 
-- Description: Assert the column value should be in the range.
+- Description: The column value should pass the given assertion.
+
+### range
 - Assert:
     - `gte`:  the value should be greater than or equal to
     - `gt`:  the value should be greater than
@@ -69,6 +71,24 @@ world_city:
       - name: assert_column_value
         assert:
           gte: '2022-01-01;
+```
+</details>
+
+### set
+- Assert:
+    - `in`:  the value should one element of the given set
+
+<details>
+  <summary>YAML Example: The value should be one of following values ['US', 'Japan', 'India'] </summary>
+
+```
+world_city:
+  columns:
+    country:
+      tests:
+      - name: assert_column_value
+        assert:
+            in: ['US', 'Japan', 'India']
 ```
 </details>
 

--- a/docs/assertions-custom.md
+++ b/docs/assertions-custom.md
@@ -57,7 +57,11 @@ class AssertNothingTableExample(BaseAssertionType):
   def name(self):
     return 'assert_nothing_table_example'
 
-  def execute(self, context: AssertionContext, table: str, column: str, metrics: dict) -> AssertionResult:
+  def execute(self, context: AssertionContext) -> AssertionResult:
+    table = context.table
+    column = context.column
+    metrics = context.profiler_result
+
     table_metrics = metrics.get('tables', {}).get(table)
     if table_metrics is None:
       # cannot find the table in the metrics
@@ -93,18 +97,18 @@ class AssertNothingTableExample(BaseAssertionType):
 register_assertion_function(AssertNothingTableExample)
 ```
 
-* name method provides the function name that will be used in the assertion yaml.
-* execute method is your implementation to give the result of the assertion function.
-* validate method could help you check `assert` parameters before PipeRider is profiling.
+* `name` method provides the function name that will be used in the assertion yaml.
+* `execute` method is your implementation to give the result of the assertion function.
+* `validate` method could help you check `assert` parameters before PipeRider is profiling.
 
-#### execute details
+#### Execute details
 
-When the assertion has been called, PipeRider will put all arguments to `execute` method for you:
+When the assertion has been called, PipeRider will put assertion context to `execute` method for you:
 
-* context: helper object for assembling result entry to the report.
-* table: the table name you are asserting.
-* column: the column name you are checking, but it could be null when the assertion is put on the table level assertion.
-* metrics: the profiling output could be asserted.
+* `context`: helper object for assembling result entry to the report.
+* `context.table`: the table name you are asserting.
+* `context.column`: the column name you are checking, but it could be `null` when the assertion is put on the table level assertion.
+* `context.profiler_result`: the profiler output could be asserted.
 
 ### Assertion process
 

--- a/piperider_cli/assertion_engine/assertion.py
+++ b/piperider_cli/assertion_engine/assertion.py
@@ -149,15 +149,14 @@ class ValidationResult:
     def require_range_pair(self, name):
         return self._require_numeric_pair(name, {int, float, datetime, date, time})
 
-    def require_same_types(self, *names):
-        for name in names:
-            values = self.context.asserts.get(name)
+    def require_same_types(self, name):
+        values = self.context.asserts.get(name)
 
-            base_type = type(values[0])
-            for v in values:
-                if type(v) != base_type:
-                    self.errors.append(f'{name} parameter should be the same types')
-                    return self
+        base_type = type(values[0])
+        for v in values:
+            if type(v) != base_type:
+                self.errors.append(f'{name} parameter should be the same types')
+                return self
 
         return self
 

--- a/piperider_cli/assertion_engine/assertion.py
+++ b/piperider_cli/assertion_engine/assertion.py
@@ -149,14 +149,15 @@ class ValidationResult:
     def require_range_pair(self, name):
         return self._require_numeric_pair(name, {int, float, datetime, date, time})
 
-    def require_same_types(self, name):
-        values = self.context.asserts.get(name)
+    def require_same_types(self, *names):
+        for name in names:
+            values = self.context.asserts.get(name)
 
-        base_type = type(values[0])
-        for v in values:
-            if type(v) != base_type:
-                self.errors.append(f'{name} parameter should be the same types')
-                return self
+            base_type = type(values[0])
+            for v in values:
+                if type(v) != base_type:
+                    self.errors.append(f'{name} parameter should be the same types')
+                    return self
 
         return self
 

--- a/piperider_cli/assertion_engine/event.py
+++ b/piperider_cli/assertion_engine/event.py
@@ -1,0 +1,48 @@
+from rich.color import Color
+from rich.progress import Progress, Column, TextColumn, BarColumn, TimeElapsedColumn, MofNCompleteColumn
+from rich.style import Style
+
+
+class AssertionEventHandler:
+    def handle_assertion_start(self, assertions):
+        pass
+
+    def handle_assertion_end(self, results, exceptions):
+        pass
+
+    def handle_execution_start(self, assertion_context):
+        pass
+
+    def handle_execution_end(self, assertion_result):
+        pass
+
+
+class DefaultAssertionEventHandler(AssertionEventHandler):
+
+    def __init__(self):
+        subject_column = TextColumn("{task.fields[test_subject]}")
+        assert_column = TextColumn("{task.fields[display_name]}", style='green')
+        bar_column = BarColumn(bar_width=60, pulse_style=Style.from_color(Color.from_rgb(244, 164, 96)))
+        mofn_column = MofNCompleteColumn(table_column=Column(width=5, justify="right"))
+        time_elapsed_column = TimeElapsedColumn()
+        self.progress = Progress(subject_column, assert_column, bar_column, mofn_column, time_elapsed_column)
+        self.task_id = None
+
+    def handle_assertion_start(self, assertions):
+        self.progress.start()
+        fields = dict(display_name='', test_subject='')
+        self.task_id = self.progress.add_task('assertions', total=len(assertions), **fields)
+
+    def handle_assertion_end(self, results, exceptions):
+        self.progress.update(self.task_id, **dict(display_name='', test_subject='Test completed'))
+        self.progress.stop()
+
+    def handle_execution_start(self, assertion_context):
+        display_name = assertion_context.name if assertion_context.name is not None else assertion_context.metric
+        test_subject = assertion_context.table if assertion_context.table else '-'
+        if assertion_context.column:
+            test_subject = f'{test_subject}.{assertion_context.column}'
+        self.progress.update(self.task_id, **dict(display_name=display_name, test_subject=test_subject))
+
+    def handle_execution_end(self, assertion_result):
+        self.progress.update(self.task_id, advance=1, **dict(display_name=''))

--- a/piperider_cli/assertion_engine/types/__init__.py
+++ b/piperider_cli/assertion_engine/types/__init__.py
@@ -30,7 +30,7 @@ class _NotFoundAssertion(BaseAssertionType):
     def name(self):
         return self.assertion_name
 
-    def execute(self, context: AssertionContext, table: str, column: str, metrics: dict) -> AssertionResult:
+    def execute(self, context: AssertionContext) -> AssertionResult:
         raise BaseException('this is not-found-assertion, cannot be used')
 
     def validate(self, context: AssertionContext) -> ValidationResult:

--- a/piperider_cli/assertion_engine/types/assert_column_misc.py
+++ b/piperider_cli/assertion_engine/types/assert_column_misc.py
@@ -10,8 +10,8 @@ class AssertColumnNotNull(BaseAssertionType):
     def name(self):
         return "assert_column_not_null"
 
-    def execute(self, context: AssertionContext, table: str, column: str, metrics: dict):
-        return assert_column_not_null(context, table, column, metrics)
+    def execute(self, context: AssertionContext):
+        return assert_column_not_null(context)
 
     def validate(self, context: AssertionContext) -> ValidationResult:
         return ValidationResult(context).keep_no_args()
@@ -21,8 +21,8 @@ class AssertColumnNull(BaseAssertionType):
     def name(self):
         return "assert_column_null"
 
-    def execute(self, context: AssertionContext, table: str, column: str, metrics: dict):
-        return assert_column_null(context, table, column, metrics)
+    def execute(self, context: AssertionContext):
+        return assert_column_null(context)
 
     def validate(self, context: AssertionContext) -> ValidationResult:
         return ValidationResult(context).keep_no_args()
@@ -32,8 +32,8 @@ class AssertColumnUnique(BaseAssertionType):
     def name(self):
         return "assert_column_unique"
 
-    def execute(self, context: AssertionContext, table: str, column: str, metrics: dict):
-        return assert_column_unique(context, table, column, metrics)
+    def execute(self, context: AssertionContext):
+        return assert_column_unique(context)
 
     def validate(self, context: AssertionContext) -> ValidationResult:
         return ValidationResult(context).keep_no_args()
@@ -43,8 +43,8 @@ class AssertColumnExist(BaseAssertionType):
     def name(self):
         return "assert_column_exist"
 
-    def execute(self, context: AssertionContext, table: str, column: str, metrics: dict):
-        return assert_column_exist(context, table, column, metrics)
+    def execute(self, context: AssertionContext):
+        return assert_column_exist(context)
 
     def validate(self, context: AssertionContext) -> ValidationResult:
         return ValidationResult(context).keep_no_args()
@@ -54,7 +54,11 @@ class AssertColumnValue(BaseAssertionType):
     def name(self):
         return "assert_column_value"
 
-    def execute(self, context: AssertionContext, table: str, column: str, metrics: dict):
+    def execute(self, context: AssertionContext):
+        table = context.table
+        column = context.column
+        metrics = context.profiler_result
+
         target_metrics = metrics.get('tables', {}).get(table)
         if column:
             target_metrics = target_metrics.get('columns', {}).get(column)
@@ -130,7 +134,11 @@ class AssertColumnValue(BaseAssertionType):
             results.errors.append('The number of operator should be 1 or 2.')
 
 
-def assert_column_not_null(context: AssertionContext, table: str, column: str, metrics: dict) -> AssertionResult:
+def assert_column_not_null(context: AssertionContext) -> AssertionResult:
+    table = context.table
+    column = context.column
+    metrics = context.profiler_result
+
     column_metrics = metrics.get('tables', {}).get(table, {}).get('columns', {}).get(column)
     if not column_metrics:
         return context.result.fail_with_metric_not_found_error(context.table, context.column)
@@ -150,7 +158,11 @@ def assert_column_not_null(context: AssertionContext, table: str, column: str, m
     return context.result.fail()
 
 
-def assert_column_null(context: AssertionContext, table: str, column: str, metrics: dict) -> AssertionResult:
+def assert_column_null(context: AssertionContext) -> AssertionResult:
+    table = context.table
+    column = context.column
+    metrics = context.profiler_result
+
     column_metrics = metrics.get('tables', {}).get(table, {}).get('columns', {}).get(column)
     if not column_metrics:
         # cannot find the column in the metrics
@@ -170,7 +182,11 @@ def assert_column_null(context: AssertionContext, table: str, column: str, metri
     return context.result.fail()
 
 
-def assert_column_unique(context: AssertionContext, table: str, column: str, metrics: dict) -> AssertionResult:
+def assert_column_unique(context: AssertionContext) -> AssertionResult:
+    table = context.table
+    column = context.column
+    metrics = context.profiler_result
+
     column_metrics = metrics.get('tables', {}).get(table, {}).get('columns', {}).get(column)
     if not column_metrics:
         # cannot find the column in the metrics
@@ -191,7 +207,11 @@ def assert_column_unique(context: AssertionContext, table: str, column: str, met
     return context.result.fail()
 
 
-def assert_column_exist(context: AssertionContext, table: str, column: str, metrics: dict) -> AssertionResult:
+def assert_column_exist(context: AssertionContext) -> AssertionResult:
+    table = context.table
+    column = context.column
+    metrics = context.profiler_result
+
     table_metrics = metrics.get('tables', {}).get(table)
     if not table_metrics:
         # cannot find the table in the metrics

--- a/piperider_cli/assertion_engine/types/assert_column_misc.py
+++ b/piperider_cli/assertion_engine/types/assert_column_misc.py
@@ -173,6 +173,7 @@ class AssertColumnValue(BaseAssertionType):
         context.result.expected = assert_set
         assert_set = set(assert_set)
 
+        samples = None
         if target_metrics:
             distinct = target_metrics.get('distinct')
             topk = []
@@ -183,30 +184,25 @@ class AssertColumnValue(BaseAssertionType):
                 return context.result.fail()
 
             # TODO: define topk default max length
-            if len(topk) < 5:
+            if len(topk) < 50:
                 if len(assert_set) < len(topk):
                     return context.result.fail()
 
                 for k in topk:
                     if k not in assert_set:
                         return context.result.fail()
+
+                return context.result.success()
             else:
-                samples = target_metrics['samples']
-                result = AssertColumnValue._query_column_category(context, samples, len(assert_set) + 1)
-                if len(result) > len(assert_set):
-                    return context.result.fail()
+                samples = target_metrics.get('samples')
 
-                for row, in result:
-                    if row not in assert_set:
-                        return context.result.fail()
-        else:
-            result = AssertColumnValue._query_column_category(context, None, len(assert_set) + 1)
-            if len(result) > len(assert_set):
+        result = AssertColumnValue._query_column_category(context, samples, len(assert_set) + 1)
+        if len(result) > len(assert_set):
+            return context.result.fail()
+
+        for row, in result:
+            if row not in assert_set:
                 return context.result.fail()
-
-            for row, in result:
-                if row not in assert_set:
-                    return context.result.fail()
 
         return context.result.success()
 

--- a/piperider_cli/assertion_engine/types/assert_column_ranges.py
+++ b/piperider_cli/assertion_engine/types/assert_column_ranges.py
@@ -9,8 +9,8 @@ class AssertColumnMinInRange(BaseAssertionType):
     def name(self):
         return "assert_column_min_in_range"
 
-    def execute(self, context: AssertionContext, table: str, column: str, metrics: dict):
-        return assert_column_min_in_range(context, table, column, metrics)
+    def execute(self, context: AssertionContext):
+        return assert_column_min_in_range(context)
 
     def validate(self, context: AssertionContext) -> ValidationResult:
         result = ValidationResult(context).require('min')
@@ -24,8 +24,8 @@ class AssertColumnMaxInRange(BaseAssertionType):
     def name(self):
         return "assert_column_max_in_range"
 
-    def execute(self, context: AssertionContext, table: str, column: str, metrics: dict):
-        return assert_column_max_in_range(context, table, column, metrics)
+    def execute(self, context: AssertionContext):
+        return assert_column_max_in_range(context)
 
     def validate(self, context: AssertionContext) -> ValidationResult:
         result = ValidationResult(context).require('max')
@@ -39,8 +39,8 @@ class AssertColumnInRange(BaseAssertionType):
     def name(self):
         return "assert_column_in_range"
 
-    def execute(self, context: AssertionContext, table: str, column: str, metrics: dict):
-        return assert_column_in_range(context, table, column, metrics)
+    def execute(self, context: AssertionContext):
+        return assert_column_in_range(context)
 
     def validate(self, context: AssertionContext) -> ValidationResult:
         result = ValidationResult(context).require('range')
@@ -50,20 +50,23 @@ class AssertColumnInRange(BaseAssertionType):
         return result.require_range_pair('range').require_same_types('range')
 
 
-def assert_column_min_in_range(context: AssertionContext, table: str, column: str, metrics: dict) -> AssertionResult:
-    return _assert_column_in_range(context, table, column, metrics, target_metric='min')
+def assert_column_min_in_range(context: AssertionContext) -> AssertionResult:
+    return _assert_column_in_range(context, target_metric='min')
 
 
-def assert_column_max_in_range(context: AssertionContext, table: str, column: str, metrics: dict) -> AssertionResult:
-    return _assert_column_in_range(context, table, column, metrics, target_metric='max')
+def assert_column_max_in_range(context: AssertionContext) -> AssertionResult:
+    return _assert_column_in_range(context, target_metric='max')
 
 
-def assert_column_in_range(context: AssertionContext, table: str, column: str, metrics: dict) -> AssertionResult:
-    return _assert_column_in_range(context, table, column, metrics, target_metric='range')
+def assert_column_in_range(context: AssertionContext) -> AssertionResult:
+    return _assert_column_in_range(context, target_metric='range')
 
 
-def _assert_column_in_range(context: AssertionContext, table: str, column: str, metrics: dict,
-                            **kwargs) -> AssertionResult:
+def _assert_column_in_range(context: AssertionContext, **kwargs) -> AssertionResult:
+    table = context.table
+    column = context.column
+    metrics = context.profiler_result
+
     table_metrics = metrics.get('tables', {}).get(table)
     if table_metrics is None:
         return context.result.fail_with_metric_not_found_error(context.table, None)

--- a/piperider_cli/assertion_engine/types/assert_column_types.py
+++ b/piperider_cli/assertion_engine/types/assert_column_types.py
@@ -9,8 +9,8 @@ class AssertColumnSchemaType(BaseAssertionType):
     def name(self):
         return "assert_column_schema_type"
 
-    def execute(self, context: AssertionContext, table: str, column: str, metrics: dict):
-        return assert_column_schema_type(context, table, column, metrics)
+    def execute(self, context: AssertionContext):
+        return assert_column_schema_type(context)
 
     def validate(self, context: AssertionContext) -> ValidationResult:
         # type list: https://docs.sqlalchemy.org/en/14/core/type_basics.html#sql-standard-and-multiple-vendor-types
@@ -21,8 +21,8 @@ class AssertColumnType(BaseAssertionType):
     def name(self):
         return "assert_column_type"
 
-    def execute(self, context: AssertionContext, table: str, column: str, metrics: dict):
-        return assert_column_type(context, table, column, metrics)
+    def execute(self, context: AssertionContext):
+        return assert_column_type(context)
 
     def validate(self, context: AssertionContext) -> ValidationResult:
         result = ValidationResult(context).require('type', str)
@@ -39,8 +39,8 @@ class AssertColumnInTypes(BaseAssertionType):
     def name(self):
         return "assert_column_in_types"
 
-    def execute(self, context: AssertionContext, table: str, column: str, metrics: dict):
-        return assert_column_in_types(context, table, column, metrics)
+    def execute(self, context: AssertionContext):
+        return assert_column_in_types(context)
 
     def validate(self, context: AssertionContext) -> ValidationResult:
         result = ValidationResult(context).require('types', list)
@@ -54,7 +54,11 @@ class AssertColumnInTypes(BaseAssertionType):
         return result
 
 
-def assert_column_schema_type(context: AssertionContext, table: str, column: str, metrics: dict) -> AssertionResult:
+def assert_column_schema_type(context: AssertionContext) -> AssertionResult:
+    table = context.table
+    column = context.column
+    metrics = context.profiler_result
+
     column_metrics = metrics.get('tables', {}).get(table, {}).get('columns', {}).get(column)
     if not column_metrics:
         return context.result.fail_with_metric_not_found_error(context.table, context.column)
@@ -74,7 +78,11 @@ def assert_column_schema_type(context: AssertionContext, table: str, column: str
     return context.result.fail()
 
 
-def assert_column_type(context: AssertionContext, table: str, column: str, metrics: dict) -> AssertionResult:
+def assert_column_type(context: AssertionContext) -> AssertionResult:
+    table = context.table
+    column = context.column
+    metrics = context.profiler_result
+
     column_metrics = metrics.get('tables', {}).get(table, {}).get('columns', {}).get(column)
     if not column_metrics:
         return context.result.fail_with_metric_not_found_error(context.table, context.column)
@@ -99,7 +107,11 @@ def assert_column_type(context: AssertionContext, table: str, column: str, metri
     return context.result.fail()
 
 
-def assert_column_in_types(context: AssertionContext, table: str, column: str, metrics: dict) -> AssertionResult:
+def assert_column_in_types(context: AssertionContext) -> AssertionResult:
+    table = context.table
+    column = context.column
+    metrics = context.profiler_result
+
     column_metrics = metrics.get('tables', {}).get(table, {}).get('columns', {}).get(column)
     if not column_metrics:
         return context.result.fail_with_metric_not_found_error(context.table, context.column)

--- a/piperider_cli/assertion_engine/types/assert_metrics.py
+++ b/piperider_cli/assertion_engine/types/assert_metrics.py
@@ -13,7 +13,11 @@ class AssertMetric(BaseAssertionType):
     def name(self):
         return ''
 
-    def execute(self, context: AssertionContext, table: str, column: str, metrics: dict):
+    def execute(self, context: AssertionContext):
+        table = context.table
+        column = context.column
+        metrics = context.profiler_result
+
         target_metrics = metrics.get('tables', {}).get(table)
         if column:
             target_metrics = target_metrics.get('columns', {}).get(column)

--- a/piperider_cli/assertion_engine/types/assert_rows.py
+++ b/piperider_cli/assertion_engine/types/assert_rows.py
@@ -8,8 +8,8 @@ class AssertRowCountInRange(BaseAssertionType):
     def name(self):
         return "assert_row_count_in_range"
 
-    def execute(self, context: AssertionContext, table: str, column: str, metrics: dict):
-        return assert_row_count_in_range(context, table, column, metrics)
+    def execute(self, context: AssertionContext):
+        return assert_row_count_in_range(context)
 
     def validate(self, context: AssertionContext) -> ValidationResult:
         return ValidationResult(context).require('count').require_int_pair('count')
@@ -19,8 +19,8 @@ class AssertRowCount(BaseAssertionType):
     def name(self):
         return "assert_row_count"
 
-    def execute(self, context: AssertionContext, table: str, column: str, metrics: dict):
-        return assert_row_count(context, table, column, metrics)
+    def execute(self, context: AssertionContext):
+        return assert_row_count(context)
 
     def validate(self, context: AssertionContext) -> ValidationResult:
         results = ValidationResult(context) \
@@ -38,10 +38,14 @@ class AssertRowCount(BaseAssertionType):
         return results
 
 
-def assert_row_count(context: AssertionContext, table: str, column: str, metrics: dict) -> AssertionResult:
+def assert_row_count(context: AssertionContext) -> AssertionResult:
+    table = context.table
+    column = context.column
+    metrics = context.profiler_result
+
     table_metrics = metrics.get('tables', {}).get(table)
     if not table_metrics:
-        return context.result.fail_with_metric_not_found_error(context.table, context.column)
+        return context.result.fail_with_metric_not_found_error(table, column)
 
     # Get the metric for the current table
     row_count = table_metrics.get('row_count')
@@ -72,10 +76,14 @@ def assert_row_count(context: AssertionContext, table: str, column: str, metrics
     return context.result.fail()
 
 
-def assert_row_count_in_range(context: AssertionContext, table: str, column: str, metrics: dict) -> AssertionResult:
+def assert_row_count_in_range(context: AssertionContext) -> AssertionResult:
+    table = context.table
+    column = context.column
+    metrics = context.profiler_result
+
     table_metrics = metrics.get('tables', {}).get(table)
     if not table_metrics:
-        return context.result.fail_with_metric_not_found_error(context.table, context.column)
+        return context.result.fail_with_metric_not_found_error(table, column)
 
     # Get the metric for the current table
     row_count = table_metrics.get('row_count')

--- a/piperider_cli/assertion_engine/types/base.py
+++ b/piperider_cli/assertion_engine/types/base.py
@@ -14,7 +14,7 @@ class BaseAssertionType(metaclass=abc.ABCMeta):
         pass
 
     @abc.abstractmethod
-    def execute(self, context: AssertionContext, table: str, column: str, metrics: dict) -> AssertionResult:
+    def execute(self, context: AssertionContext) -> AssertionResult:
         pass
 
     @abc.abstractmethod

--- a/piperider_cli/assertion_generator.py
+++ b/piperider_cli/assertion_generator.py
@@ -55,7 +55,7 @@ class AssertionGenerator():
 
         # Generate recommended assertions
         assertion_engine = AssertionEngine(None)
-        assertion_engine.load_assertions(profiling_result=profiling_result)
+        assertion_engine.load_assertions(profiler_result=profiling_result)
         assertion_exist = True if assertion_engine.assertions_content else False
         console.rule('Generating Recommended Assertions')
         recommended_assertions = assertion_engine.generate_recommended_assertions(profiling_result,

--- a/piperider_cli/data/piperider-init-template/plugins/customized_assertions.py.template
+++ b/piperider_cli/data/piperider-init-template/plugins/customized_assertions.py.template
@@ -6,7 +6,11 @@ class AssertNothingTableExample(BaseAssertionType):
     def name(self):
         return 'assert_nothing_table_example'
 
-    def execute(self, context: AssertionContext, table: str, column: str, metrics: dict) -> AssertionResult:
+    def execute(self, context: AssertionContext) -> AssertionResult:
+        table = context.table
+        column = context.column
+        metrics = context.profiler_result
+
         table_metrics = metrics.get('tables', {}).get(table)
         if table_metrics is None:
             # cannot find the table in the metrics
@@ -42,7 +46,11 @@ class AssertNothingColumnExample(BaseAssertionType):
     def name(self):
         return "assert_nothing_column_example"
 
-    def execute(self, context: AssertionContext, table: str, column: str, metrics: dict) -> AssertionResult:
+    def execute(self, context: AssertionContext) -> AssertionResult:
+        table = context.table
+        column = context.column
+        metrics = context.profiler_result
+
         column_metrics = metrics.get('tables', {}).get(table, {}).get('columns', {}).get(column)
         if column_metrics is None:
             # cannot find the column in the metrics

--- a/piperider_cli/profiler/profiler.py
+++ b/piperider_cli/profiler/profiler.py
@@ -564,7 +564,6 @@ class StringColumnProfiler(BaseColumnProfiler):
                 func.count(cte.c.c).label("_valids"),
                 func.count(cte.c.zero_length).label("_zero_length"),
                 func.count(distinct(cte.c.c)).label("_distinct"),
-                func.sum(func.cast(cte.c.len, Float)).label("_sum"),
                 func.avg(cte.c.len).label("_avg"),
                 func.min(cte.c.len).label("_min"),
                 func.max(cte.c.len).label("_max"),
@@ -576,7 +575,7 @@ class StringColumnProfiler(BaseColumnProfiler):
                     cte.c.len)) / ((func.count(cte.c.len) - 1) * func.count(cte.c.len)).label('_variance'))
                 stmt = select(columns)
                 result = conn.execute(stmt).fetchone()
-                _total, _non_nulls, _valids, _zero_length, _distinct, _sum, _avg, _min, _max, _variance = result
+                _total, _non_nulls, _valids, _zero_length, _distinct, _avg, _min, _max, _variance = result
                 _stddev = None
                 if _variance is not None:
                     _stddev = math.sqrt(_variance)
@@ -584,12 +583,11 @@ class StringColumnProfiler(BaseColumnProfiler):
                 columns.append(func.stddev(cte.c.len).label("_stddev"))
                 stmt = select(columns)
                 result = conn.execute(stmt).fetchone()
-                _total, _non_nulls, _valids, _zero_length, _distinct, _sum, _avg, _min, _max, _stddev = result
+                _total, _non_nulls, _valids, _zero_length, _distinct, _avg, _min, _max, _stddev = result
 
             _nulls = _total - _non_nulls
             _invalids = _non_nulls - _valids
             _non_zero_length = _valids - _zero_length
-            _sum = dtof(_sum)
             _min = dtof(_min)
             _max = dtof(_max)
             _avg = dtof(_avg)
@@ -618,7 +616,6 @@ class StringColumnProfiler(BaseColumnProfiler):
                 'min_length': _min,
                 'max': _max,
                 'max_length': _max,
-                'sum': _sum,
                 'avg': _avg,
                 'avg_length': _avg,
                 'stddev': _stddev,

--- a/piperider_cli/runner.py
+++ b/piperider_cli/runner.py
@@ -620,7 +620,7 @@ class Runner():
         except Exception as e:
             raise Exception(f'Profiler Exception: {type(e).__name__}(\'{e}\')')
 
-        # TODO stop here if tests was not needed.
+        # TODO: refactor input unused arguments
         assertion_results, assertion_exceptions = _execute_assertions(console, engine, ds.name, interaction, output,
                                                                       profiler_result, created_at, skip_recommend)
 

--- a/piperider_cli/runner.py
+++ b/piperider_cli/runner.py
@@ -136,6 +136,7 @@ def _execute_assertions(console: Console, engine, ds_name: str, interaction: boo
     assertion_engine.load_assertions(profiler_result)
     assertion_exist = True if assertion_engine.assertions_content else False
 
+    results = exceptions = []
     if not assertion_exist:
         console.print('[bold yellow]No assertion found[/]')
         if _agreed_to_generate_recommended_assertions(console, interaction, skip_recommend):
@@ -157,7 +158,9 @@ def _execute_assertions(console: Console, engine, ds_name: str, interaction: boo
                 console.print(f'[bold green]Template Assertion[/bold green]: {f}')
 
     # Execute assertions
-    results, exceptions = assertion_engine.evaluate_all()
+    if len(assertion_engine.assertions):
+        console.rule('Testing')
+        results, exceptions = assertion_engine.evaluate_all()
     return results, exceptions
 
 

--- a/tests/_user_defined_assertion_functions.py
+++ b/tests/_user_defined_assertion_functions.py
@@ -6,7 +6,7 @@ class UserDefinedTests(BaseAssertionType):
     def name(self):
         return 'user-defined-test-test'
 
-    def execute(self, context: AssertionContext, table: str, column: str, metrics: dict) -> AssertionResult:
+    def execute(self, context: AssertionContext) -> AssertionResult:
         context.result.actual = 'I see you'
         context.result._expected = dict(magic_number=5566)
         return context.result.success()

--- a/tests/test_builtin_assertions.py
+++ b/tests/test_builtin_assertions.py
@@ -213,7 +213,7 @@ class BuiltinAssertionsTests(TestCase):
             self.assertEqual(dict(success=True, exceptions=None),
                              dict(success=assertion_result._success, exceptions=assertion_result._exception))
 
-    def test_assert_column_value(self):
+    def test_assert_column_value_range(self):
         assertions = """
         orders_1k:  # Table Name
           columns:
@@ -223,6 +223,26 @@ class BuiltinAssertionsTests(TestCase):
                 assert:
                   lte: 440269.51
                   gte: 1106.99
+                tags:
+                - OPTIONAL
+        """
+        engine = build_assertion_engine('orders_1k', self.metrics, assertions)
+        results, exceptions = engine.evaluate_all()
+        self.assertEqual([], exceptions)
+
+        assertion_result = results[0].result
+        self.assertEqual(dict(success=True, exceptions=None),
+                         dict(success=assertion_result._success, exceptions=assertion_result._exception))
+
+    def test_assert_column_value_set(self):
+        assertions = """
+        orders_1k:  # Table Name
+          columns:
+            o_orderstatus:
+              tests:
+              - name: assert_column_value
+                assert:
+                  in: ['O', 'F', 'P']
                 tags:
                 - OPTIONAL
         """

--- a/tests/test_builtin_assertions.py
+++ b/tests/test_builtin_assertions.py
@@ -6,7 +6,6 @@ from unittest import TestCase
 from sqlalchemy import create_engine, MetaData, Table, Column, Integer
 
 from piperider_cli.assertion_engine import AssertionEngine
-from piperider_cli.profiler import Profiler
 
 
 def build_test_assertions(assertion_config_text: str):
@@ -20,16 +19,14 @@ def build_test_assertions(assertion_config_text: str):
     return assertions_dir
 
 
-def build_assertion_engine(table, assertions):
+def build_assertion_engine(table, profiler_result, assertions):
     db_engine = create_engine('sqlite://')
-    profiler = Profiler(db_engine)
-    profiler.metadata = MetaData()
-    Table(table, profiler.metadata, Column('misc', Integer))
-    profiler.metadata.create_all(db_engine)
-    profiler.profile([table])
+    metadata = MetaData()
+    Table(table, metadata, Column('misc', Integer))
+    metadata.create_all(db_engine)
 
-    engine = AssertionEngine(profiler, build_test_assertions(assertions))
-    engine.load_assertions(config_path=None)
+    engine = AssertionEngine(db_engine, build_test_assertions(assertions))
+    engine.load_assertions(profiler_result=profiler_result, config_path=None)
     return engine
 
 
@@ -52,7 +49,7 @@ class BuiltinAssertionsTests(TestCase):
             tags:
             - OPTIONAL
         """
-        engine = build_assertion_engine('orders_1k', assertions)
+        engine = build_assertion_engine('orders_1k', self.metrics, assertions)
         results = engine.validate_assertions()
 
         self.assertEqual(1, len(results))
@@ -74,9 +71,9 @@ class BuiltinAssertionsTests(TestCase):
             tags:
             - OPTIONAL
         """
-        engine = build_assertion_engine('orders_1k', assertions)
+        engine = build_assertion_engine('orders_1k', self.metrics, assertions)
 
-        results, exceptions = engine.evaluate_all(self.metrics)
+        results, exceptions = engine.evaluate_all()
         self.assertEqual([], exceptions)
 
         assertion_result = results[0].result
@@ -110,9 +107,9 @@ class BuiltinAssertionsTests(TestCase):
                 tags:
                 - OPTIONAL
         """
-        engine = build_assertion_engine('orders_1k', assertions)
+        engine = build_assertion_engine('orders_1k', self.metrics, assertions)
 
-        results, exceptions = engine.evaluate_all(self.metrics)
+        results, exceptions = engine.evaluate_all()
         self.assertEqual([], exceptions)
 
         for result in results:
@@ -143,9 +140,9 @@ class BuiltinAssertionsTests(TestCase):
                 tags:
                 - OPTIONAL
         """
-        engine = build_assertion_engine('orders_1k', assertions)
+        engine = build_assertion_engine('orders_1k', self.metrics, assertions)
 
-        results, exceptions = engine.evaluate_all(self.metrics)
+        results, exceptions = engine.evaluate_all()
         self.assertEqual([], exceptions)
 
         for result in results:
@@ -164,9 +161,9 @@ class BuiltinAssertionsTests(TestCase):
                 tags:
                 - OPTIONAL
         """
-        engine = build_assertion_engine('orders_1k', assertions)
+        engine = build_assertion_engine('orders_1k', self.metrics, assertions)
 
-        results, exceptions = engine.evaluate_all(self.metrics)
+        results, exceptions = engine.evaluate_all()
         self.assertEqual([], exceptions)
 
         for result in results:
@@ -185,9 +182,9 @@ class BuiltinAssertionsTests(TestCase):
                 tags:
                 - OPTIONAL
         """
-        engine = build_assertion_engine('orders_1k', assertions)
+        engine = build_assertion_engine('orders_1k', self.metrics, assertions)
 
-        results, exceptions = engine.evaluate_all(self.metrics)
+        results, exceptions = engine.evaluate_all()
         self.assertEqual([], exceptions)
 
         for result in results:
@@ -206,9 +203,9 @@ class BuiltinAssertionsTests(TestCase):
                 tags:
                 - OPTIONAL
         """
-        engine = build_assertion_engine('orders_1k', assertions)
+        engine = build_assertion_engine('orders_1k', self.metrics, assertions)
 
-        results, exceptions = engine.evaluate_all(self.metrics)
+        results, exceptions = engine.evaluate_all()
         self.assertEqual([], exceptions)
 
         for result in results:
@@ -229,9 +226,8 @@ class BuiltinAssertionsTests(TestCase):
                 tags:
                 - OPTIONAL
         """
-        engine = build_assertion_engine('orders_1k', assertions)
-
-        results, exceptions = engine.evaluate_all(self.metrics)
+        engine = build_assertion_engine('orders_1k', self.metrics, assertions)
+        results, exceptions = engine.evaluate_all()
         self.assertEqual([], exceptions)
 
         assertion_result = results[0].result

--- a/tests/test_user_defined_assertions.py
+++ b/tests/test_user_defined_assertions.py
@@ -1,4 +1,3 @@
-import json
 import os
 import shutil
 import tempfile
@@ -7,8 +6,7 @@ from unittest import TestCase
 
 from sqlalchemy import create_engine, MetaData, Table, Column, Integer
 
-from piperider_cli.assertion_engine import AssertionContext, AssertionResult, AssertionEngine
-from piperider_cli.profiler import Profiler
+from piperider_cli.assertion_engine import AssertionEngine
 
 
 def prepare_project_structure():
@@ -40,13 +38,11 @@ def build_assertion_engine(project_dir, table, assertions):
         fh.write(assertions)
 
     db_engine = create_engine('sqlite://')
-    profiler = Profiler(db_engine)
-    profiler.metadata = MetaData()
-    Table(table, profiler.metadata, Column('misc', Integer))
-    profiler.metadata.create_all(db_engine)
-    profiler.profile([table])
+    metadata = MetaData()
+    Table(table, metadata, Column('misc', Integer))
+    metadata.create_all(db_engine)
 
-    engine = AssertionEngine(profiler, project_dir)
+    engine = AssertionEngine(db_engine, project_dir)
     engine.load_assertions(config_path=None)
     return engine
 
@@ -81,7 +77,7 @@ class UserDefinedTestAssertionsTests(TestCase):
         engine = build_assertion_engine(self.project_dir, 'foobarbar', assertions)
 
         # invoke customized assertion
-        results, exceptions = engine.evaluate_all({})
+        results, exceptions = engine.evaluate_all()
 
         # check no exceptions
         self.assertEqual([], exceptions)
@@ -114,7 +110,7 @@ class UserDefinedTestAssertionsTests(TestCase):
         engine = build_assertion_engine(self.project_dir, 'foobarbar', assertions)
 
         # invoke customized assertion
-        results, exceptions = engine.evaluate_all({})
+        results, exceptions = engine.evaluate_all()
         self.assertEqual([], exceptions)
 
         assertion_result = results[0].result


### PR DESCRIPTION
Signed-off-by: Wei-Chun, Chang <wcchang@infuseai.io>
Co-authored-by: Timothy Lee <ctiml@infuseai.io>
Co-authored-by: popcorny <celu@infuseai.io>

<!--  Thanks for sending a pull request!  Here are some check items for you: -->

**PR checklist**

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed

**What type of PR is this?**
feature

**What this PR does / why we need it**:
support more column value check

**Which issue(s) this PR fixes**:
sc-29028
 
**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
The interface of the assertion class is changed.
The `execute` only accepts one assertion context as the input parameter.

- original `customized_assertions.py.template`
```python
class AssertNothingTableExample(BaseAssertionType):    
   
    def execute(self, context: AssertionContext, table: str, column: str, metrics: dict) -> AssertionResult:
```

- new `customized_assertions.py.template`
```python
class AssertNothingTableExample(BaseAssertionType):

    def execute(self, context: AssertionContext) -> AssertionResult:
        table = context.table
        column = context.column
        metrics = context.profiler_result
```