### PR TITLE
[Bug] Fix compatibility of dbt profile entry name

### DIFF
--- a/piperider_cli/configuration.py
+++ b/piperider_cli/configuration.py
@@ -230,6 +230,8 @@ class Configuration(object):
                 target_names = list(profile.get(profile_name).get('outputs').keys())
                 for target in target_names:
                     credential = dbtutil.load_credential_from_dbt_profile(profile, profile_name, target)
+                    if credential.get('pass') and credential.get('password') is None:
+                        credential['password'] = credential.pop('pass')
                     datasource_class = DATASOURCE_PROVIDERS[credential.get('type')]
                     data_source = datasource_class(
                         name=target,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some check items for you: -->

**PR checklist**

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed

**What type of PR is this?**
bug

**What this PR does / why we need it**:
- in dbt postgres project, credential entry name `pass` and `password` is allowed.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
NONE
