### PR TITLE
[Bug] Allow piperider load duplicated key in dbt yaml

### DIFF
--- a/piperider_cli/configuration.py
+++ b/piperider_cli/configuration.py
@@ -102,7 +102,9 @@ class Configuration(object):
 
         with open(dbt_project_path, 'r') as fd:
             try:
-                dbt_project = yaml.safe_load(fd)
+                yml = yaml.YAML()
+                yml.allow_duplicate_keys = True
+                dbt_project = yml.load(fd)
             except Exception as e:
                 raise DbtProjectInvalidError(dbt_project_path, e)
 
@@ -376,7 +378,9 @@ def _load_dbt_profile(path):
     env.filters['as_text'] = as_text
     template = env.get_template(os.path.basename(path))
     try:
-        return yaml.safe_load(template.render())
+        yml = yaml.YAML()
+        yml.allow_duplicate_keys = True
+        return yml.load(template.render())
     except Exception as e:
         raise DbtProfileInvalidError(path, e)
 


### PR DESCRIPTION
Signed-off-by: Wei-Chun, Chang <wcchang@infuseai.io>
Co-authored-by: popcorny <celu@infuseai.io>

<!--  Thanks for sending a pull request!  Here are some check items for you: -->

**PR checklist**

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed

**What type of PR is this?**
bug

**What this PR does / why we need it**:
- dbt can load `dbt_project.yml` and `profiles.yml` with duplicated keys.
- align piperider behavior when loading `dbt_project.yml` and `profiles.yml`.

**Which issue(s) this PR fixes**:
sc-29650

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
NONE