### PR TITLE
[Bug] The report would encounter error if use --table option

### DIFF
--- a/piperider_cli/runner.py
+++ b/piperider_cli/runner.py
@@ -725,8 +725,9 @@ class Runner():
                 _show_assertion_result(assertion_results, assertion_exceptions)
                 run_result['tests'].extend([r.to_result_entry() for r in assertion_results])
 
-        if dbt_manifest:
-            run_result['dbt'] = dict(manifest=dbt_manifest)
+        if not table:
+            if dbt_manifest:
+                run_result['dbt'] = dict(manifest=dbt_manifest)
 
         for t in run_result['tables']:
             _clean_up_profile_null_properties(run_result['tables'][t])


### PR DESCRIPTION
For dbt project, use `--table` would not profile all models, but it show the dbt tree. The items we click would not show report correctly

**PR checklist**

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed
