### PR TITLE
[Bug] - squished table details page; schema legacy_assertIon_test `title` property

### DIFF
--- a/piperider_cli/profiler/schema.json
+++ b/piperider_cli/profiler/schema.json
@@ -649,7 +649,7 @@
       }
     },
     "legacy_assertion_test": {
-      "title": "AssertionTest",
+      "title": "AssertionTest1",
       "type": "object",
       "required": [
         "name",

--- a/static_report/src/components/shared/Tables/TableMetrics/DupedTableRowStats.tsx
+++ b/static_report/src/components/shared/Tables/TableMetrics/DupedTableRowStats.tsx
@@ -26,11 +26,8 @@ export function DupedTableRowStats({ tableDatum, ...props }: Props & BoxProps) {
             name={name}
             metakey={metakey}
             firstSlot={firstSlot}
-            firstSlotWidth={'16em'}
             secondSlot={secondSlot}
-            secondSlotWidth={'16em'}
             tooltipValues={tooltipValues}
-            width="100%"
             {...props}
           />
         ),

--- a/static_report/src/components/shared/Tables/TableMetrics/DupedTableRowStats.tsx
+++ b/static_report/src/components/shared/Tables/TableMetrics/DupedTableRowStats.tsx
@@ -28,6 +28,7 @@ export function DupedTableRowStats({ tableDatum, ...props }: Props & BoxProps) {
             firstSlot={firstSlot}
             secondSlot={secondSlot}
             tooltipValues={tooltipValues}
+            width={'100%'}
             {...props}
           />
         ),

--- a/static_report/src/components/shared/Tables/TableMetrics/TableGeneralStats.tsx
+++ b/static_report/src/components/shared/Tables/TableMetrics/TableGeneralStats.tsx
@@ -85,6 +85,7 @@ export function TableGeneralStats({ tableDatum, ...props }: Props & BoxProps) {
             firstSlot={firstSlot}
             secondSlot={secondSlot}
             tooltipValues={tooltipValues}
+            width={'100%'}
             {...props}
           />
         ),

--- a/static_report/src/components/shared/Tables/TableMetrics/TableGeneralStats.tsx
+++ b/static_report/src/components/shared/Tables/TableMetrics/TableGeneralStats.tsx
@@ -83,11 +83,8 @@ export function TableGeneralStats({ tableDatum, ...props }: Props & BoxProps) {
             name={name}
             metakey={metakey}
             firstSlot={firstSlot}
-            firstSlotWidth={'5em'}
             secondSlot={secondSlot}
-            secondSlotWidth={'15em'}
             tooltipValues={tooltipValues}
-            width="100%"
             {...props}
           />
         ),

--- a/static_report/src/components/shared/Tables/TableOverview.tsx
+++ b/static_report/src/components/shared/Tables/TableOverview.tsx
@@ -11,7 +11,7 @@ interface Props {
 
 export function TableOverview({ tableDatum, ...props }: Props & BoxProps) {
   return (
-    <Grid mb={8} gap={8}>
+    <Grid mb={8} gap={8} {...props}>
       <GridItem colSpan={1}>
         <TableGeneralStats tableDatum={tableDatum} />
       </GridItem>

--- a/static_report/src/components/shared/Widgets/DupedTableRowsWidget.tsx
+++ b/static_report/src/components/shared/Widgets/DupedTableRowsWidget.tsx
@@ -19,14 +19,14 @@ export function DupedTableRowsWidget({ tableDatum, hasAnimation }: Props) {
       <Divider my={3} />
       {dataCompInput ? (
         <>
-          <Box height={'55px'}>
+          <Box height={'55px'} w={'400px'}>
             <FlatStackedBarChart
               data={dataCompInput}
               animation={animationOptions}
             />
           </Box>
           <Box mt={6}>
-            <DupedTableRowStats tableDatum={tableDatum} width={'100%'} />
+            <DupedTableRowStats tableDatum={tableDatum} />
           </Box>
         </>
       ) : (

--- a/static_report/src/components/shared/Widgets/DupedTableRowsWidget.tsx
+++ b/static_report/src/components/shared/Widgets/DupedTableRowsWidget.tsx
@@ -14,12 +14,12 @@ export function DupedTableRowsWidget({ tableDatum, hasAnimation }: Props) {
   const animationOptions = hasAnimation ? {} : false;
 
   return (
-    <Box mb={6}>
+    <Box mb={6} w={'100%'}>
       <Text fontSize={'xl'}>Duplicate Rows</Text>
       <Divider my={3} />
       {dataCompInput ? (
         <>
-          <Box height={'55px'} w={'400px'}>
+          <Box height={'55px'}>
             <FlatStackedBarChart
               data={dataCompInput}
               animation={animationOptions}

--- a/static_report/src/components/shared/Widgets/QuantilesWidget.tsx
+++ b/static_report/src/components/shared/Widgets/QuantilesWidget.tsx
@@ -11,7 +11,7 @@ export function QuantilesWidget({ columnDatum }: Props) {
   const { p50, max, min, p25, p75 } = columnDatum || {};
   if (columnDatum) {
     return (
-      <Box p={9} bg={'gray.50'} minWidth={'0px'}>
+      <Box bg={'gray.50'} minWidth={'0px'}>
         <Text fontSize={'xl'}>Quantile Data</Text>
         <Divider my={3} />
         <Box my={5}>

--- a/static_report/src/pages/CRColumnDetailsPage.tsx
+++ b/static_report/src/pages/CRColumnDetailsPage.tsx
@@ -148,9 +148,9 @@ export default function CRColumnDetailsPage({
                 <TabPanel>
                   <ComparableGridHeader />
                   <Grid templateColumns={'1fr 1px 1fr'} gap={3}>
-                    <TableOverview tableDatum={baseDataTable} />
+                    <TableOverview tableDatum={baseDataTable} w={'20em'} />
                     <Divider orientation="vertical" />
-                    <TableOverview tableDatum={targetDataTable} />
+                    <TableOverview tableDatum={targetDataTable} w={'20em'} />
                     <TableDescription
                       description={baseDataTable?.description}
                     />

--- a/static_report/src/pages/CRColumnDetailsPage.tsx
+++ b/static_report/src/pages/CRColumnDetailsPage.tsx
@@ -148,9 +148,9 @@ export default function CRColumnDetailsPage({
                 <TabPanel>
                   <ComparableGridHeader />
                   <Grid templateColumns={'1fr 1px 1fr'} gap={3}>
-                    <TableOverview tableDatum={baseDataTable} w={'20em'} />
+                    <TableOverview tableDatum={baseDataTable} />
                     <Divider orientation="vertical" />
-                    <TableOverview tableDatum={targetDataTable} w={'20em'} />
+                    <TableOverview tableDatum={targetDataTable} />
                     <TableDescription
                       description={baseDataTable?.description}
                     />

--- a/static_report/src/sdlc/single-report-schema.ts
+++ b/static_report/src/sdlc/single-report-schema.ts
@@ -68,6 +68,10 @@ export interface TableSchema {
   columns: {
     [k: string]: ColumnSchema;
   };
+  piperider_assertion_result: null | PipeRiderAssertionResult;
+  dbt_assertion_result?: null | DbtAssertionResult;
+  profile_duration?: string;
+  elapsed_milli?: number;
 }
 /**
  * This interface was referenced by `undefined`'s JSON-Schema definition
@@ -295,16 +299,47 @@ export interface Topk {
   values: (string | number)[];
   counts: number[];
 }
+export interface PipeRiderAssertionResult {
+  tests: AssertionTest1[];
+  columns: {
+    /**
+     * This interface was referenced by `undefined`'s JSON-Schema definition
+     * via the `patternProperty` ".+".
+     */
+    [k: string]: AssertionTest1[];
+  };
+}
+export interface AssertionTest1 {
+  name: string;
+  status: 'passed' | 'failed';
+  parameters?: {
+    [k: string]: unknown;
+  };
+  tags?: string[];
+  expected?: unknown;
+  actual?: unknown;
+  [k: string]: unknown;
+}
+export interface DbtAssertionResult {
+  tests: AssertionTest1[];
+  columns: {
+    /**
+     * This interface was referenced by `undefined`'s JSON-Schema definition
+     * via the `patternProperty` ".+".
+     */
+    [k: string]: AssertionTest1[];
+  };
+}
 export interface AssertionTest {
   id: string;
   name: string;
-  metric: string | null;
+  metric?: string | null;
   table: string | null;
   column: string | null;
   tags: string[];
   status: 'passed' | 'failed';
-  expected: unknown;
-  actual: unknown;
+  expected?: unknown;
+  actual?: unknown;
   message: string | null;
   display_name: string;
   source: string;


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some check items for you: -->

**PR checklist**

- [X] Ensure you have added or ran the appropriate tests for your PR.
- [X] DCO signed

**What type of PR is this?**
fix
**What this PR does / why we need it**:
- Minor UI issues: squished comparison table-overview info (duplicate rows, table composition);
- quantile's extra padding misaligned with layout
- fix schema title (breaks typescript json schema generator)
**Which issue(s) this PR fixes**:
none
**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**: yes
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
- On certain screen sizes, the squished comparison table-overview info is fixed (duplicate rows, table composition);
- Quantile's extra padding misaligned with layout is fixed