### PR TITLE
[Feature] sc-31437 Default enable dbt-run-results flag if file exists

### DIFF
--- a/piperider_cli/cli.py
+++ b/piperider_cli/cli.py
@@ -163,7 +163,6 @@ def diagnose(**kwargs):
 @click.option('--skip-report', is_flag=True, help='Skip generating report.')
 @click.option('--dbt-state', default=None, help='Directory of the the dbt state.')
 @click.option('--dbt-list', is_flag=True, help='Associate with dbt list format input.')
-@click.option('--dbt-run-results', is_flag=True, help='Associate with dbt run results.')
 @click.option('--report-dir', default=None, type=click.STRING, help='Use a different report directory.')
 @click.option('--upload', is_flag=True, help='Upload the report to the PipeRider Cloud.')
 @click.option('--project', default=None, type=click.STRING, help='Specify the project name to upload.')
@@ -182,16 +181,15 @@ def run(**kwargs):
     skip_report = kwargs.get('skip_report')
     dbt_state_dir = kwargs.get('dbt_state')
     dbt_list = kwargs.get('dbt_list')
-    dbt_run_results = kwargs.get('dbt_run_results')
     force_upload = kwargs.get('upload')
     project_name = kwargs.get('project')
 
     console = Console()
 
     # True -> 1, False -> 0
-    if sum([True if table else False, dbt_list, dbt_run_results]) > 1:
+    if sum([True if table else False, dbt_list]) > 1:
         console.print("[bold red]Error:[/bold red] "
-                      "['--table', '--dbt-list', '--dbt-run-results'] are mutually exclusive")
+                      "['--table', '--dbt-list'] are mutually exclusive")
         sys.exit(1)
 
     # Search dbt project config files
@@ -221,7 +219,6 @@ def run(**kwargs):
                       output=output,
                       skip_report=skip_report,
                       dbt_state_dir=dbt_state_dir,
-                      dbt_run_results=dbt_run_results,
                       dbt_resources=dbt_resources,
                       report_dir=kwargs.get('report_dir'))
     if ret in (0, EC_ERR_TEST_FAILED):

--- a/piperider_cli/cli.py
+++ b/piperider_cli/cli.py
@@ -163,6 +163,8 @@ def diagnose(**kwargs):
 @click.option('--skip-report', is_flag=True, help='Skip generating report.')
 @click.option('--dbt-state', default=None, help='Directory of the the dbt state.')
 @click.option('--dbt-list', is_flag=True, help='Associate with dbt list format input.')
+@click.option('--dbt-run-results', is_flag=True, help='Associate with dbt run results.',
+              hidden=True)  # For backward compatibility
 @click.option('--report-dir', default=None, type=click.STRING, help='Use a different report directory.')
 @click.option('--upload', is_flag=True, help='Upload the report to the PipeRider Cloud.')
 @click.option('--project', default=None, type=click.STRING, help='Specify the project name to upload.')

--- a/piperider_cli/dbtutil.py
+++ b/piperider_cli/dbtutil.py
@@ -226,6 +226,10 @@ def get_dbt_state_tests_result(dbt_state_dir: str, table_filter=None):
         if node.get('resource_type') != 'test':
             continue
 
+        # The test is just compiled, but not executed
+        if result.get('status') == 'success':
+            continue
+
         unique_tests[unique_id] = dict(
             status=result.get('status'),
             failures=result.get('failures'),

--- a/piperider_cli/dbtutil.py
+++ b/piperider_cli/dbtutil.py
@@ -222,7 +222,7 @@ def get_dbt_state_candidate(dbt_state_dir: str, options: dict, *, select_for_met
     return candidate
 
 
-def get_dbt_state_tests_result(dbt_state_dir: str):
+def get_dbt_state_tests_result(dbt_state_dir: str, table_filter=None):
     output = []
     unique_tests = {}
 
@@ -260,6 +260,14 @@ def get_dbt_state_tests_result(dbt_state_dir: str):
 
         if table is None:
             continue
+
+        if table_filter is not None:
+            if len(table.split('.')) == 2:
+                _, table_name = table.split('.')
+            else:
+                table_name = table
+            if table_name != table_filter:
+                continue
 
         output.append(dict(
             id=unique_id,

--- a/piperider_cli/dbtutil.py
+++ b/piperider_cli/dbtutil.py
@@ -161,20 +161,11 @@ def get_dbt_state_candidate(dbt_state_dir: str, options: dict, *, select_for_met
         material_whitelist.append('view')
 
     tag = options.get('tag')
-    dbt_run_results = options.get('dbt_run_results')
     dbt_resources = options.get('dbt_resources')
 
     manifest = _get_state_manifest(dbt_state_dir)
     nodes = manifest.get('nodes')
     sources = manifest.get('sources')
-
-    run_results_ids = []
-    if dbt_run_results:
-        run_results = _get_state_run_results(dbt_state_dir)
-        for result in run_results.get('results'):
-            if result.get('status') != 'success':
-                continue
-            run_results_ids.append(result.get('unique_id'))
 
     def profiling_chosen_fn(key, node):
         statistics = Statistics()
@@ -184,9 +175,6 @@ def get_dbt_state_candidate(dbt_state_dir: str, options: dict, *, select_for_met
                 statistics.add_field_one('filter')
             return chosen
         else:
-            if dbt_run_results and key not in run_results_ids:
-                statistics.add_field_one('norun')
-                return False
             if tag:
                 chosen = tag in node.get('tags', [])
                 if not chosen:

--- a/piperider_cli/runner.py
+++ b/piperider_cli/runner.py
@@ -667,7 +667,6 @@ class Runner():
                 options = dict(
                     view_profile=configuration.include_views,
                     dbt_resources=dbt_resources,
-                    dbt_run_results=dbtutil.is_dbt_run_results_ready(dbt_state_dir),
                     tag=dbt_config.get('tag')
                 )
                 subjects, dbt_metadata_subjects = get_dbt_all_subjects(dbt_state_dir, options, filter_fn)

--- a/tests/test_dbt_util.py
+++ b/tests/test_dbt_util.py
@@ -51,7 +51,7 @@ class TestRunner(TestCase):
         tables = dbtutil.get_dbt_state_candidate(self.dbt_state_dir, dict(view_profile=None,
                                                                           dbt_resources=None,
                                                                           tag=None))
-        self.assertEqual(len(tables), 1)
+        self.assertEqual(len(tables), 9)
         self.assertEqual(tables[0].get('name'), 'PRICE_PRESENT')
         self.assertEqual(tables[0].get('schema'), 'PUBLIC')
         self.assertEqual(tables[0].get('alias'), 'PRICE_PRESENT')
@@ -136,20 +136,20 @@ class TestRunner(TestCase):
         tables = dbtutil.get_dbt_state_candidate(self.dbt_state_dir, dict(view_profile=None,
                                                                           dbt_resources=None,
                                                                           tag='piperider'))
-        self.assertEqual(len(tables), 1)
+        self.assertEqual(len(tables), 4)
         self.assertEqual(tables[0].get('name'), 'PRICE_PRESENT')
 
     def test_get_dbt_state_candidate_tag_and_run_results_emptyset(self):
         tables = dbtutil.get_dbt_state_candidate(self.dbt_state_dir, dict(view_profile=None,
                                                                           dbt_resources=None,
                                                                           tag='test'))
-        self.assertEqual(len(tables), 0)
+        self.assertEqual(len(tables), 2)
 
     def test_get_dbt_state_candidate_view_profile_tag_and_run_results(self):
         tables = dbtutil.get_dbt_state_candidate(self.dbt_state_dir, dict(view_profile=True,
                                                                           dbt_resources=None,
                                                                           tag='piperider'))
-        self.assertEqual(len(tables), 1)
+        self.assertEqual(len(tables), 4)
         self.assertEqual(tables[0].get('name'), 'PRICE_PRESENT')
 
     def test_get_dbt_state_tests_result(self):

--- a/tests/test_dbt_util.py
+++ b/tests/test_dbt_util.py
@@ -15,7 +15,6 @@ class TestRunner(TestCase):
     def test_get_dbt_state_candidate(self):
         tables = dbtutil.get_dbt_state_candidate(self.dbt_state_dir, dict(view_profile=None,
                                                                           dbt_resources=None,
-                                                                          dbt_run_results=None,
                                                                           tag=None))
 
         self.assertEqual(len(tables), 9)
@@ -34,7 +33,6 @@ class TestRunner(TestCase):
     def test_get_dbt_state_candidate_view_profile(self):
         tables = dbtutil.get_dbt_state_candidate(self.dbt_state_dir, dict(view_profile=True,
                                                                           dbt_resources=None,
-                                                                          dbt_run_results=None,
                                                                           tag=None))
 
         self.assertEqual(len(tables), 10)
@@ -52,7 +50,6 @@ class TestRunner(TestCase):
     def test_get_dbt_state_candidate_run_results(self):
         tables = dbtutil.get_dbt_state_candidate(self.dbt_state_dir, dict(view_profile=None,
                                                                           dbt_resources=None,
-                                                                          dbt_run_results=True,
                                                                           tag=None))
         self.assertEqual(len(tables), 1)
         self.assertEqual(tables[0].get('name'), 'PRICE_PRESENT')
@@ -65,7 +62,6 @@ class TestRunner(TestCase):
         resources = dict(models=models, metrics=[])
         tables = dbtutil.get_dbt_state_candidate(self.dbt_state_dir, dict(view_profile=None,
                                                                           dbt_resources=resources,
-                                                                          dbt_run_results=None,
                                                                           tag=None))
         self.assertEqual(len(tables), 2)
         self.assertEqual(tables[0].get('name'), 'session')
@@ -77,7 +73,6 @@ class TestRunner(TestCase):
         resources = dict(models=models, metrics=[])
         tables = dbtutil.get_dbt_state_candidate(self.dbt_state_dir, dict(view_profile=None,
                                                                           dbt_resources=resources,
-                                                                          dbt_run_results=None,
                                                                           tag=None))
         self.assertEqual(len(tables), 2)
 
@@ -91,7 +86,6 @@ class TestRunner(TestCase):
         resources = dict(models=[], metrics=metrics)
         tables = dbtutil.get_dbt_state_candidate(self.dbt_state_dir, dict(view_profile=None,
                                                                           dbt_resources=resources,
-                                                                          dbt_run_results=None,
                                                                           tag=None))
         self.assertEqual(len(tables), 0)
 
@@ -100,14 +94,12 @@ class TestRunner(TestCase):
         resources = dict(models=models, metrics=[])
         tables = dbtutil.get_dbt_state_candidate(self.dbt_state_dir, dict(view_profile=None,
                                                                           dbt_resources=resources,
-                                                                          dbt_run_results=None,
                                                                           tag=None))
         self.assertEqual(len(tables), 0)
 
         resources = dict(models=[], metrics=[])
         tables = dbtutil.get_dbt_state_candidate(self.dbt_state_dir, dict(view_profile=None,
                                                                           dbt_resources=resources,
-                                                                          dbt_run_results=None,
                                                                           tag=None))
         self.assertEqual(len(tables), 0)
 
@@ -118,7 +110,6 @@ class TestRunner(TestCase):
         resources = dict(models=models, metrics=[])
         tables = dbtutil.get_dbt_state_candidate(self.dbt_state_dir, dict(view_profile=None,
                                                                           dbt_resources=resources,
-                                                                          dbt_run_results=None,
                                                                           tag=None))
         self.assertEqual(len(tables), 3)
         self.assertEqual(tables[0].get('name'), 'stg_event')
@@ -128,7 +119,6 @@ class TestRunner(TestCase):
     def test_get_dbt_state_candidate_tag(self):
         tables = dbtutil.get_dbt_state_candidate(self.dbt_state_dir, dict(view_profile=None,
                                                                           dbt_resources=None,
-                                                                          dbt_run_results=None,
                                                                           tag='test'))
         self.assertEqual(len(tables), 2)
         self.assertEqual(tables[0].get('name'), 'stg_event')
@@ -137,7 +127,6 @@ class TestRunner(TestCase):
     def test_get_dbt_state_candidate_tag_and_view(self):
         tables = dbtutil.get_dbt_state_candidate(self.dbt_state_dir, dict(view_profile=True,
                                                                           dbt_resources=None,
-                                                                          dbt_run_results=None,
                                                                           tag='test'))
         self.assertEqual(len(tables), 2)
         self.assertEqual(tables[0].get('name'), 'stg_event')
@@ -146,7 +135,6 @@ class TestRunner(TestCase):
     def test_get_dbt_state_candidate_tag_and_run_results(self):
         tables = dbtutil.get_dbt_state_candidate(self.dbt_state_dir, dict(view_profile=None,
                                                                           dbt_resources=None,
-                                                                          dbt_run_results=True,
                                                                           tag='piperider'))
         self.assertEqual(len(tables), 1)
         self.assertEqual(tables[0].get('name'), 'PRICE_PRESENT')
@@ -154,14 +142,12 @@ class TestRunner(TestCase):
     def test_get_dbt_state_candidate_tag_and_run_results_emptyset(self):
         tables = dbtutil.get_dbt_state_candidate(self.dbt_state_dir, dict(view_profile=None,
                                                                           dbt_resources=None,
-                                                                          dbt_run_results=True,
                                                                           tag='test'))
         self.assertEqual(len(tables), 0)
 
     def test_get_dbt_state_candidate_view_profile_tag_and_run_results(self):
         tables = dbtutil.get_dbt_state_candidate(self.dbt_state_dir, dict(view_profile=True,
                                                                           dbt_resources=None,
-                                                                          dbt_run_results=True,
                                                                           tag='piperider'))
         self.assertEqual(len(tables), 1)
         self.assertEqual(tables[0].get('name'), 'PRICE_PRESENT')

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -1,8 +1,8 @@
 import os
 from unittest import TestCase
 
-from piperider_cli.runner import _filter_subject, get_dbt_profile_subjects
 from piperider_cli.profiler import ProfileSubject
+from piperider_cli.runner import _filter_subject, get_dbt_profile_subjects
 from piperider_cli.statistics import Statistics
 
 
@@ -27,7 +27,6 @@ class TestRunner(TestCase):
         options = dict(
             view_profile=False,
             dbt_resources=None,
-            dbt_run_results=None,
             tag='test'
         )
 
@@ -50,7 +49,6 @@ class TestRunner(TestCase):
                 models=['infusetude.amplitude.project'],
                 metrics=[]
             ),
-            dbt_run_results=None,
             tag=None
         )
 
@@ -69,7 +67,6 @@ class TestRunner(TestCase):
         options = dict(
             view_profile=None,
             dbt_resources=None,
-            dbt_run_results=None,
             tag=None
         )
 
@@ -89,7 +86,6 @@ class TestRunner(TestCase):
         options = dict(
             view_profile=None,
             dbt_resources=None,
-            dbt_run_results=None,
             tag=None
         )
 
@@ -109,7 +105,6 @@ class TestRunner(TestCase):
         options = dict(
             view_profile=True,
             dbt_resources=None,
-            dbt_run_results=None,
             tag=None
         )
 
@@ -128,7 +123,6 @@ class TestRunner(TestCase):
         options = dict(
             view_profile=False,
             dbt_resources=None,
-            dbt_run_results=None,
             tag=None
         )
 


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some check items for you: -->

**PR checklist**

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed

**What type of PR is this?**
Feature

**What this PR does / why we need it**:
 - When running command with `--table` option, piperider will only show the dbt test results with the selected table
 - Default enable the flag `dbt-run-results` if the `run_results.json` is found. Disable this flag if there is no `run_results.json` file.

**Which issue(s) this PR fixes**:
sc-31437

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
