### PR TITLE
fix: assertion-list widget filter (col-details-pages)

### DIFF
--- a/static_report/src/components/Widgets/AssertionListWidget.tsx
+++ b/static_report/src/components/Widgets/AssertionListWidget.tsx
@@ -47,6 +47,7 @@ type JoinFields = {
 type JoinedAssertionTest = ComparedAssertionTestValue & JoinFields;
 interface Props extends Comparable {
   comparableAssertions: ReportState['assertionsOnly'];
+  filterByTableOnly?: boolean;
   filterString?: string;
   setFilterString?: (input: string) => void;
   caseSensitiveFilter?: boolean;
@@ -59,6 +60,7 @@ interface Props extends Comparable {
 */
 export function AssertionListWidget({
   comparableAssertions,
+  filterByTableOnly,
   filterString = '',
   setFilterString,
   caseSensitiveFilter,
@@ -231,10 +233,13 @@ export function AssertionListWidget({
                   filterString,
                   `g${caseSensitiveFilter ? '' : 'i'}`,
                 );
-                return filterString
+                // return either the hard-override filter or default to the provided filterString;
+                return filterByTableOnly
+                  ? (v.table || '') === filterString
+                  : filterString
                   ? (v?.name || '').search(filterRegEx) > -1 ||
-                      (v.table || '').search(filterRegEx) > -1 ||
-                      (v.column || '').search(filterRegEx) > -1
+                    (v.table || '').search(filterRegEx) > -1 ||
+                    (v.column || '').search(filterRegEx) > -1
                   : true;
               })
               .map((row) => {

--- a/static_report/src/pages/CRColumnDetailsPage.tsx
+++ b/static_report/src/pages/CRColumnDetailsPage.tsx
@@ -182,6 +182,7 @@ export default function CRColumnDetailsPage({
                   <Grid templateColumns={'1fr'} gap={3} height={'100%'}>
                     <AssertionListWidget
                       filterString={tableName}
+                      filterByTableOnly
                       caseSensitiveFilter
                       comparableAssertions={assertionsOnly}
                       tableSize={'sm'}

--- a/static_report/src/pages/SRColumnDetailsPage.tsx
+++ b/static_report/src/pages/SRColumnDetailsPage.tsx
@@ -159,6 +159,7 @@ export default function SRColumnDetailsPage({
                   )}
                   <AssertionListWidget
                     filterString={dataTable.name}
+                    filterByTableOnly
                     caseSensitiveFilter
                     comparableAssertions={assertionsOnly}
                     singleOnly


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some check items for you: -->

**PR checklist**

- [X ] Ensure you have added or ran the appropriate tests for your PR.
- [X ] DCO signed

**What type of PR is this?**
Fix
**What this PR does / why we need it**:
The previous filter for assert-list-widget is too loose, should be a strict equality for pages that need only the subset table, regardless of similar naming on the column, table, assertion name level

**Which issue(s) this PR fixes**:
N/A
**Special notes for your reviewer**:
From: 
![Screenshot 2022-12-14 at 1 45 42 PM](https://user-images.githubusercontent.com/11186480/207523328-e2f24cbb-319d-4ff2-9db3-ea3f24298b45.png)

To: 
![image](https://user-images.githubusercontent.com/11186480/207523192-a4bcef75-9807-41fe-95b0-5ac3e3c37ff1.png)

**Does this PR introduce a user-facing change?**: yes
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
Previously, overlapping names of assertion, column, table would erroneously include assertions as the filtered results in the assertion list widget. This has been fixed to strictly check only on the table name implemented at the page level.