### PR TITLE
[Feature] Support keypair and SSO authentication in snowflake connector

### DIFF
--- a/piperider_cli/datasource/field.py
+++ b/piperider_cli/datasource/field.py
@@ -74,6 +74,8 @@ class DataSourceField(metaclass=ABCMeta):
         ignore = self.ignore
         if isinstance(ignore, bool) and ignore is True or isinstance(ignore, Callable) and ignore(answers):
             return None
+        if isinstance(default, Callable):
+            default = default(answers)
 
         if self.type == 'password':
             password = True

--- a/piperider_cli/datasource/snowflake.py
+++ b/piperider_cli/datasource/snowflake.py
@@ -1,6 +1,12 @@
+import inquirer
+
 from piperider_cli.error import PipeRiderConnectorError, PipeRiderCredentialFieldError
 from . import DataSource
-from .field import TextField, PasswordField
+from .field import TextField, PasswordField, ListField, PathField, DataSourceField
+
+AUTH_METHOD_PASSWORD = 'password'
+AUTH_METHOD_KEYPAIR = 'keypair'
+AUTH_METHOD_SSO = 'sso'
 
 
 class SnowflakeDataSource(DataSource):
@@ -10,7 +16,18 @@ class SnowflakeDataSource(DataSource):
         self.fields = [
             TextField('account', description='Account'),
             TextField('user', description='Username'),
-            PasswordField('password', description='Password'),
+            ListField('_method', description='Authentication Methods',
+                      default=[AUTH_METHOD_PASSWORD, AUTH_METHOD_KEYPAIR, AUTH_METHOD_SSO]),
+
+            PasswordField('password', description='Password',
+                          ignore=lambda answers: answers.get('_method') != AUTH_METHOD_PASSWORD),
+            PathField('private_key_path', description='Private key path',
+                      ignore=lambda answers: answers.get('_method') != AUTH_METHOD_KEYPAIR),
+            PasswordField('private_key_passphrase', description='Passphrase for the private key', optional=True,
+                          ignore=lambda answers: answers.get('_method') != AUTH_METHOD_KEYPAIR),
+            TextField('authenticator', description='Authenticator (\'externalbrowser\' or a valid Okta URL)',
+                      default=lambda answers: 'externalbrowser' if answers.get('_method') == AUTH_METHOD_SSO else None,
+                      ignore=lambda answers: answers.get('_method') != AUTH_METHOD_SSO),
             TextField('role', description='Role', optional=True),
             TextField('database', description='Database'),
             TextField('warehouse', description='Warehouse'),
@@ -40,24 +57,54 @@ class SnowflakeDataSource(DataSource):
         db_parameters = {
             "account": account,
             "user": user,
-            "password": password,
             "database": database,
             "schema": schema,
             "warehouse": warehouse
         }
 
+        if password:
+            db_parameters["password"] = password
+
         if role:
             db_parameters["role"] = role
 
         if authenticator:
-            if authenticator not in ['snowflake', 'username_password_mfa']:
-                raise PipeRiderCredentialFieldError('authenticator', 'The authentication method is not supported')
             db_parameters["authenticator"] = authenticator
 
         return URL(**db_parameters)
 
     def engine_args(self):
-        return dict(connect_args={'connect_timeout': self._connect_timeout})
+        return dict(connect_args={
+            'connect_timeout': self._connect_timeout,
+            'private_key': self._get_private_key(),
+        })
+
+    def _get_private_key(self):
+        private_key_path = self.credential.get('private_key_path')
+        private_key_passphrase = self.credential.get('private_key_passphrase')
+
+        if private_key_path is None:
+            return None
+
+        from cryptography.hazmat.backends import default_backend
+        from cryptography.hazmat.primitives import serialization
+
+        if private_key_passphrase:
+            encoded_passphase = private_key_passphrase.encode()
+        else:
+            encoded_passphase = None
+
+        with open(private_key_path, "rb") as key:
+            p_key = serialization.load_pem_private_key(
+                key.read(),
+                password=encoded_passphase,
+                backend=default_backend()
+            )
+
+        return p_key.private_bytes(
+            encoding=serialization.Encoding.DER,
+            format=serialization.PrivateFormat.PKCS8,
+            encryption_algorithm=serialization.NoEncryption())
 
     def verify_connector(self):
         try:


### PR DESCRIPTION
Add two more configuration

SSO: https://docs.snowflake.com/en/user-guide/admin-security-fed-auth.html
Key pair: https://docs.snowflake.com/en/user-guide/key-pair-auth.html


Key/pair
```
private_key_path: <path to the private key>
private_key_passphrase: <keyphase for the private key>
```

SSO. see [link](https://docs.snowflake.com/en/user-guide/python-connector-api.html#functions)
```
authenticator: 'externalbrowser' or 'https://<okta_account_name>.okta.com'
```

**PR checklist**

- [X] Ensure you have added or ran the appropriate tests for your PR.
- [X] DCO signed

**What type of PR is this?**
Feature

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
#532 
sc-29948

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
Yes
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
