### PR TITLE
[Bug] Fold uploaded report url when it's larger than available space

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ flake8:
 	@echo "Passed"
 
 test: dev-requires
-	py.test --cov=piperider_cli --cov-report html tests
+	python3 -m pytest --cov=piperider_cli --cov-report html tests
 
 pre-release: dev-requires
 	pip install build

--- a/piperider_cli/cloud_connector.py
+++ b/piperider_cli/cloud_connector.py
@@ -410,7 +410,7 @@ class CloudConnector:
             ascii_table.add_column('Status', justify='left', style='cyan')
             ascii_table.add_column('Name', justify='left')
             ascii_table.add_column('Created At', justify='left')
-            ascii_table.add_column('Report URL', justify='left', no_wrap=True)
+            ascii_table.add_column('Report URL', justify='left', overflow='fold')
             ascii_table.add_column('Message', justify='left')
 
             for response in results:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some check items for you: -->

**PR checklist**

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed

**What type of PR is this?**
bug

**What this PR does / why we need it**:
- if the uploaded report URL's length is too long, the URL would be cropped.

**Which issue(s) this PR fixes**:
sc-31109

**Special notes for your reviewer**:
when the URL is folded, the link cannot be clicked directly.

<img width="623" alt="截圖 2023-04-17 下午6 32 38" src="https://user-images.githubusercontent.com/16777014/232464412-d09e7fa1-e884-4592-98ad-42b374a864cb.png">


**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
NONE