### PR TITLE
[Bug] Fix wrong source table name when users specify identifier in dbt schema

### DIFF
--- a/piperider_cli/runner.py
+++ b/piperider_cli/runner.py
@@ -509,7 +509,7 @@ def get_dbt_all_subjects(dbt_state_dir, options, filter_fn):
                 # NOTE: In manifest.json, the source definition will include the 'identifier' field.
                 #       If users do not specify an additional 'identifier' in dbt source schema,
                 #       its value will be the same as the "name" field.
-                name = node.get('identifier')
+                name = node.get('name')
                 table = node.get('identifier')  # there is no alias in the source definition
                 schema = node.get('schema')
                 database = node.get('database')

--- a/piperider_cli/runner.py
+++ b/piperider_cli/runner.py
@@ -506,8 +506,11 @@ def get_dbt_all_subjects(dbt_state_dir, options, filter_fn):
         result = []
         for node in nodes:
             if "source" == node.get('resource_type'):
-                name = node.get('name')
-                table = node.get('name')  # there is no alias in the source definition
+                # NOTE: In manifest.json, the source definition will include the 'identifier' field.
+                #       If users do not specify an additional 'identifier' in dbt source schema,
+                #       its value will be the same as the "name" field.
+                name = node.get('identifier')
+                table = node.get('identifier')  # there is no alias in the source definition
                 schema = node.get('schema')
                 database = node.get('database')
             else:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some check items for you: -->

**PR checklist**

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed

**What type of PR is this?**
Bugfix

**What this PR does / why we need it**:
For source node, `name` field might not be the actual table name, but `identifier` does.
Read the `identifier` field instead of `name` one.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
