### PR TITLE
[Feature] Allow only name or only metric in assert test entry

### DIFF
--- a/piperider_cli/assertion_engine/assertion.py
+++ b/piperider_cli/assertion_engine/assertion.py
@@ -398,20 +398,26 @@ class AssertionContext:
         return None
 
     def to_result_entry(self):
-        return dict(
-            id=self._get_assertion_id(),
-            name=self.result.name,
-            metric=self.metric,
-            table=self.table,
-            column=self.column,
-            status='passed' if self.result._success is True else 'failed',
-            expected=self.result.expected,
-            actual=self.result.actual,
-            tags=self.tags,
-            message=self._get_assertion_message(),
-            display_name=self.result.name,
-            source='piperider'
+        entry = dict(id=self._get_assertion_id())
+        if self.metric:
+            entry['metric'] = self.metric
+        else:
+            entry['name'] = self.name
+        entry.update(
+            dict(
+                table=self.table,
+                column=self.column,
+                status='passed' if self.result._success is True else 'failed',
+                expected=self.result.expected,
+                actual=self.result.actual,
+                tags=self.tags,
+                message=self._get_assertion_message(),
+                display_name=self.result.name,
+                source='piperider'
+            )
         )
+
+        return entry
 
 
 class AssertionEngine:

--- a/piperider_cli/profiler/schema.json
+++ b/piperider_cli/profiler/schema.json
@@ -569,7 +569,6 @@
       "type": "object",
       "required": [
         "id",
-        "name",
         "table",
         "column",
         "tags",
@@ -652,7 +651,6 @@
       "title": "AssertionTest1",
       "type": "object",
       "required": [
-        "name",
         "status"
       ],
       "additionalProperties": true,


### PR DESCRIPTION
Signed-off-by: Wei-Chun, Chang <wcchang@infuseai.io>

<!--  Thanks for sending a pull request!  Here are some check items for you: -->

**PR checklist**

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed

**What type of PR is this?**
feature

**What this PR does / why we need it**:
only allow one name or one metric property in assert test entry

**Which issue(s) this PR fixes**:
sc-29029

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
NONE