### PR TITLE
[Feature] The CLI use the server response to get the report url

### DIFF
--- a/piperider_cli/cloud_connector.py
+++ b/piperider_cli/cloud_connector.py
@@ -241,11 +241,10 @@ def upload_to_cloud(run: RunOutput, debug=False, project: PipeRiderProject = Non
 
     if response.get('success') is True:
         run_id = response.get('id')
+        report_url = response.get('url')
         if run_id:
-            report_url = f'{piperider_cloud.service.cloud_host}/{project.workspace_name}/{project.name}/runs/{run_id}'
             _patch_cloud_upload_response(run.path, project, run_id)
-        else:
-            report_url = 'N/A'
+
         return {
             'success': True,
             'message': response.get("message"),
@@ -279,14 +278,10 @@ def get_run_report_id(project: PipeRiderProject, report_key: str) -> Optional[in
     return None
 
 
-def create_compare_reports(base_id: int, target_id: int, tables_from, project: PipeRiderProject = None) -> dict:
+def create_compare_reports(base_id: str, target_id: str, tables_from, project: PipeRiderProject = None) -> dict:
     if project is None:
         project = piperider_cloud.get_default_project()
     response = piperider_cloud.compare_reports(base_id, target_id, tables_from, project=project)
-    if response:
-        url = f'{piperider_cloud.service.cloud_host}/{project.workspace_name}/{project.name}/runs/{base_id}/comparison/{target_id}'
-        response['url'] = url
-
     return response
 
 


### PR DESCRIPTION
The response of **upload report** and **make compare report ** contains the `url` for the report. The PR is to use the `url` to print the report url.

**PR checklist**

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed

**What type of PR is this?**

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
