### PR TITLE
[Feature] warning users are reading report in non-supported mobile device

### DIFF
--- a/static_report/src/App.tsx
+++ b/static_report/src/App.tsx
@@ -139,6 +139,21 @@ function AppComparison() {
 }
 
 function App() {
+  const isMobile: boolean = /iPhone|iPad|iPod|Android/i.test(
+    navigator.userAgent,
+  );
+
+  if (isMobile) {
+    return (
+      <>
+        <div>
+          Please open this on a Desktop Computer. Mobile is currently not
+          supported.
+        </div>
+      </>
+    );
+  }
+
   if (process.env.REACT_APP_SINGLE_REPORT === 'true') {
     return <AppSingle />;
   } else {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some check items for you: -->

**PR checklist**

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed

**What type of PR is this?**

Feature added

**What this PR does / why we need it**:

PipeRider hasn't supported showing reports on mobile devices. We only show the warning message when found a browser with a mobile device user-agent name.



**Which issue(s) this PR fixes**:

sc-30597


----

## Demo 

https://piperider-dev-tmp.s3.ap-northeast-1.amazonaws.com/sc30597/git_repo_analytics-20230301160820/index.html
