### PR TITLE
[Bug] Skip the metric if depends_on.nodes is empty

### DIFF
--- a/piperider_cli/dbtutil.py
+++ b/piperider_cli/dbtutil.py
@@ -299,7 +299,12 @@ def get_dbt_state_metrics(dbt_state_dir: str, dbt_tag: str, dbt_resources: Optio
             schema = None
             database = None
         else:
-            depends_on_node = metric.get('depends_on').get('nodes')[0]
+            nodes = metric.get('depends_on').get('nodes', [])
+            # Note: In "metrics" definition, if "model" value doesn't use `ref()` function,
+            #       the "depends_on.nodes" will be empty in the generated metrics manifest
+            if len(nodes) == 0:
+                continue
+            depends_on_node = nodes[0]
             table = manifest.get('nodes').get(depends_on_node).get('alias')
             schema = manifest.get('nodes').get(depends_on_node).get('schema')
             database = manifest.get('nodes').get(depends_on_node).get('database')


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some check items for you: -->

**PR checklist**

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed

**What type of PR is this?**
Bugfix

**What this PR does / why we need it**:
- Check depends_on.nodes
- Skip the metric if calculation_method != dervied and depends_on.nodes is empty.

**Which issue(s) this PR fixes**:
sc-31348

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
