### PR TITLE
[Feature] Allows to skip the target check

### DIFF
--- a/piperider_cli/runner.py
+++ b/piperider_cli/runner.py
@@ -605,7 +605,7 @@ def get_dbt_state_dir(dbt_state_dir, dbt_config, ds, dbt_run_results):
     if not dbtutil.is_dbt_state_ready(dbt_state_dir):
         return None, f"[bold red]Error:[/bold red] No available 'manifest.json' under '{dbt_state_dir}'"
 
-    if not os.environ.get('PIPERIDER_SKIP_TARGET_CHECK', None):
+    if os.environ.get('PIPERIDER_SKIP_TARGET_CHECK', None) != '1':
         if not check_dbt_manifest_compatibility(ds, dbt_state_dir):
             return None, f"[bold red]Error:[/bold red] Target mismatched. Please run 'dbt compile -t {dbt_config.get('target')}' to generate the new manifest, or set the environment variable 'PIPERIDER_SKIP_TARGET_CHECK=1' to skip the check."
 

--- a/piperider_cli/runner.py
+++ b/piperider_cli/runner.py
@@ -571,6 +571,7 @@ def check_dbt_manifest_compatibility(ds: DataSource, dbt_state_dir: str):
     def filter_schema(model):
         model_schema = model.get('schema', '')
         return model_schema == schema or model_schema.startswith(f'{schema}_')
+
     filtered_models = list(filter(filter_schema, models))
 
     if len(models) != len(filtered_models):
@@ -604,9 +605,9 @@ def get_dbt_state_dir(dbt_state_dir, dbt_config, ds, dbt_run_results):
     if not dbtutil.is_dbt_state_ready(dbt_state_dir):
         return None, f"[bold red]Error:[/bold red] No available 'manifest.json' under '{dbt_state_dir}'"
 
-    if not check_dbt_manifest_compatibility(ds, dbt_state_dir):
-        return None, f"[bold red]Error:[/bold red] Target mismatched. " \
-                     f"Please run 'dbt compile -t {dbt_config.get('target')}' to generate the new manifest"
+    if not os.environ.get('PIPERIDER_SKIP_TARGET_CHECK', None):
+        if not check_dbt_manifest_compatibility(ds, dbt_state_dir):
+            return None, f"[bold red]Error:[/bold red] Target mismatched. Please run 'dbt compile -t {dbt_config.get('target')}' to generate the new manifest, or set the environment variable 'PIPERIDER_SKIP_TARGET_CHECK=1' to skip the check."
 
     if dbt_run_results:
         if not dbtutil.is_dbt_run_results_ready(dbt_state_dir):


### PR DESCRIPTION
Fix #626

To set `PIPERIDER_SKIP_TARGET_CHECK=1`  to skip the target check.

Example:

```
$ export PIPERIDER_SKIP_TARGET_CHECK=1
$ piperider run
```

**PR checklist**

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed

**What type of PR is this?**
Feature

**What this PR does / why we need it**:
See #626 

**Which issue(s) this PR fixes**:
#626, sc-30840

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
