### PR TITLE
[Bug] Exchange manifest direction and append empty dict

### DIFF
--- a/piperider_cli/dbt/list_task.py
+++ b/piperider_cli/dbt/list_task.py
@@ -319,7 +319,7 @@ def compare_models_between_manifests(
     include_downstream: bool = False,
 ):
     task = _DbtListTask()
-    task.manifest = base_manifest
+    task.manifest = altered_manifest
 
     dbt_flags = flags_module.get_flags()
     setattr(dbt_flags, "state", None)
@@ -330,7 +330,7 @@ def compare_models_between_manifests(
 
     setattr(dbt_flags, "selector", None)
 
-    task.previous_state = _InMemoryPreviousState(altered_manifest)
+    task.previous_state = _InMemoryPreviousState(base_manifest)
     if include_downstream:
         setattr(dbt_flags, "select", ("state:modified+",))
     else:

--- a/piperider_cli/reports/__init__.py
+++ b/piperider_cli/reports/__init__.py
@@ -689,8 +689,8 @@ class JoinedTables:
         result = dict()
         for key in keys:
             value = dict()
-            value["base"] = base.get(key)
-            value["target"] = target.get(key)
+            value["base"] = base.get(key, {})
+            value["target"] = target.get(key, {})
             result[key] = value
         return result
 
@@ -725,8 +725,8 @@ class JoinedTables:
 
     def _create_columns_and_their_metrics(self, table_name):
         table = self._joined_tables[table_name]
-        b = table.get("base", {}).get("columns")
-        t = table.get("target", {}).get("columns")
+        b = table.get("base", {}).get("columns", {})
+        t = table.get("target", {}).get("columns", {})
         all_column_keys = sorted(set(list(b.keys()) + list(t.keys())))
         return all_column_keys, b, t
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some check items for you: -->

**PR checklist**

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed

**What type of PR is this?**
bug

**What this PR does / why we need it**:
- change comparing manifest direction
- append empty `{}` when no corresponding column

**Which issue(s) this PR fixes**:
sc-31660

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
NONE