### PR TITLE
[Feature] Support running on dbt state with custom db/schema macros

### DIFF
--- a/piperider_cli/cli.py
+++ b/piperider_cli/cli.py
@@ -157,6 +157,8 @@ def diagnose(**kwargs):
 @click.option('--report-dir', default=None, type=click.STRING, help='Use a different report directory.')
 @click.option('--upload', is_flag=True, help='Upload the report to the PipeRider Cloud.')
 @click.option('--open', is_flag=True, help='Opens the generated report in the system\'s default browser')
+@click.option('--only', default=None, type=click.STRING, help='Regex to include tables to profile')
+@click.option('--filter', default=None, type=click.STRING, help='Regex to filter tables to profile')
 @add_options(debug_option)
 def run(**kwargs):
     'Profile data source, run assertions, and generate report(s). By default, the raw results and reports are saved in ".piperider/outputs".'
@@ -168,12 +170,17 @@ def run(**kwargs):
     skip_report = kwargs.get('skip_report')
     dbt_state_dir = kwargs.get('dbt_state')
     force_upload = kwargs.get('upload')
+    only = kwargs.get('only')
+    filter = kwargs.get('filter')
     ret = Runner.exec(datasource=datasource,
                       table=table,
                       output=output,
                       skip_report=skip_report,
                       dbt_state_dir=dbt_state_dir,
-                      report_dir=kwargs.get('report_dir'))
+                      report_dir=kwargs.get('report_dir'),
+                      only=only,
+                      filter=filter
+                      )
     if ret in (0, EC_ERR_TEST_FAILED):
         auto_upload = CloudConnector.is_auto_upload()
         is_cloud_view = (force_upload or auto_upload)

--- a/piperider_cli/dbtutil.py
+++ b/piperider_cli/dbtutil.py
@@ -166,8 +166,7 @@ def get_dbt_state_candidate(dbt_state_dir: str, view_profile: bool = False,
             continue
         config_material = node.get('config').get('materialized')
         if config_material in material_whitelist and not _is_filtered_out(node.get('name'), whitelist, blacklist):
-            candidate.append(ProfileSubject(node.get('alias'), node.get('schema'), node.get('name')))
-
+            candidate.append(ProfileSubject(node.get('alias'), node.get('schema'), node.get('name'), node.get('database')))
     return candidate
 
 

--- a/piperider_cli/profiler/profiler.py
+++ b/piperider_cli/profiler/profiler.py
@@ -23,10 +23,11 @@ HISTOGRAM_NUM_BUCKET = 50
 
 
 class ProfileSubject:
-    def __init__(self, name: str, schema: str = None, model: str = None):
+    def __init__(self, name: str, schema: str = None, model: str = None, database: str = None):
         self.table = name
         self.schema = schema
         self.alias = model
+        self.database = database
 
     def get_lower_schema(self):
         return self.schema.lower() if self.schema else None

--- a/piperider_cli/runner.py
+++ b/piperider_cli/runner.py
@@ -1,3 +1,4 @@
+from collections import defaultdict
 import json
 import math
 import os
@@ -7,6 +8,7 @@ import sys
 import uuid
 from datetime import datetime
 
+from deepmerge import always_merger
 from rich import box
 from rich.color import Color
 from rich.console import Console
@@ -603,42 +605,17 @@ class Runner():
             console.print(f"[bold red]Error: datasource '{datasource}' doesn't exist[/bold red]")
             console.print(f"Available datasources: {', '.join(datasource_names)}")
             return 1
-
         # Use the first datasource if no datasource is specified
         ds_name = datasource if datasource else datasource_names[0]
         ds = datasources[ds_name]
 
-        passed, reasons = ds.validate()
-        if not passed:
-            console.print(f"[bold red]Error:[/bold red] The credential of '{ds.name}' is not configured.")
-            for reason in reasons:
-                console.print(f'    {reason}')
-            console.print(
-                "[bold yellow]Hint:[/bold yellow]\n  Please execute command 'piperider init' to move forward.")
-            return 1
-
         if not datasource and len(datasource_names) > 1:
             console.print(
-                f"[bold yellow]Warning: multiple datasources found ({', '.join(datasource_names)}), using '{ds_name}'[/bold yellow]\n")
+                f"[bold yellow]Warning: multiple datasources found ({', '.join(datasource_names)}), using '{ds.name}'[/bold yellow]\n")
 
-        console.print(f'[bold dark_orange]DataSource:[/bold dark_orange] {ds.name}')
-        console.rule('Validating')
-        err = ds.verify_connector()
-        if err:
-            console.print(
-                f'[[bold red]FAILED[/bold red]] Failed to load the \'{ds.type_name}\' connector.')
-            raise err
-
-        try:
-            available_tables = ds.verify_connection(configuration.include_views)
-        except Exception as err:
-            console.print(
-                f'[[bold red]FAILED[/bold red]] Failed to connect the \'{ds.name}\' data source.')
-            raise err
-        stop_runner = _validate_assertions(console)
-        if stop_runner:
-            console.print('\n\n[bold red]ERROR:[/bold red] Stop profiling, please fix the syntax errors above.')
-            return 1
+        tables = None
+        dbt_test_results = None
+        datasources_to_tables = {ds: None}
 
         dbt_config = ds.args.get('dbt')
 
@@ -646,21 +623,6 @@ class Runner():
             console.log('[bold red]ERROR:[/bold red] DBT configuration is not completed, please check the config.yml')
             return 1
 
-        console.rule('Profiling')
-        run_id = uuid.uuid4().hex
-        created_at = datetime.utcnow()
-        engine = ds.create_engine()
-        default_schema = ds.credential.get('schema')
-
-        if default_schema is None and ds.type_name == 'bigquery':
-            default_schema = ds.credential.get('dataset')
-
-        if default_schema is None:
-            inspector = inspect(engine)
-            default_schema = inspector.default_schema_name
-
-        tables = None
-        dbt_test_results = None
         if dbt_state_dir:
             if not dbtutil.is_dbt_state_ready(dbt_state_dir):
                 console.print(
@@ -671,82 +633,157 @@ class Runner():
                                                      configuration.includes, configuration.excludes)
             dbt_test_results = dbtutil.get_dbt_state_tests_result(dbt_state_dir)
 
-        if table:
-            if len(table.split('.')) == 2:
-                schema, table_name = table.split('.')
-                tables = [ProfileSubject(table_name, schema, table_name)]
-            else:
-                tables = [ProfileSubject(table, default_schema, table)]
-            # cli --table is specified, no inclusion and exclusion applied
-            configuration.includes = None
-            configuration.excludes = None
+            grouped_tables = defaultdict(lambda: defaultdict(lambda: list()))
+            for table_ in tables:
+                grouped_tables[table_.database][table_.schema].append(table_)
+            datasources_to_tables = {
+                type(ds)(
+                    name=f"{ds.name}.{db}.{schema}",
+                    credential={
+                        **ds.credential,
+                        **{"database": db, "schema": schema}
+                    }
+                ): tables
+                for (db, schema_tables) in grouped_tables.items()
+                for (schema, tables) in schema_tables.items()
+            }
 
-        run_result = {}
-        available_tables = [t.table for t in tables] if tables else available_tables
-        profiler = Profiler(engine, RichProfilerEventHandler(available_tables), configuration)
-        try:
-            profiler_result = profiler.profile(tables)
-            run_result.update(profiler_result)
-        except NoSuchTableError as e:
-            console.print(f"[bold red]Error:[/bold red] No such table '{str(e)}'")
-            return 1
-        except Exception as e:
-            raise Exception(f'Profiler Exception: {type(e).__name__}(\'{e}\')')
+        overall_run_results = {'tables': {}, 'tests': []}
+        overall_assertion_results = []
+        overall_assertion_exceptions = []
+        run_id = uuid.uuid4().hex
+        created_at = datetime.utcnow()
+        for ds_, tables in datasources_to_tables.items():
+            run_result = {'tables': {}, 'tests': []}
+            assertion_results = []
+            assertion_exceptions = []
 
-        metrics = []
-        if dbt_state_dir:
-            metrics = dbtutil.get_dbt_state_metrics(dbt_state_dir)
+            default_schema = ds_.credential.get('schema')
+            if table:
+                if len(table.split('.')) == 2:
+                    schema, table_name = table.split('.')
+                    tables = [ProfileSubject(table_name, schema, table_name)]
+                else:
+                    tables = [ProfileSubject(table, default_schema, table)]
+                # cli --table is specified, no inclusion and exclusion applied
+                configuration.includes = None
+                configuration.excludes = None
 
