### PR TITLE
[Bug] sc-31751 Fix compare command throw error  'int' object has no attribute 'dump'

### DIFF
--- a/piperider_cli/recipe_executor.py
+++ b/piperider_cli/recipe_executor.py
@@ -12,7 +12,7 @@ console = Console()
 
 class RecipeExecutor:
     @staticmethod
-    def exec(recipe_name: str, auto_generate_default_recipe: bool = True, select=None, debug=False):
+    def exec(recipe_name: str, auto_generate_default_recipe: bool = True, select: tuple = None, debug=False):
         recipe_path = select_recipe_file(recipe_name)
         if select:
             if recipe_name:
@@ -21,7 +21,7 @@ class RecipeExecutor:
                 )
             console.print(
                 f"[[bold green]Select[/bold green]] Manually select the dbt nodes to run by '{','.join(select)}'")
-        if recipe_path is None or select is not None:
+        if recipe_path is None or select:
             if auto_generate_default_recipe:
                 config = Configuration.instance()
                 dbt_project_path = None


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some check items for you: -->

**PR checklist**

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed

**What type of PR is this?**
Bugfix

**What this PR does / why we need it**:
Fix piperider compare command throw error "'int' object has no attribute 'dump'"

**Which issue(s) this PR fixes**:
sc-31751

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
