### PR TITLE
[Bug] Fix the datetime overflow problem while profiling

### DIFF
--- a/piperider_cli/profiler/profiler.py
+++ b/piperider_cli/profiler/profiler.py
@@ -1180,10 +1180,14 @@ class DatetimeColumnProfiler(BaseColumnProfiler):
         if days_delta > 365 * 4:
             _type = "yearly"
             dmin = date(min.year, 1, 1)
-            dmax = date(max.year, 1, 1) + relativedelta(years=+1)
+            if max.year < 3000:
+                dmax = date(max.year, 1, 1) + relativedelta(years=+1)
+            else:
+                dmax = date(3000, 1, 1)
             interval_years = math.ceil((dmax.year - dmin.year) / 50)
             interval = relativedelta(years=+interval_years)
             num_buckets = math.ceil((dmax.year - dmin.year) / interval.years)
+
             cte = select([date_trunc("YEAR", column).label("d")]).select_from(table).cte()
         elif days_delta > 60:
             _type = "monthly"


### PR DESCRIPTION
Fix #533 

<!--  Thanks for sending a pull request!  Here are some check items for you: -->

**PR checklist**

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed

**What type of PR is this?**
Bug

**What this PR does / why we need it**:
If max value of datetime column is huge, it would bump into python datetime overflow. (max=9999-12-31) 

**Which issue(s) this PR fixes**:
#533
sc-29904

**Special notes for your reviewer**:
Set the upper bound for datetime histogram to prevent for running into exception

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