-        if metrics:
-            console.rule('Metrics')
-            run_result['metrics'] = MetricEngine(
+            if tables is not None and len(tables) == 0:
+                continue
+
+            passed, reasons = ds_.validate()
+            if not passed:
+                console.print(f"[bold red]Error:[/bold red] The credential of '{ds_.name}' is not configured.")
+                for reason in reasons:
+                    console.print(f'    {reason}')
+                console.print(
+                    "[bold yellow]Hint:[/bold yellow]\n  Please execute command 'piperider init' to move forward.")
+                return 1
+
+            console.print(f'[bold dark_orange]DataSource:[/bold dark_orange] {ds_.name}')
+            console.rule('Validating')
+            err = ds_.verify_connector()
+            if err:
+                console.print(
+                    f'[[bold red]FAILED[/bold red]] Failed to load the \'{ds_.type_name}\' connector.')
+                raise err
+
+            try:
+                available_tables = ds_.verify_connection(include_views=configuration.include_views)
+            except Exception as err:
+                console.print(
+                    f'[[bold red]FAILED[/bold red]] Failed to connect the \'{ds_.name}\' data source.')
+                raise err
+            stop_runner = _validate_assertions(console)
+            if stop_runner:
+                console.print('\n\n[bold red]ERROR:[/bold red] Stop profiling, please fix the syntax errors above.')
+                return 1
+
+            console.rule('Profiling')
+            engine = ds_.create_engine()
+
+            if default_schema is None and ds_.type_name == 'bigquery':
+                default_schema = ds_.credential.get('dataset')
+
+            if default_schema is None:
+                inspector = inspect(engine)
+                default_schema = inspector.default_schema_name
+
+            available_tables = [t.table for t in tables] if tables else available_tables
+            profiler = Profiler(engine, RichProfilerEventHandler(available_tables), configuration)
+            try:
+                profiler_result = profiler.profile(tables)
+                run_result.update(profiler_result)
+            except NoSuchTableError as e:
+                console.print(f"[bold red]Error:[/bold red] No such table '{str(e)}'")
+                return 1
+            except Exception as e:
+                raise Exception(f'Profiler Exception: {type(e).__name__}(\'{e}\')')
+
+            metrics = []
+            if dbt_state_dir:
+                metrics = dbtutil.get_dbt_state_metrics(dbt_state_dir)
+
+            if metrics:
+                console.rule('Metrics')
+                run_result['metrics'] = MetricEngine(
+                    engine,
+                    metrics,
+                    RichMetricEventHandler([m.label for m in metrics])
+                ).execute()
+
+            # TODO: refactor input unused arguments
+            assertion_results, assertion_exceptions = _execute_assertions(
+                console,
                 engine,
-                metrics,
-                RichMetricEventHandler([m.label for m in metrics])
-            ).execute()
+                ds_.name,
+                output,
+                profiler_result,
+                created_at
+            )
 
-        # TODO: refactor input unused arguments
-        assertion_results, assertion_exceptions = _execute_assertions(console, engine, ds.name, output,
-                                                                      profiler_result, created_at)
+            overall_run_results = always_merger.merge(run_result, overall_run_results)
+            overall_assertion_results.extend(assertion_results)
+            overall_assertion_exceptions.extend(assertion_exceptions)
 
-        run_result['tests'] = []
-        if assertion_results or dbt_test_results:
+        if overall_assertion_results or dbt_test_results:
             console.rule('Assertion Results')
             if dbt_test_results:
                 console.rule('dbt')
                 _show_dbt_test_result(dbt_test_results)
-                run_result['tests'].extend(dbt_test_results)
-                if assertion_results:
+                overall_run_results['tests'].extend(dbt_test_results)
+                if overall_assertion_results:
                     console.rule('PipeRider')
-            if assertion_results:
-                _show_assertion_result(assertion_results, assertion_exceptions)
-                run_result['tests'].extend([r.to_result_entry() for r in assertion_results])
+            if overall_assertion_results:
+                _show_assertion_result(overall_assertion_results, overall_assertion_exceptions)
+                overall_run_results['tests'].extend([r.to_result_entry() for r in overall_assertion_exceptions])
 
         console.rule('Summary')
 
