### PR TITLE
[Bug] The option --dbt-state should not profile the views

### DIFF
--- a/piperider_cli/runner.py
+++ b/piperider_cli/runner.py
@@ -604,7 +604,14 @@ class Runner():
                 console.print(
                     f"[bold red]Error:[/bold red] No available 'manifest.json' or 'run_results.json' under '{dbt_state_dir}'")
                 return 1
-            tables = dbtutil.get_dbt_state_candidate(dbt_state_dir, default_schema)
+
+            includes = dbtutil.get_dbt_state_candidate(dbt_state_dir, default_schema)
+
+            if configuration.includes is not None:
+                # intersect 'includes' and 'configuration.includes'
+                includes = [include for include in includes if include in configuration.includes]
+
+            configuration.includes = includes
 
             dbt_test_results, dbt_test_results_compatible = dbtutil.get_dbt_state_tests_result(dbt_state_dir,
                                                                                                default_schema)


### PR DESCRIPTION
The option --dbt-state should not profile the views

**PR checklist**

- [X] Ensure you have added or ran the appropriate tests for your PR.
- [X] DCO signed

**What type of PR is this?**
bug

**What this PR does / why we need it**:
- tables we retrieved from `dbt-state` is a table filter

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
NONE