### PR TITLE
[Feature] sc-31590 Run command support -s to select dbt models

### DIFF
--- a/piperider_cli/cli.py
+++ b/piperider_cli/cli.py
@@ -229,11 +229,10 @@ def run(**kwargs):
         raise DbtProjectNotFoundError()
 
     dbt_resources = None
-    if select and (dbt_list or env_dbt_resources is not None):
+    if select and dbt_list is True:
         raise PipeRiderConflictOptionsError(
-            'Cannot use options "--select" with "--dbt-list" or environment variable "PIPERIDER_DBT_RESOURCES"',
-            hint='Remove "--select" option and use "--dbt-list" or environment variable "PIPERIDER_DBT_RESOURCES" '
-                 'instead.'
+            'Cannot use options "--select" with "--dbt-list"',
+            hint='Remove "--select" option and use "--dbt-list" instead.'
         )
 
     if dbt_list:
@@ -469,6 +468,7 @@ def cloud_compare_reports(**kwargs):
 @click.option('--dry-run', is_flag=True, default=False, help='Display the run details without actually executing it')
 @click.option('--interactive', is_flag=True, default=False,
               help='Prompt for confirmation to proceed with the run (Y/N)')
+@add_options([dbt_select_option_builder()])
 @add_options(dbt_related_options)
 @add_options(debug_option)
 def compare_with_recipe(**kwargs):
@@ -482,6 +482,7 @@ def compare_with_recipe(**kwargs):
     enable_share = kwargs.get('share')
     open_report = kwargs.get('open')
     project_name = kwargs.get('project')
+    select = kwargs.get('select')
     debug = kwargs.get('debug', False)
 
     # reconfigure recipe global flags
@@ -511,7 +512,7 @@ def compare_with_recipe(**kwargs):
     ret = 0
     try:
         # note: dry-run and interactive are set by configure_recipe_execution_flags
-        recipe_config: RecipeConfiguration = RecipeExecutor.exec(recipe_name=recipe, debug=debug)
+        recipe_config: RecipeConfiguration = RecipeExecutor.exec(recipe_name=recipe, select=select, debug=debug)
         last = False
         base = target = None
         if not recipe_config.base.is_file_specified() and not recipe_config.target.is_file_specified():

--- a/piperider_cli/cli.py
+++ b/piperider_cli/cli.py
@@ -53,13 +53,11 @@ def dbt_select_option_builder():
                             multiple=True,
                             cls=MultiOption)
     except Exception:
-        pass
-    # For dbt-core < 1.5.0
-    return click.option('--select', '-s', default=None, help='Specify the dbt nodes to include.',
-                        multiple=True)
+        # For dbt-core < 1.5.0
+        return click.option('--select', '-s', default=None, help='Specify the dbt nodes to include.',
+                            multiple=True)
 
 
-dbt_select_option = [dbt_select_option_builder()]
 dbt_related_options = [
     click.option('--dbt-project-dir', type=click.Path(exists=True),
                  help='The path to the dbt project directory.'),
@@ -191,7 +189,7 @@ def diagnose(**kwargs):
 @click.option('--project', default=None, type=click.STRING, help='Specify the project name to upload.')
 @click.option('--share', default=False, is_flag=True, help='Enable public share of the report to PipeRider Cloud.')
 @click.option('--open', is_flag=True, help='Opens the generated report in the system\'s default browser')
-@add_options(dbt_select_option)
+@add_options([dbt_select_option_builder()])
 @add_options(dbt_related_options)
 @add_options(debug_option)
 def run(**kwargs):
@@ -234,7 +232,8 @@ def run(**kwargs):
     if select and (dbt_list or env_dbt_resources is not None):
         raise PipeRiderConflictOptionsError(
             'Cannot use options "--select" with "--dbt-list" or environment variable "PIPERIDER_DBT_RESOURCES"',
-            hint='Remove "--select" option and use "--dbt-list" or environment variable "PIPERIDER_DBT_RESOURCES" instead.'
+            hint='Remove "--select" option and use "--dbt-list" or environment variable "PIPERIDER_DBT_RESOURCES" '
+                 'instead.'
         )
 
     if dbt_list:
@@ -470,7 +469,6 @@ def cloud_compare_reports(**kwargs):
 @click.option('--dry-run', is_flag=True, default=False, help='Display the run details without actually executing it')
 @click.option('--interactive', is_flag=True, default=False,
               help='Prompt for confirmation to proceed with the run (Y/N)')
-@click.option('--select', '-s', default=None, type=click.STRING, help='Specify the dbt nodes to include.')
 @add_options(dbt_related_options)
 @add_options(debug_option)
 def compare_with_recipe(**kwargs):

--- a/piperider_cli/dbt/list_task.py
+++ b/piperider_cli/dbt/list_task.py
@@ -12,7 +12,6 @@ from dbt.contracts.project import PackageConfig, UserConfig
 from dbt.contracts.state import PreviousState
 from dbt.exceptions import EventCompilationError
 from dbt.node_types import NodeType
-
 from dbt.task.list import ListTask
 
 from piperider_cli.dbt import disable_dbt_compile_stats
@@ -115,7 +114,7 @@ class _Adapter(BaseAdapter):
         pass
 
     def rename_relation(
-            self, from_relation: BaseRelation, to_relation: BaseRelation
+        self, from_relation: BaseRelation, to_relation: BaseRelation
     ) -> None:
         pass
 
@@ -126,7 +125,7 @@ class _Adapter(BaseAdapter):
         pass
 
     def list_relations_without_caching(
-            self, schema_relation: BaseRelation
+        self, schema_relation: BaseRelation
     ) -> List[BaseRelation]:
         pass
 
@@ -315,7 +314,7 @@ class ResourceSelector:
         )
 
 
-def list_resources_from_manifest(manifest: Manifest, selector: ResourceSelector = None):
+def list_resources_from_manifest(manifest: Manifest, selector: ResourceSelector = None, select: tuple = None):
     task = _DbtListTask()
     task.manifest = manifest
 
@@ -333,15 +332,15 @@ def list_resources_from_manifest(manifest: Manifest, selector: ResourceSelector 
         setattr(dbt_flags, "resource_types", selector.build_selected_set())
 
     setattr(dbt_flags, "selector", None)
-    setattr(dbt_flags, "select", None)
+    setattr(dbt_flags, "select", select)
     with disable_dbt_compile_stats():
         return task.run()
 
 
 def compare_models_between_manifests(
-        base_manifest: Manifest,
-        altered_manifest: Manifest,
-        include_downstream: bool = False,
+    base_manifest: Manifest,
+    altered_manifest: Manifest,
+    include_downstream: bool = False,
 ):
     task = _DbtListTask()
     task.manifest = altered_manifest

--- a/piperider_cli/error.py
+++ b/piperider_cli/error.py
@@ -205,3 +205,10 @@ class CloudReportError(PipeRiderError):
     def __init__(self, error_msg):
         self.message = error_msg
         pass
+
+
+class PipeRiderConflictOptionsError(PipeRiderError):
+    def __init__(self, error_msg, hint=''):
+        self.message = error_msg
+        self.hint = hint
+        pass

--- a/piperider_cli/recipe_executor.py
+++ b/piperider_cli/recipe_executor.py
@@ -14,8 +14,14 @@ class RecipeExecutor:
     @staticmethod
     def exec(recipe_name: str, auto_generate_default_recipe: bool = True, select=None, debug=False):
         recipe_path = select_recipe_file(recipe_name)
-
-        if recipe_path is None:
+        if select:
+            if recipe_name:
+                console.print(
+                    "[[bold yellow]Warning[/bold yellow]] The recipe will be ignored when --select is provided."
+                )
+            console.print(
+                f"[[bold green]Select[/bold green]] Manually select the dbt nodes to run by '{','.join(select)}'")
+        if recipe_path is None or select is not None:
             if auto_generate_default_recipe:
                 config = Configuration.instance()
                 dbt_project_path = None
@@ -24,7 +30,7 @@ class RecipeExecutor:
                 # generate a default recipe
                 console.rule("Recipe executor: generate default recipe")
                 options = None
-                if select is not None:
+                if select:
                     options = {}
                     options['select'] = select
                 recipe = generate_default_recipe(dbt_project_path=dbt_project_path, options=options)

--- a/piperider_cli/recipe_executor.py
+++ b/piperider_cli/recipe_executor.py
@@ -12,7 +12,7 @@ console = Console()
 
 class RecipeExecutor:
     @staticmethod
-    def exec(recipe_name: str, auto_generate_default_recipe: bool = True, debug=False):
+    def exec(recipe_name: str, auto_generate_default_recipe: bool = True, select=None, debug=False):
         recipe_path = select_recipe_file(recipe_name)
 
         if recipe_path is None:
@@ -23,7 +23,11 @@ class RecipeExecutor:
                     dbt_project_path = os.path.relpath(config.dataSources[0].args.get('dbt', {}).get('projectDir'))
                 # generate a default recipe
                 console.rule("Recipe executor: generate default recipe")
-                recipe = generate_default_recipe(dbt_project_path=dbt_project_path)
+                options = None
+                if select is not None:
+                    options = {}
+                    options['select'] = select
+                recipe = generate_default_recipe(dbt_project_path=dbt_project_path, options=options)
                 if recipe is None:
                     raise RecipeConfigException(
                         message='Default recipe generation failed.',

--- a/piperider_cli/recipes/default_recipe_generator.py
+++ b/piperider_cli/recipes/default_recipe_generator.py
@@ -29,21 +29,25 @@ def _create_base_recipe(dbt_project_path=None, options: dict = None) -> RecipeMo
     Create the base recipe
     """
     base = RecipeModel()
+    select_options = ''
 
     if tool().git_branch() is not None:
         base.branch = 'main'
+
+    if options and options.get('select'):
+        select_options = '--select ' + ' '.join(options.get('select'))
 
     dbt_project = _read_dbt_project_file(dbt_project_path)
     if dbt_project:
         base.dbt = RecipeDbtField({
             'commands': [
                 'dbt deps',
-                'dbt build'
+                f'dbt build {select_options}'.strip()
             ]
         })
 
     base.piperider = RecipePiperiderField({
-        'command': 'piperider run'
+        'command': f'piperider run {select_options}'.strip(),
     })
     return base
 
@@ -53,20 +57,23 @@ def _create_target_recipe(dbt_project_path=None, options: dict = None) -> Recipe
     Create the target recipe
     """
     target = RecipeModel()
+    select_options = ''
 
     # The target branch should be empty by default
+    if options and options.get('select'):
+        select_options = '--select ' + ' '.join(options.get('select'))
 
     dbt_project = _read_dbt_project_file(dbt_project_path)
     if dbt_project:
         target.dbt = RecipeDbtField({
             'commands': [
                 'dbt deps',
-                'dbt build'
+                f'dbt build {select_options}'.strip()
             ]
         })
 
     target.piperider = RecipePiperiderField({
-        'command': 'piperider run'
+        'command': f'piperider run {select_options}'.strip(),
     })
     return target
 
@@ -81,8 +88,8 @@ def generate_default_recipe(overwrite_existing: bool = False,
         if interactive is True:
             console.print('[bold green]Piperider default recipe already exist[/bold green]')
         return 0
-    base = _create_base_recipe(dbt_project_path)
-    target = _create_target_recipe(dbt_project_path)
+    base = _create_base_recipe(dbt_project_path, options)
+    target = _create_target_recipe(dbt_project_path, options)
     recipe = RecipeConfiguration(base=base, target=target)
 
     try:

--- a/piperider_cli/runner.py
+++ b/piperider_cli/runner.py
@@ -640,6 +640,7 @@ class Runner():
             dbt_manifest = dbtutil.get_dbt_manifest(dbt_state_dir)
             dbt_run_results = dbtutil.get_dbt_run_results(dbt_state_dir)
             if dbt_select:
+                # If the dbt_resources were already provided by environment variable PIPERIDER_DBT_RESOURCES, skip the dbt select
                 dbt_resources = dbt_resources if dbt_resources else dbtutil.get_dbt_resources(dbt_manifest,
                                                                                               select=dbt_select)
         console.print('everything is OK.')

--- a/piperider_cli/runner.py
+++ b/piperider_cli/runner.py
@@ -1,5 +1,4 @@
 import json
-import math
 import os
 import shutil
 import sys
@@ -7,6 +6,7 @@ import uuid
 from datetime import datetime
 from typing import List, Optional
 
+import math
 from rich import box
 from rich.color import Color
 from rich.console import Console
@@ -561,7 +561,7 @@ def get_dbt_state_dir(dbt_state_dir, dbt_config, ds):
 class Runner():
     @staticmethod
     def exec(datasource=None, table=None, output=None, skip_report=False, dbt_state_dir: str = None,
-             dbt_resources: Optional[dict] = None, report_dir: str = None):
+             dbt_resources: Optional[dict] = None, dbt_select: tuple = None, report_dir: str = None):
         console = Console()
 
         raise_exception_when_directory_not_writable(output)
@@ -639,6 +639,9 @@ class Runner():
                 return sys.exit(1)
             dbt_manifest = dbtutil.get_dbt_manifest(dbt_state_dir)
             dbt_run_results = dbtutil.get_dbt_run_results(dbt_state_dir)
+            if dbt_select:
+                dbt_resources = dbt_resources if dbt_resources else dbtutil.get_dbt_resources(dbt_manifest,
+                                                                                              select=dbt_select)
         console.print('everything is OK.')
 
         console.rule('Collect metadata')


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some check items for you: -->

**PR checklist**

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed

**What type of PR is this?**
Feature

**What this PR does / why we need it**:
- PipeRider `run` command support options `-s` or `--select` The logic will be equaled as dbt's `--select` option.
- Piperider `compare` command support options `-s` or `--select`. But it will only be affected when no default recipe is found. If the user has provided a recipe file, we will execute the `--select` option and ignore the recipe file.

**Which issue(s) this PR fixes**:
SC-31590

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
No
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
