### PR TITLE
[Bug] : broken initial load of toggled index for selected table/column (data-sidebar)

### DIFF
--- a/static_report/src/components/Columns/MasterSideNav/ColumnListAccordionPanel.tsx
+++ b/static_report/src/components/Columns/MasterSideNav/ColumnListAccordionPanel.tsx
@@ -27,7 +27,6 @@ export function ColumnListAccordionPanel({
           const isActiveColumn =
             (target || base)?.name === currentColumn &&
             indexedTableName === currentTable;
-          // console.log(colKey, isActiveColumn);
 
           return (
             <Box key={colKey}>

--- a/static_report/src/components/Columns/MasterSideNav/ColumnListAccordionPanel.tsx
+++ b/static_report/src/components/Columns/MasterSideNav/ColumnListAccordionPanel.tsx
@@ -27,6 +27,8 @@ export function ColumnListAccordionPanel({
           const isActiveColumn =
             (target || base)?.name === currentColumn &&
             indexedTableName === currentTable;
+          // console.log(colKey, isActiveColumn);
+
           return (
             <Box key={colKey}>
               {/* LIST - Columns */}

--- a/static_report/src/components/Columns/MasterSideNav/MasterSideNav.tsx
+++ b/static_report/src/components/Columns/MasterSideNav/MasterSideNav.tsx
@@ -8,7 +8,7 @@ import {
   AccordionItem,
   AccordionPanel,
 } from '@chakra-ui/react';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { FiChevronDown, FiChevronRight } from 'react-icons/fi';
 import { useLocalStorage } from 'react-use';
 
@@ -52,16 +52,22 @@ export function MasterSideNav({
   const [placeholder] = useLocalStorage(MASTER_LIST_SHOW_EXTRA, '');
 
   //initial state depends on position of current table in tableColEntryList
-  const initialIndex = tableColEntryList.findIndex(
-    ([key]) => key === currentTable,
-  );
+  const expandedIndex = tableColEntryList.findIndex(([key]) => {
+    return key === currentTable;
+  });
 
   //If parent container passes a `initAsExpandedTables: boolean` flag, certain routes to decide whether to show as expanded or not
   const [rootTablesExpandedIndexList, setRootTablesExpandedIndexList] =
     useState<number[]>(initAsExpandedTables ? [0] : []);
   const [tablesExpandedIndexList, setTablesExpandedIndexList] = useState<
     number[]
-  >([initialIndex]);
+  >([expandedIndex]);
+
+  useEffect(() => {
+    if (expandedIndex > -1) {
+      setTablesExpandedIndexList([expandedIndex]);
+    }
+  }, [expandedIndex]);
 
   return (
     <Box w={'100%'} zIndex={150} bg={'inherit'}>
@@ -111,7 +117,7 @@ export function MasterSideNav({
                 </h2>
                 <AccordionPanel py={0}>
                   <>
-                    <Accordion allowMultiple index={tablesExpandedIndexList}>
+                    <Accordion allowToggle index={tablesExpandedIndexList}>
                       {tableColEntryList.map(
                         ([tableName, compTableColItem, meta], index) => {
                           const fallbackTableEntries =


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some check items for you: -->

**PR checklist**

- [ X] Ensure you have added or ran the appropriate tests for your PR.
- [ X] DCO signed

**What type of PR is this?**
Fix
**What this PR does / why we need it**:
Fix bug in sidenav report menu (refreshing page doesn't expand the correct active nested item)

**Which issue(s) this PR fixes**:
N/A
**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**: Yes
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
Now on page refresh of a actively selected table or column, the sidebar initially show active item as expanded 