-        for t in run_result['tables']:
-            _clean_up_profile_null_properties(run_result['tables'][t])
-        _show_summary(run_result, assertion_results, assertion_exceptions, dbt_test_results)
-        _show_recommended_assertion_notice_message(console, assertion_results)
+        for t in overall_run_results['tables']:
+            _clean_up_profile_null_properties(overall_run_results['tables'][t])
+        _show_summary(overall_run_results, overall_assertion_results, overall_assertion_exceptions, dbt_test_results)
+        _show_recommended_assertion_notice_message(console, overall_assertion_results)
 
         if dbt_state_dir:
             if not dbtutil.is_dbt_state_ready(dbt_state_dir):
                 console.print(
                     f"[bold red]Error:[/bold red] No available 'manifest.json' or 'run_results.json' under '{dbt_state_dir}'")
                 return 1
-            dbtutil.append_descriptions(run_result, dbt_state_dir)
-        _append_descriptions_from_assertion(run_result)
+            dbtutil.append_descriptions(overall_run_results, dbt_state_dir)
+        _append_descriptions_from_assertion(overall_run_results)
 
-        run_result['id'] = run_id
-        run_result['created_at'] = datetime_to_str(created_at)
-        run_result['datasource'] = dict(name=ds.name, type=ds.type_name)
-        decorate_with_metadata(run_result)
+        overall_run_results['id'] = run_id
+        overall_run_results['created_at'] = datetime_to_str(created_at)
+        overall_run_results['datasource'] = dict(name=ds.name, type=ds.type_name)
+        decorate_with_metadata(overall_run_results)
 
         output_path = prepare_default_output_path(filesystem, created_at, ds)
         output_file = os.path.join(output_path, 'run.json')
 
         with open(output_file, 'w') as f:
-            f.write(json.dumps(run_result, separators=(',', ':')))
+            f.write(json.dumps(overall_run_results, separators=(',', ':')))
 
         if dbt_state_dir:
             abs_dir = os.path.abspath(dbt_state_dir)
@@ -765,9 +802,9 @@ class Runner():
         if skip_report:
             console.print(f'Results saved to {output if output else output_path}')
 
-        _analyse_and_log_run_event(run_result, assertion_results, dbt_test_results)
+        _analyse_and_log_run_event(overall_run_results, overall_assertion_results, dbt_test_results)
 
-        if not _check_test_status(assertion_results, assertion_exceptions, dbt_test_results):
+        if not _check_test_status(overall_assertion_results, overall_assertion_exceptions, dbt_test_results):
             return EC_ERR_TEST_FAILED
 
         return 0

--- a/piperider_cli/runner.py
+++ b/piperider_cli/runner.py
@@ -584,7 +584,7 @@ def _check_test_status(assertion_results, assertion_exceptions, dbt_test_results
 class Runner():
     @staticmethod
     def exec(datasource=None, table=None, output=None, skip_report=False, dbt_state_dir: str = None,
-             report_dir: str = None):
+             report_dir: str = None, only: str = None, filter: str = None):
         console = Console()
 
         raise_exception_when_directory_not_writable(output)
@@ -668,6 +668,14 @@ class Runner():
                 # cli --table is specified, no inclusion and exclusion applied
                 configuration.includes = None
                 configuration.excludes = None
+
+            if only:
+                p = re.compile(only)
+                tables = [s for s in tables if p.match(s.table)]
+
+            if filter:
+                p = re.compile(filter)
+                tables = [s for s in tables if not p.match(s.table)]
 
             if tables is not None and len(tables) == 0:
                 continue


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some check items for you: -->

**PR checklist**

- [ X] Ensure you have added or ran the appropriate tests for your PR.
- [ X] DCO signed

**What type of PR is this?**
New Feature

**What this PR does / why we need it**:
Currently for running this project on a large dbt project that writes to multiple databases and schemas using custom dbt macros doe snot work at all.  This PR allows this to work and includes regex include(only)/exclude(filter) at command line to run on a substate of the entire large dbt project

**Which issue(s) this PR fixes**:
issue: 556

**Special notes for your reviewer**:
I am not sure if I followed all conventions correctly and if there are any gotchas that I am unaware of either in other databases types(tested throughly on snowflake) or conventions/patterns used for projects that are not dbt, but from reading the code this should work for everything.  I will say running this on a large DBT project that took over 12 hours to run, not having the ability to not fail everything on an error is very limiting/annoying.  I think catching errors and printing but continuing with everything else would be a nice addition, I just did not know how to represent that in the final html report.

**Does this PR introduce a user-facing change?**:
Yes, `piperider run` get the --only and --filter parameters to allow user to include tables using a regex and filter to exclude tables using a regex