### PR TITLE
[Bug] Fix compatibility of inquirer v3.1.3

### DIFF
--- a/piperider_cli/hack/inquirer.py
+++ b/piperider_cli/hack/inquirer.py
@@ -1,6 +1,6 @@
 import inquirer.errors as errors
 import inquirer.themes as themes
-from inquirer.questions import Question
+from inquirer.questions import Checkbox as CheckboxQuestion
 from inquirer.render.console import ConsoleRender
 from inquirer.render.console._checkbox import Checkbox
 from inquirer.render.console._confirm import Confirm
@@ -30,12 +30,12 @@ class HackedConsoleRender(ConsoleRender):
         return matrix.get(question_type)
 
 
-class LimitedCheckboxQuestion(Question):
+class LimitedCheckboxQuestion(CheckboxQuestion):
     kind = 'limited_checkbox'
 
     def __init__(self, name, message="", choices=None, default=None, ignore=False, validate=True, carousel=False,
                  limited=0):
-        super().__init__(name, message, choices, default, ignore, validate)
+        super().__init__(name, message=message, choices=choices, default=default, ignore=ignore, validate=validate)
         self.carousel = carousel
         if limited > 0 and limited <= len(choices):
             self.limited = limited


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some check items for you: -->

**PR checklist**

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed

**What type of PR is this?**
- bug

**What this PR does / why we need it**:
- When piperider depends on inquirer v3.1.3, the `LimitedCheckboxQuestion` has a missing attribute.

**Which issue(s) this PR fixes**:
sc-30803

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
NONE