### PR TITLE
[Chore] adjustment TableActionBar children prop position

### DIFF
--- a/static_report/src/components/Tables/TableActionBar.tsx
+++ b/static_report/src/components/Tables/TableActionBar.tsx
@@ -35,8 +35,9 @@ export function TableActionBar({ children }: Props) {
             <Icon as={FiAlertCircle} />
           </Flex>
         </Tooltip>
-        {children}
       </Flex>
+
+      {children}
     </Flex>
   );
 }


### PR DESCRIPTION
## Screenshot

*Before*
<img width="1360" alt="截圖 2022-12-06 上午11 40 27" src="https://user-images.githubusercontent.com/10325111/205808047-d75621c0-bb0b-4d12-b5f4-409bf6fbf149.png">

*After*
<img width="1350" alt="截圖 2022-12-06 上午11 46 58" src="https://user-images.githubusercontent.com/10325111/205808077-aed733ee-cf1f-4474-bc5f-1f50e363ea87.png">

## Description

I checked the OSS currently didn't use `children` anymore and we can move `children` out of the source name block.

- adjustment table action bar children prop position

Signed-off-by: Jie Peng <im@jiepeng.me>

<!--  Thanks for sending a pull request!  Here are some check items for you: -->

**PR checklist**

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed