### PR TITLE
[Bug] If the run result and manifest does not match, it would cause error.

### DIFF
--- a/piperider_cli/dbtutil.py
+++ b/piperider_cli/dbtutil.py
@@ -224,6 +224,9 @@ def get_dbt_state_tests_result(dbt_state_dir: str, table_filter=None):
         unique_id = result.get('unique_id')
 
         node = nodes.get(unique_id)
+        if not node:
+            continue
+
         if node.get('resource_type') != 'test':
             continue
 


### PR DESCRIPTION
It's only happens while developing:

1. copy other manifest.json to my project
2. run piperider
3. the `run_results` cannot find corresponding id in the manifest.

**PR checklist**

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed
