### PR TITLE
[Feature] Output absolute report path when piperider run

### DIFF
--- a/piperider_cli/generate_report.py
+++ b/piperider_cli/generate_report.py
@@ -79,6 +79,8 @@ class GenerateReport:
             report_template_html = f.read()
 
         run_json_path = get_run_json_path(filesystem.get_output_dir(), input)
+        if os.path.islink(os.path.dirname(run_json_path)):
+            run_json_path = os.path.realpath(run_json_path)
         if not os.path.isfile(run_json_path):
             print(os.path.abspath(run_json_path))
             raise PipeRiderNoProfilingResultError(run_json_path)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some check items for you: -->

**PR checklist**

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed

**What type of PR is this?**
feature

**What this PR does / why we need it**:
- output absolute report path

**Which issue(s) this PR fixes**:
sc-30549

**Special notes for your reviewer**:
both `os.path.islink` and `os.path.realpath` can work in a non admin Windows enviornment

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
NONE