### PR TITLE
[Feature] sc-31205 Mark assertions page as deprecated in front-end page

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,13 +39,7 @@ PipeRider automatically compares your data to highlight the difference in impact
 
    You can find all supported data source connectors [here](https://docs.piperider.io/reference/supported-data-sources).
 
-1. **Initialize PipeRider**: Go to your dbt project, and initialize PipeRider.
-
-   ```bash
-   piperider init
-   ```
-
-1. **Add PipeRider tag on your model**:
+1. **Add PipeRider tag on your model**: Go to your dbt project, and add the PipeRider tag on the model you want to profile.
 
    ```sql
    --models/staging/stg_customers.sql

--- a/piperider_cli/assertion_generator.py
+++ b/piperider_cli/assertion_generator.py
@@ -23,7 +23,7 @@ class AssertionGenerator():
     def exec(input_path=None, report_dir: str = None, no_recommend: bool = False, table: str = None):
         console.rule('Deprecated', style='bold red')
         console.print(
-            'Assertions Generator will be deprecated in the future. If you have a strong need for assertions, please contact us by "piperider feedback".\n')
+            'Assertions Generator is deprecated and will be removed in the future. If you have a strong need for assertions, please contact us by "piperider feedback".\n')
         filesystem = FileSystem(report_dir=report_dir)
         raise_exception_when_directory_not_writable(report_dir)
 

--- a/piperider_cli/assertion_generator.py
+++ b/piperider_cli/assertion_generator.py
@@ -21,6 +21,9 @@ def _validate_input_result(result):
 class AssertionGenerator():
     @staticmethod
     def exec(input_path=None, report_dir: str = None, no_recommend: bool = False, table: str = None):
+        console.rule('Deprecated', style='bold red')
+        console.print(
+            'Assertions Generator will be deprecated in the future. If you have a strong need for assertions, please contact us by "piperider feedback".\n')
         filesystem = FileSystem(report_dir=report_dir)
         raise_exception_when_directory_not_writable(report_dir)
 

--- a/piperider_cli/cli.py
+++ b/piperider_cli/cli.py
@@ -242,7 +242,7 @@ def run(**kwargs):
     return ret
 
 
-@cli.command(short_help='Generate recommended assertions.', cls=TrackCommand)
+@cli.command(short_help='Generate recommended assertions. - Deprecated', cls=TrackCommand)
 @click.option('--input', default=None, type=click.Path(exists=True), help='Specify the raw result file.')
 @click.option('--no-recommend', is_flag=True, help='Generate assertions templates only.')
 @click.option('--report-dir', default=None, type=click.STRING, help='Use a different report directory.')

--- a/piperider_cli/initializer.py
+++ b/piperider_cli/initializer.py
@@ -113,7 +113,7 @@ def _generate_configuration(dbt_project_path=None, dbt_profiles_dir=None, intera
         # TODO: mark as deprecated in the future
         console.rule('Deprecated', style='bold red')
         console.print(
-            'Non-dbt project will be deprecated in the future. If you have a strong need for non-dbt project, please contact us by "piperider feedback".\n')
+            'Non-dbt project is deprecated and will be removed in the future. If you have a strong need for non-dbt project, please contact us by "piperider feedback".\n')
         return _ask_user_input_datasource(config=config)
 
     if config is not None:

--- a/piperider_cli/initializer.py
+++ b/piperider_cli/initializer.py
@@ -111,6 +111,9 @@ def _generate_configuration(dbt_project_path=None, dbt_profiles_dir=None, intera
 
     if dbt_project_path is None:
         # TODO: mark as deprecated in the future
+        console.rule('Deprecated', style='bold red')
+        console.print(
+            'Non-dbt project will be deprecated in the future. If you have a strong need for non-dbt project, please contact us by "piperider feedback".\n')
         return _ask_user_input_datasource(config=config)
 
     if config is not None:

--- a/static_report/src/components/Columns/MasterSideNav/MasterSideNav.tsx
+++ b/static_report/src/components/Columns/MasterSideNav/MasterSideNav.tsx
@@ -25,6 +25,9 @@ import { ColumnListAccordionPanel } from './ColumnListAccordionPanel';
 import { RoutableAccordionButton } from './RoutableAccordionButton';
 import { TableItemAccordionButton } from './TableItemAccordionButton';
 
+// const { assertionsOnly } = useReportStore.getState();
+// const { metadata } = assertionsOnly || {};
+
 interface Props extends Comparable {
   isTablesIndex?: boolean;
   initAsExpandedTables?: boolean;
@@ -223,12 +226,16 @@ export function MasterSideNav({
         <AccordionItem>
           <RoutableAccordionButton title="Metrics" path={BM_ROUTE_PATH} />
         </AccordionItem>
+
+        {/* Only show the Assertions Button when the report contain assertions result */}
+        {/* {Number(metadata?.base?.total) > 0 && ( */}
         <AccordionItem>
           <RoutableAccordionButton
             title="Assertions"
             path={ASSERTIONS_ROUTE_PATH}
           />
         </AccordionItem>
+        {/* )} */}
       </Accordion>
     </Box>
   );

--- a/static_report/src/components/Columns/MasterSideNav/MasterSideNav.tsx
+++ b/static_report/src/components/Columns/MasterSideNav/MasterSideNav.tsx
@@ -13,7 +13,7 @@ import { FiChevronDown, FiChevronRight } from 'react-icons/fi';
 import { useLocation, useRoute } from 'wouter';
 
 import { Comparable } from '../../../types';
-import { borderVal } from '../../../utils';
+import { borderVal, useReportStore } from '../../../utils';
 import {
   ASSERTIONS_ROUTE_PATH,
   BM_ROUTE_PATH,
@@ -24,9 +24,6 @@ import { CompTableColEntryItem } from '../../../utils/store';
 import { ColumnListAccordionPanel } from './ColumnListAccordionPanel';
 import { RoutableAccordionButton } from './RoutableAccordionButton';
 import { TableItemAccordionButton } from './TableItemAccordionButton';
-
-// const { assertionsOnly } = useReportStore.getState();
-// const { metadata } = assertionsOnly || {};
 
 interface Props extends Comparable {
   isTablesIndex?: boolean;
@@ -52,6 +49,9 @@ export function MasterSideNav({
 
   const [matchTable, paramsTable] = useRoute(TABLE_DETAILS_ROUTE_PATH);
   const [matchColumn, paramsColumn] = useRoute(COLUMN_DETAILS_ROUTE_PATH);
+
+  const { assertionsOnly } = useReportStore.getState();
+  const { metadata } = assertionsOnly || {};
 
   if (matchTable) {
     currentTable = paramsTable.tableName as string;
@@ -228,14 +228,14 @@ export function MasterSideNav({
         </AccordionItem>
 
         {/* Only show the Assertions Button when the report contain assertions result */}
-        {/* {Number(metadata?.base?.total) > 0 && ( */}
-        <AccordionItem>
-          <RoutableAccordionButton
-            title="Assertions"
-            path={ASSERTIONS_ROUTE_PATH}
-          />
-        </AccordionItem>
-        {/* )} */}
+        {Number(metadata?.base?.total) > 0 && (
+          <AccordionItem>
+            <RoutableAccordionButton
+              title="Assertions"
+              path={ASSERTIONS_ROUTE_PATH}
+            />
+          </AccordionItem>
+        )}
       </Accordion>
     </Box>
   );

--- a/static_report/src/components/Common/HelpMenu.tsx
+++ b/static_report/src/components/Common/HelpMenu.tsx
@@ -16,11 +16,14 @@ type Props = {
   feedbackLink?: string;
 };
 
+export const FeedbackLinkFromLocalReport =
+  'https://docs.google.com/forms/d/e/1FAIpQLSe0J8qC78lqMVxSAJFPub6QXx2NcVY8WLvIVEGthOeQcJHxFQ/viewform?usp=pp_url&entry.2024961102=PipeRider+Local+Reports';
+
 export function HelpMenu({
   githubLink = 'https://github.com/InfuseAI/piperider',
   discordLink = 'https://discord.gg/328QcXnkKD',
   docLink = 'https://docs.piperider.io/',
-  feedbackLink = 'https://forms.gle/zyf7UZdnZRCJWQNd9',
+  feedbackLink = FeedbackLinkFromLocalReport,
 }: Props) {
   return (
     <Menu>

--- a/static_report/src/components/Common/Navbar.tsx
+++ b/static_report/src/components/Common/Navbar.tsx
@@ -2,7 +2,7 @@ import { Flex, Icon, Image, Link, Text } from '@chakra-ui/react';
 import { FiSquare, FiColumns } from 'react-icons/fi';
 import { NO_VALUE } from '../Columns';
 import { useReportStore } from '../../utils/store';
-import { HelpMenu } from './HelpMenu';
+import { HelpMenu, FeedbackLinkFromLocalReport } from './HelpMenu';
 
 type Props = {
   isSingleReport: boolean;
@@ -47,7 +47,7 @@ export function Navbar({ isSingleReport }: Props) {
       </Flex>
 
       <Flex position="absolute" right="96px" zIndex={100}>
-        <HelpMenu feedbackLink="https://docs.google.com/forms/d/e/1FAIpQLSe0J8qC78lqMVxSAJFPub6QXx2NcVY8WLvIVEGthOeQcJHxFQ/viewform?usp=pp_url&entry.2024961102=PipeRider+Local+Reports" />
+        <HelpMenu feedbackLink={FeedbackLinkFromLocalReport} />
       </Flex>
     </Flex>
   );

--- a/static_report/src/pages/CRAssertionListPage.tsx
+++ b/static_report/src/pages/CRAssertionListPage.tsx
@@ -1,4 +1,13 @@
-import { Box, Flex, Text } from '@chakra-ui/react';
+import {
+  Box,
+  Flex,
+  Text,
+  Alert,
+  AlertIcon,
+  AlertTitle,
+  AlertDescription,
+  Link,
+} from '@chakra-ui/react';
 import { useState } from 'react';
 import { SearchTextInput } from '../components/Common/SearchTextInput';
 import { TableListAssertionSummary } from '../components/Tables';
@@ -22,6 +31,24 @@ export function CRAssertionListPage() {
 
   return (
     <Box>
+      <Alert status="warning" mb={5}>
+        <AlertIcon />
+        <Box>
+          <AlertTitle>
+            The Assertions page will be deprecated in the future
+          </AlertTitle>
+          <AlertDescription fontSize="sm">
+            If you have a strong need for this page, please contact us by the{' '}
+            <Link
+              href="https://forms.gle/zyf7UZdnZRCJWQNd9"
+              style={{ textDecoration: 'underline' }}
+            >
+              feedback link
+            </Link>
+            . Your feedback is important to us. Thank you!
+          </AlertDescription>
+        </Box>
+      </Alert>
       <Flex w={'100%'}>
         <Text fontSize={'xl'} fontWeight={'semibold'} textAlign={'left'}>
           Assertions

--- a/static_report/src/pages/CRAssertionListPage.tsx
+++ b/static_report/src/pages/CRAssertionListPage.tsx
@@ -16,6 +16,7 @@ import { useTrackOnMount } from '../hooks';
 import { EVENTS, CR_TYPE_LABEL } from '../utils';
 import { assertionListWidth } from '../utils/layout';
 import { useReportStore } from '../utils/store';
+import { FeedbackLinkFromLocalReport } from '../components/Common/HelpMenu';
 
 export function CRAssertionListPage() {
   useTrackOnMount({
@@ -40,7 +41,7 @@ export function CRAssertionListPage() {
           <AlertDescription fontSize="sm">
             If you have a strong need for this page, please contact us by the{' '}
             <Link
-              href="https://forms.gle/zyf7UZdnZRCJWQNd9"
+              href={FeedbackLinkFromLocalReport}
               style={{ textDecoration: 'underline' }}
             >
               feedback link

--- a/static_report/src/pages/CRAssertionListPage.tsx
+++ b/static_report/src/pages/CRAssertionListPage.tsx
@@ -36,7 +36,7 @@ export function CRAssertionListPage() {
         <AlertIcon />
         <Box>
           <AlertTitle>
-            The Assertions page will be deprecated in the future
+            The Assertions page is deprecated and will be removed in the future
           </AlertTitle>
           <AlertDescription fontSize="sm">
             If you have a strong need for this page, please contact us by the{' '}

--- a/static_report/src/pages/SRAssertionListPage.tsx
+++ b/static_report/src/pages/SRAssertionListPage.tsx
@@ -15,6 +15,7 @@ import { AssertionListWidget } from '../components/Widgets/AssertionListWidget';
 import { useTrackOnMount } from '../hooks';
 import { EVENTS, SR_TYPE_LABEL, useReportStore } from '../utils';
 import { assertionListWidth } from '../utils/layout';
+import { FeedbackLinkFromLocalReport } from '../components/Common/HelpMenu';
 
 export function SRAssertionListPage() {
   useTrackOnMount({
@@ -40,7 +41,7 @@ export function SRAssertionListPage() {
           <AlertDescription fontSize="sm">
             If you have a strong need for this page, please contact us by the{' '}
             <Link
-              href="https://forms.gle/zyf7UZdnZRCJWQNd9"
+              href={FeedbackLinkFromLocalReport}
               style={{ textDecoration: 'underline' }}
             >
               feedback link

--- a/static_report/src/pages/SRAssertionListPage.tsx
+++ b/static_report/src/pages/SRAssertionListPage.tsx
@@ -1,4 +1,13 @@
-import { Box, Flex, Text } from '@chakra-ui/react';
+import {
+  Box,
+  Flex,
+  Text,
+  Alert,
+  AlertIcon,
+  AlertDescription,
+  AlertTitle,
+  Link,
+} from '@chakra-ui/react';
 import { useState } from 'react';
 import { AssertionPassFailCountLabel } from '../components/Assertions/AssertionPassFailCountLabel';
 import { SearchTextInput } from '../components/Common/SearchTextInput';
@@ -22,6 +31,24 @@ export function SRAssertionListPage() {
 
   return (
     <Box>
+      <Alert status="warning" mb={5}>
+        <AlertIcon />
+        <Box>
+          <AlertTitle>
+            The Assertions page will be deprecated in the future
+          </AlertTitle>
+          <AlertDescription fontSize="sm">
+            If you have a strong need for this page, please contact us by the{' '}
+            <Link
+              href="https://forms.gle/zyf7UZdnZRCJWQNd9"
+              style={{ textDecoration: 'underline' }}
+            >
+              feedback link
+            </Link>
+            . Your feedback is important to us. Thank you!
+          </AlertDescription>
+        </Box>
+      </Alert>
       <Text fontSize={'xl'} fontWeight={'semibold'} textAlign={'left'}>
         Assertions
       </Text>

--- a/static_report/src/pages/SRAssertionListPage.tsx
+++ b/static_report/src/pages/SRAssertionListPage.tsx
@@ -36,7 +36,7 @@ export function SRAssertionListPage() {
         <AlertIcon />
         <Box>
           <AlertTitle>
-            The Assertions page will be deprecated in the future
+            The Assertions page is deprecated and will be removed in the future
           </AlertTitle>
           <AlertDescription fontSize="sm">
             If you have a strong need for this page, please contact us by the{' '}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some check items for you: -->

**PR checklist**

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed

**What type of PR is this?**
Feature

**What this PR does / why we need it**:
- Mark assertions and non-dbt project as deprecated
  <img width="1104" alt="CleanShot 2023-05-10 at 14 41 09@2x" src="https://github.com/InfuseAI/piperider/assets/959606/78ac037a-d20d-4aee-aad9-045811b0772f">
  <img width="1512" alt="CleanShot 2023-05-10 at 14 42 28@2x" src="https://github.com/InfuseAI/piperider/assets/959606/e1e07f45-0c12-407e-a9a7-bde6250c0eda">
- Report will not show assertions if there are no assertions data
  <img width="1167" alt="CleanShot 2023-05-10 at 14 43 22@2x" src="https://github.com/InfuseAI/piperider/assets/959606/722ca408-fe5e-4042-862f-c976d886479e">
- Report will show assertion is deprecated when showing the assertions result
  <img width="1177" alt="CleanShot 2023-05-10 at 14 44 04@2x" src="https://github.com/InfuseAI/piperider/assets/959606/6e853fef-405e-42af-a229-febcc12b030a">
- Update README.md

**Which issue(s) this PR fixes**:
sc-31205

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
