### PR TITLE
[Bug] Fix keyerror of compare-reports with --tables-from option

### DIFF
--- a/piperider_cli/compare_report.py
+++ b/piperider_cli/compare_report.py
@@ -151,8 +151,11 @@ class ComparisonData(object):
 
             base['tables'] = {table_name: base['tables'][table_name] for table_name in base['tables'] if
                               table_name in target_run_tables}
-            base['metrics'] = [metric for metric in base['metrics'] if metric.get('name') in target_run_metrics]
-            base['tests'] = [test for test in base['tests'] if test.get('id') in target_run_tests]
+            if 'metrics' in base:
+                base['metrics'] = [metric for metric in base['metrics'] if metric.get('name') in target_run_metrics]
+
+            if 'tests' in base:
+                base['tests'] = [test for test in base['tests'] if test.get('id') in target_run_tests]
         elif tables_from == 'base-only':
             base_run_tables = base.get('tables', {}).keys()
             base_run_metrics = {metric.get('name') for metric in base.get('metrics', [])}
@@ -160,8 +163,11 @@ class ComparisonData(object):
 
             target['tables'] = {table_name: target['tables'][table_name] for table_name in target['tables'] if
                                 table_name in base_run_tables}
-            target['metrics'] = [metric for metric in target['metrics'] if metric.get('name') in base_run_metrics]
-            target['tests'] = [test for test in target['tests'] if test.get('id') in base_run_tests]
+            if 'metrics' in target:
+                target['metrics'] = [metric for metric in target['metrics'] if metric.get('name') in base_run_metrics]
+
+            if 'tests' in target:
+                target['tests'] = [test for test in target['tests'] if test.get('id') in base_run_tests]
 
         self._base = base
         self._target = target


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some check items for you: -->

**PR checklist**

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed

**What type of PR is this?**
bug

**What this PR does / why we need it**:
- piperider raised keyerror when compare-reports with `--tables-from` option

**Which issue(s) this PR fixes**:
sc-31507

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
NONE