### PR TITLE
Add PIPERIDER_API_PROJECT variables

### DIFF
--- a/piperider_cli/event/track.py
+++ b/piperider_cli/event/track.py
@@ -65,6 +65,7 @@ class TrackCommand(Command):
     def invoke(self, ctx: Context) -> t.Any:
         status = False
         try:
+            self.apply_project_parameters(ctx)
 
             ret = super(TrackCommand, self).invoke(ctx)
             if ret is None or ret == 0:
@@ -104,3 +105,8 @@ Consider using the following options to select a project:
         finally:
             event.log_usage_event(ctx.command.name, ctx.params, status)
             event.flush_events(ctx.command.name)
+
+    def apply_project_parameters(self, ctx):
+        # sc-30888 use PIPERIDER_API_PROJECT if `--project` did not set
+        if 'project' in ctx.params and ctx.params.get('project') is None:
+            ctx.params['project'] = os.environ.get('PIPERIDER_API_PROJECT')


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some check items for you: -->

**PR checklist**

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed

**What type of PR is this?**

enhancement

**What this PR does / why we need it**:

* make users could set the project from the environment variable: `PIPERIDER_API_PROJECT` 

**Which issue(s) this PR fixes**:

sc-30888

**Special notes for your reviewer**:

A project setting is evaluated in this priority:

* `--project` from the CLI
* env `PIPERIDER_API_PROJECT`
* `default_project` from the configuration file
