### PR TITLE
[Chore] Update unique-id resolving strategy

### DIFF
--- a/piperider_cli/dbt/list_task.py
+++ b/piperider_cli/dbt/list_task.py
@@ -390,7 +390,7 @@ def list_resources_unique_id_from_manifest(manifest: Manifest):
 
     setattr(dbt_flags, "output", "json")
     setattr(dbt_flags, "output", "json")
-    setattr(dbt_flags, "output_keys", "unique_id,name")
+    setattr(dbt_flags, "output_keys", "unique_id,name,resource_type")
     setattr(dbt_flags, "selector_name", None)
     setattr(dbt_flags, "resource_types", [])
 
@@ -495,6 +495,11 @@ class ChangeSet:
         self.target: Dict = target
         self.base_manifest: Manifest = self._m(base)
         self.target_manifest: Manifest = self._m(target)
+
+        # resources in this format [{unique_id, name, resource_type}]
+        self.base_resources = list_resources_unique_id_from_manifest(self.base_manifest)
+        self.target_resources = list_resources_unique_id_from_manifest(self.target_manifest)
+
         self.explicit_changes = sorted(self._do_list_explicit_changes())
 
     def _m(self, run: Dict):
@@ -503,14 +508,20 @@ class ChangeSet:
             raise ValueError('Cannot find .dbt.manifest in run data')
         return load_manifest(manifest)
 
-    def _do_list_explicit_changes(self):
-        base_resources = [x.get('unique_id') for x in list_resources_unique_id_from_manifest(self.base_manifest)]
-        target_resources = [x.get('unique_id') for x in list_resources_unique_id_from_manifest(self.target_manifest)]
+    def resolve_unique_id(self, resource_name: str, resource_type: str):
+        for entry in self.base_resources + self.target_resources:
+            if entry.get('resource_type') == resource_type and entry.get('name') == resource_name:
+                return entry.get('unique_id')
 
-        # exclude added and removed
+    def _do_list_explicit_changes(self):
+        base_resources = [x.get('unique_id') for x in self.base_resources]
+        target_resources = [x.get('unique_id') for x in self.target_resources]
+
         resource_in_both = list(set(base_resources).intersection(target_resources))
+        # exclude added and removed by intersection with common resources
         output = [x.get('unique_id') for x in list_changes_in_unique_id(self.base_manifest, self.target_manifest, True)]
         output = list(set(output).intersection(resource_in_both))
+
         return output
 
     def list_explicit_changes(self):
@@ -527,6 +538,12 @@ class ChangeSet:
                 if metrics_b.get(x) != metrics_t.get(x):
                     ref_id = metrics_t.get(x).get('ref_id')
                     if ref_id:
+                        diffs.append(ref_id)
+                    else:
+                        # resolve the unique id for the legacy report
+                        metric_name = metrics_t.get(x).get('headers')[-1]
+                        ref_id = self.resolve_unique_id(metric_name, 'metric')
+                        assert ref_id is not None
                         diffs.append(ref_id)
 
         implicit = list(set(diffs))
@@ -547,7 +564,12 @@ class ChangeSet:
                 if r1 == r2 and c1 == c2 and not self.has_changed(b, t):
                     pass
                 else:
-                    diffs.append(ref_id)
+                    if ref_id:
+                        diffs.append(ref_id)
+                    else:
+                        resolved_id = self.resolve_unique_id(table_name, 'model')
+                        assert resolved_id is not None
+                        diffs.append(resolved_id)
 
         return diffs
 

--- a/tests/mock_dbt_data/sc-31587-metrics-base.json
+++ b/tests/mock_dbt_data/sc-31587-metrics-base.json
@@ -1,0 +1,20923 @@
+{
+  "tables": {
+    "int_order_payments_pivoted": {
+      "name": "int_order_payments_pivoted",
+      "row_count": 99,
+      "samples": 99,
+      "samples_p": 1,
+      "col_count": 9,
+      "columns": {
+        "order_id": {
+          "name": "order_id",
+          "type": "integer",
+          "schema_type": "INTEGER",
+          "total": 99,
+          "samples": 99,
+          "samples_p": 1,
+          "non_nulls": 99,
+          "non_nulls_p": 1,
+          "nulls": 0,
+          "nulls_p": 0,
+          "valids": 99,
+          "valids_p": 1,
+          "invalids": 0,
+          "invalids_p": 0,
+          "zeros": 0,
+          "zeros_p": 0,
+          "negatives": 0,
+          "negatives_p": 0,
+          "positives": 99,
+          "positives_p": 1,
+          "distinct": 99,
+          "distinct_p": 1,
+          "min": 1,
+          "max": 99,
+          "sum": 4950,
+          "avg": 50,
+          "stddev": 28.722813232690147,
+          "duplicates": 0,
+          "duplicates_p": 0,
+          "non_duplicates": 99,
+          "non_duplicates_p": 1,
+          "histogram": {
+            "labels": [
+              "1 _ 3",
+              "3 _ 5",
+              "5 _ 7",
+              "7 _ 9",
+              "9 _ 11",
+              "11 _ 13",
+              "13 _ 15",
+              "15 _ 17",
+              "17 _ 19",
+              "19 _ 21",
+              "21 _ 23",
+              "23 _ 25",
+              "25 _ 27",
+              "27 _ 29",
+              "29 _ 31",
+              "31 _ 33",
+              "33 _ 35",
+              "35 _ 37",
+              "37 _ 39",
+              "39 _ 41",
+              "41 _ 43",
+              "43 _ 45",
+              "45 _ 47",
+              "47 _ 49",
+              "49 _ 51",
+              "51 _ 53",
+              "53 _ 55",
+              "55 _ 57",
+              "57 _ 59",
+              "59 _ 61",
+              "61 _ 63",
+              "63 _ 65",
+              "65 _ 67",
+              "67 _ 69",
+              "69 _ 71",
+              "71 _ 73",
+              "73 _ 75",
+              "75 _ 77",
+              "77 _ 79",
+              "79 _ 81",
+              "81 _ 83",
+              "83 _ 85",
+              "85 _ 87",
+              "87 _ 89",
+              "89 _ 91",
+              "91 _ 93",
+              "93 _ 95",
+              "95 _ 97",
+              "97 _ 99",
+              "99 _ 101"
+            ],
+            "counts": [
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              1
+            ],
+            "bin_edges": [
+              1,
+              3,
+              5,
+              7,
+              9,
+              11,
+              13,
+              15,
+              17,
+              19,
+              21,
+              23,
+              25,
+              27,
+              29,
+              31,
+              33,
+              35,
+              37,
+              39,
+              41,
+              43,
+              45,
+              47,
+              49,
+              51,
+              53,
+              55,
+              57,
+              59,
+              61,
+              63,
+              65,
+              67,
+              69,
+              71,
+              73,
+              75,
+              77,
+              79,
+              81,
+              83,
+              85,
+              87,
+              89,
+              91,
+              93,
+              95,
+              97,
+              99,
+              101
+            ]
+          },
+          "p5": 5,
+          "p25": 25,
+          "p50": 50,
+          "p75": 75,
+          "p95": 95,
+          "topk": {
+            "values": [
+              "1",
+              "2",
+              "3",
+              "4",
+              "5",
+              "6",
+              "7",
+              "8",
+              "9",
+              "10",
+              "11",
+              "12",
+              "13",
+              "14",
+              "15",
+              "16",
+              "17",
+              "18",
+              "19",
+              "20",
+              "21",
+              "22",
+              "23",
+              "24",
+              "25",
+              "26",
+              "27",
+              "28",
+              "29",
+              "30",
+              "31",
+              "32",
+              "33",
+              "34",
+              "35",
+              "36",
+              "37",
+              "38",
+              "39",
+              "40",
+              "41",
+              "42",
+              "43",
+              "44",
+              "45",
+              "46",
+              "47",
+              "48",
+              "49",
+              "50"
+            ],
+            "counts": [
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1
+            ]
+          },
+          "profile_duration": "0.04",
+          "elapsed_milli": 36,
+          "description": "This is a unique identifier for an order"
+        },
+        "customer_id": {
+          "name": "customer_id",
+          "type": "integer",
+          "schema_type": "INTEGER",
+          "total": 99,
+          "samples": 99,
+          "samples_p": 1,
+          "non_nulls": 99,
+          "non_nulls_p": 1,
+          "nulls": 0,
+          "nulls_p": 0,
+          "valids": 99,
+          "valids_p": 1,
+          "invalids": 0,
+          "invalids_p": 0,
+          "zeros": 0,
+          "zeros_p": 0,
+          "negatives": 0,
+          "negatives_p": 0,
+          "positives": 99,
+          "positives_p": 1,
+          "distinct": 62,
+          "distinct_p": 0.6262626262626263,
+          "min": 1,
+          "max": 99,
+          "sum": 4777,
+          "avg": 48.25252525252525,
+          "stddev": 27.781341350472967,
+          "duplicates": 66,
+          "duplicates_p": 0.6666666666666666,
+          "non_duplicates": 33,
+          "non_duplicates_p": 0.3333333333333333,
+          "histogram": {
+            "labels": [
+              "1 _ 3",
+              "3 _ 5",
+              "5 _ 7",
+              "7 _ 9",
+              "9 _ 11",
+              "11 _ 13",
+              "13 _ 15",
+              "15 _ 17",
+              "17 _ 19",
+              "19 _ 21",
+              "21 _ 23",
+              "23 _ 25",
+              "25 _ 27",
+              "27 _ 29",
+              "29 _ 31",
+              "31 _ 33",
+              "33 _ 35",
+              "35 _ 37",
+              "37 _ 39",
+              "39 _ 41",
+              "41 _ 43",
+              "43 _ 45",
+              "45 _ 47",
+              "47 _ 49",
+              "49 _ 51",
+              "51 _ 53",
+              "53 _ 55",
+              "55 _ 57",
+              "57 _ 59",
+              "59 _ 61",
+              "61 _ 63",
+              "63 _ 65",
+              "65 _ 67",
+              "67 _ 69",
+              "69 _ 71",
+              "71 _ 73",
+              "73 _ 75",
+              "75 _ 77",
+              "77 _ 79",
+              "79 _ 81",
+              "81 _ 83",
+              "83 _ 85",
+              "85 _ 87",
+              "87 _ 89",
+              "89 _ 91",
+              "91 _ 93",
+              "93 _ 95",
+              "95 _ 97",
+              "97 _ 99",
+              "99 _ 101"
+            ],
+            "counts": [
+              3,
+              3,
+              1,
+              3,
+              1,
+              2,
+              1,
+              1,
+              1,
+              2,
+              4,
+              0,
+              4,
+              3,
+              2,
+              2,
+              2,
+              3,
+              1,
+              2,
+              3,
+              0,
+              2,
+              2,
+              2,
+              4,
+              7,
+              0,
+              2,
+              1,
+              0,
+              4,
+              3,
+              1,
+              4,
+              3,
+              0,
+              1,
+              0,
+              3,
+              0,
+              2,
+              3,
+              1,
+              3,
+              2,
+              3,
+              0,
+              0,
+              2
+            ],
+            "bin_edges": [
+              1,
+              3,
+              5,
+              7,
+              9,
+              11,
+              13,
+              15,
+              17,
+              19,
+              21,
+              23,
+              25,
+              27,
+              29,
+              31,
+              33,
+              35,
+              37,
+              39,
+              41,
+              43,
+              45,
+              47,
+              49,
+              51,
+              53,
+              55,
+              57,
+              59,
+              61,
+              63,
+              65,
+              67,
+              69,
+              71,
+              73,
+              75,
+              77,
+              79,
+              81,
+              83,
+              85,
+              87,
+              89,
+              91,
+              93,
+              95,
+              97,
+              99,
+              101
+            ]
+          },
+          "p5": 3,
+          "p25": 26,
+          "p50": 50,
+          "p75": 70,
+          "p95": 93,
+          "topk": {
+            "values": [
+              "54",
+              "3",
+              "22",
+              "51",
+              "66",
+              "71",
+              "1",
+              "8",
+              "25",
+              "26",
+              "27",
+              "30",
+              "35",
+              "42",
+              "46",
+              "47",
+              "50",
+              "53",
+              "57",
+              "63",
+              "64",
+              "69",
+              "70",
+              "79",
+              "84",
+              "85",
+              "90",
+              "94",
+              "99",
+              "2",
+              "6",
+              "7",
+              "9",
+              "11",
+              "12",
+              "13",
+              "16",
+              "18",
+              "19",
+              "20",
+              "21",
+              "28",
+              "31",
+              "32",
+              "33",
+              "34",
+              "36",
+              "38",
+              "39",
+              "40"
+            ],
+            "counts": [
+              5,
+              3,
+              3,
+              3,
+              3,
+              3,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1
+            ]
+          },
+          "profile_duration": "0.04",
+          "elapsed_milli": 36,
+          "description": "Foreign key to the customers table"
+        },
+        "order_date": {
+          "name": "order_date",
+          "type": "datetime",
+          "schema_type": "DATE",
+          "total": 99,
+          "samples": 99,
+          "samples_p": 1,
+          "non_nulls": 99,
+          "non_nulls_p": 1,
+          "nulls": 0,
+          "nulls_p": 0,
+          "valids": 99,
+          "valids_p": 1,
+          "invalids": 0,
+          "invalids_p": 0,
+          "distinct": 69,
+          "distinct_p": 0.696969696969697,
+          "min": "2023-03-14",
+          "max": "2023-06-20",
+          "duplicates": 53,
+          "duplicates_p": 0.5353535353535354,
+          "non_duplicates": 46,
+          "non_duplicates_p": 0.46464646464646464,
+          "histogram": {
+            "labels": [
+              "2023-03-01 - 2023-04-01",
+              "2023-04-01 - 2023-05-01",
+              "2023-05-01 - 2023-06-01",
+              "2023-06-01 - 2023-07-01"
+            ],
+            "counts": [
+              17,
+              28,
+              31,
+              23
+            ],
+            "bin_edges": [
+              "2023-03-01",
+              "2023-04-01",
+              "2023-05-01",
+              "2023-06-01",
+              "2023-07-01"
+            ]
+          },
+          "profile_duration": "0.02",
+          "elapsed_milli": 22,
+          "description": "Date (UTC) that the order was placed"
+        },
+        "status": {
+          "name": "status",
+          "type": "string",
+          "schema_type": "VARCHAR",
+          "total": 99,
+          "samples": 99,
+          "samples_p": 1,
+          "non_nulls": 99,
+          "non_nulls_p": 1,
+          "nulls": 0,
+          "nulls_p": 0,
+          "valids": 99,
+          "valids_p": 1,
+          "invalids": 0,
+          "invalids_p": 0,
+          "zero_length": 0,
+          "zero_length_p": 0,
+          "non_zero_length": 99,
+          "non_zero_length_p": 1,
+          "distinct": 5,
+          "distinct_p": 0.050505050505050504,
+          "min": 6,
+          "min_length": 6,
+          "max": 14,
+          "max_length": 14,
+          "avg": 8.404040404040405,
+          "avg_length": 8.404040404040405,
+          "stddev": 1.3844559228926323,
+          "stddev_length": 1.3844559228926323,
+          "duplicates": 99,
+          "duplicates_p": 1,
+          "non_duplicates": 0,
+          "non_duplicates_p": 0,
+          "topk": {
+            "values": [
+              "completed",
+              "shipped",
+              "placed",
+              "returned",
+              "return_pending"
+            ],
+            "counts": [
+              67,
+              13,
+              13,
+              4,
+              2
+            ]
+          },
+          "histogram": {
+            "labels": [
+              "6",
+              "7",
+              "8",
+              "9",
+              "10",
+              "11",
+              "12",
+              "13",
+              "14"
+            ],
+            "counts": [
+              13,
+              13,
+              4,
+              67,
+              0,
+              0,
+              0,
+              0,
+              2
+            ],
+            "bin_edges": [
+              6,
+              7,
+              8,
+              9,
+              10,
+              11,
+              12,
+              13,
+              14,
+              15
+            ]
+          },
+          "histogram_length": {
+            "labels": [
+              "6",
+              "7",
+              "8",
+              "9",
+              "10",
+              "11",
+              "12",
+              "13",
+              "14"
+            ],
+            "counts": [
+              13,
+              13,
+              4,
+              67,
+              0,
+              0,
+              0,
+              0,
+              2
+            ],
+            "bin_edges": [
+              6,
+              7,
+              8,
+              9,
+              10,
+              11,
+              12,
+              13,
+              14,
+              15
+            ]
+          },
+          "profile_duration": "0.03",
+          "elapsed_milli": 27,
+          "description": "Orders can be one of the following statuses:\n\n| status         | description                                                                                                            |\n|----------------|------------------------------------------------------------------------------------------------------------------------|\n| placed         | The order has been placed but has not yet left the warehouse                                                           |\n| shipped        | The order has ben shipped to the customer and is currently in transit                                                  |\n| completed      | The order has been received by the customer                                                                            |\n| return_pending | The customer has indicated that they would like to return the order, but it has not yet been received at the warehouse |\n| returned       | The order has been returned by the customer and received at the warehouse                                              |"
+        },
+        "credit_card_amount": {
+          "name": "credit_card_amount",
+          "type": "integer",
+          "schema_type": "BIGINT",
+          "total": 99,
+          "samples": 99,
+          "samples_p": 1,
+          "non_nulls": 99,
+          "non_nulls_p": 1,
+          "nulls": 0,
+          "nulls_p": 0,
+          "valids": 99,
+          "valids_p": 1,
+          "invalids": 0,
+          "invalids_p": 0,
+          "zeros": 50,
+          "zeros_p": 0.5050505050505051,
+          "negatives": 0,
+          "negatives_p": 0,
+          "positives": 49,
+          "positives_p": 0.494949494949495,
+          "distinct": 25,
+          "distinct_p": 0.25252525252525254,
+          "min": 0,
+          "max": 30,
+          "sum": 871,
+          "avg": 8.797979797979798,
+          "stddev": 10.95908885492767,
+          "duplicates": 91,
+          "duplicates_p": 0.9191919191919192,
+          "non_duplicates": 8,
+          "non_duplicates_p": 0.08080808080808081,
+          "histogram": {
+            "labels": [
+              "0",
+              "1",
+              "2",
+              "3",
+              "4",
+              "5",
+              "6",
+              "7",
+              "8",
+              "9",
+              "10",
+              "11",
+              "12",
+              "13",
+              "14",
+              "15",
+              "16",
+              "17",
+              "18",
+              "19",
+              "20",
+              "21",
+              "22",
+              "23",
+              "24",
+              "25",
+              "26",
+              "27",
+              "28",
+              "29",
+              "30"
+            ],
+            "counts": [
+              50,
+              2,
+              0,
+              2,
+              2,
+              2,
+              1,
+              0,
+              1,
+              0,
+              2,
+              0,
+              2,
+              2,
+              1,
+              2,
+              2,
+              1,
+              1,
+              4,
+              1,
+              0,
+              3,
+              3,
+              1,
+              0,
+              3,
+              2,
+              1,
+              5,
+              3
+            ],
+            "bin_edges": [
+              0,
+              1,
+              2,
+              3,
+              4,
+              5,
+              6,
+              7,
+              8,
+              9,
+              10,
+              11,
+              12,
+              13,
+              14,
+              15,
+              16,
+              17,
+              18,
+              19,
+              20,
+              21,
+              22,
+              23,
+              24,
+              25,
+              26,
+              27,
+              28,
+              29,
+              30,
+              31
+            ]
+          },
+          "p5": 0,
+          "p25": 0,
+          "p50": 0,
+          "p75": 19,
+          "p95": 29,
+          "topk": {
+            "values": [
+              "0",
+              "29",
+              "19",
+              "22",
+              "23",
+              "26",
+              "30",
+              "1",
+              "3",
+              "4",
+              "5",
+              "10",
+              "12",
+              "13",
+              "15",
+              "16",
+              "27",
+              "6",
+              "8",
+              "14",
+              "17",
+              "18",
+              "20",
+              "24",
+              "28"
+            ],
+            "counts": [
+              50,
+              5,
+              4,
+              3,
+              3,
+              3,
+              3,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1
+            ]
+          },
+          "profile_duration": "0.04",
+          "elapsed_milli": 36,
+          "description": "Amount of the order (AUD) paid for by credit card"
+        },
+        "coupon_amount": {
+          "name": "coupon_amount",
+          "type": "integer",
+          "schema_type": "BIGINT",
+          "total": 99,
+          "samples": 99,
+          "samples_p": 1,
+          "non_nulls": 99,
+          "non_nulls_p": 1,
+          "nulls": 0,
+          "nulls_p": 0,
+          "valids": 99,
+          "valids_p": 1,
+          "invalids": 0,
+          "invalids_p": 0,
+          "zeros": 86,
+          "zeros_p": 0.8686868686868687,
+          "negatives": 0,
+          "negatives_p": 0,
+          "positives": 13,
+          "positives_p": 0.13131313131313133,
+          "distinct": 12,
+          "distinct_p": 0.12121212121212122,
+          "min": 0,
+          "max": 26,
+          "sum": 185,
+          "avg": 1.8686868686868687,
+          "stddev": 5.955012405351227,
+          "duplicates": 89,
+          "duplicates_p": 0.898989898989899,
+          "non_duplicates": 10,
+          "non_duplicates_p": 0.10101010101010101,
+          "histogram": {
+            "labels": [
+              "0",
+              "1",
+              "2",
+              "3",
+              "4",
+              "5",
+              "6",
+              "7",
+              "8",
+              "9",
+              "10",
+              "11",
+              "12",
+              "13",
+              "14",
+              "15",
+              "16",
+              "17",
+              "18",
+              "19",
+              "20",
+              "21",
+              "22",
+              "23",
+              "24",
+              "25",
+              "26"
+            ],
+            "counts": [
+              86,
+              1,
+              3,
+              0,
+              0,
+              0,
+              0,
+              1,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              1,
+              1,
+              1,
+              0,
+              0,
+              0,
+              1,
+              1,
+              1,
+              1,
+              1
+            ],
+            "bin_edges": [
+              0,
+              1,
+              2,
+              3,
+              4,
+              5,
+              6,
+              7,
+              8,
+              9,
+              10,
+              11,
+              12,
+              13,
+              14,
+              15,
+              16,
+              17,
+              18,
+              19,
+              20,
+              21,
+              22,
+              23,
+              24,
+              25,
+              26,
+              27
+            ]
+          },
+          "p5": 0,
+          "p25": 0,
+          "p50": 0,
+          "p75": 0,
+          "p95": 20,
+          "topk": {
+            "values": [
+              "0",
+              "2",
+              "1",
+              "7",
+              "16",
+              "17",
+              "18",
+              "22",
+              "23",
+              "24",
+              "25",
+              "26"
+            ],
+            "counts": [
+              86,
+              3,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1
+            ]
+          },
+          "profile_duration": "0.04",
+          "elapsed_milli": 41,
+          "description": "Amount of the order (AUD) paid for by coupon"
+        },
+        "bank_transfer_amount": {
+          "name": "bank_transfer_amount",
+          "type": "integer",
+          "schema_type": "BIGINT",
+          "total": 99,
+          "samples": 99,
+          "samples_p": 1,
+          "non_nulls": 99,
+          "non_nulls_p": 1,
+          "nulls": 0,
+          "nulls_p": 0,
+          "valids": 99,
+          "valids_p": 1,
+          "invalids": 0,
+          "invalids_p": 0,
+          "zeros": 67,
+          "zeros_p": 0.6767676767676768,
+          "negatives": 0,
+          "negatives_p": 0,
+          "positives": 32,
+          "positives_p": 0.32323232323232326,
+          "distinct": 19,
+          "distinct_p": 0.1919191919191919,
+          "min": 0,
+          "max": 26,
+          "sum": 411,
+          "avg": 4.151515151515151,
+          "stddev": 7.420825132023677,
+          "duplicates": 89,
+          "duplicates_p": 0.898989898989899,
+          "non_duplicates": 10,
+          "non_duplicates_p": 0.10101010101010101,
+          "histogram": {
+            "labels": [
+              "0",
+              "1",
+              "2",
+              "3",
+              "4",
+              "5",
+              "6",
+              "7",
+              "8",
+              "9",
+              "10",
+              "11",
+              "12",
+              "13",
+              "14",
+              "15",
+              "16",
+              "17",
+              "18",
+              "19",
+              "20",
+              "21",
+              "22",
+              "23",
+              "24",
+              "25",
+              "26"
+            ],
+            "counts": [
+              67,
+              0,
+              3,
+              3,
+              1,
+              1,
+              0,
+              0,
+              3,
+              1,
+              1,
+              1,
+              1,
+              0,
+              2,
+              4,
+              1,
+              2,
+              0,
+              2,
+              1,
+              0,
+              1,
+              0,
+              0,
+              1,
+              3
+            ],
+            "bin_edges": [
+              0,
+              1,
+              2,
+              3,
+              4,
+              5,
+              6,
+              7,
+              8,
+              9,
+              10,
+              11,
+              12,
+              13,
+              14,
+              15,
+              16,
+              17,
+              18,
+              19,
+              20,
+              21,
+              22,
+              23,
+              24,
+              25,
+              26,
+              27
+            ]
+          },
+          "p5": 0,
+          "p25": 0,
+          "p50": 0,
+          "p75": 5,
+          "p95": 21,
+          "topk": {
+            "values": [
+              "0",
+              "15",
+              "2",
+              "3",
+              "8",
+              "26",
+              "14",
+              "17",
+              "19",
+              "4",
+              "5",
+              "9",
+              "10",
+              "11",
+              "12",
+              "16",
+              "20",
+              "22",
+              "25"
+            ],
+            "counts": [
+              67,
+              4,
+              3,
+              3,
+              3,
+              3,
+              2,
+              2,
+              2,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1
+            ]
+          },
+          "profile_duration": "0.04",
+          "elapsed_milli": 43,
+          "description": "Amount of the order (AUD) paid for by bank transfer"
+        },
+        "gift_card_amount": {
+          "name": "gift_card_amount",
+          "type": "integer",
+          "schema_type": "BIGINT",
+          "total": 99,
+          "samples": 99,
+          "samples_p": 1,
+          "non_nulls": 99,
+          "non_nulls_p": 1,
+          "nulls": 0,
+          "nulls_p": 0,
+          "valids": 99,
+          "valids_p": 1,
+          "invalids": 0,
+          "invalids_p": 0,
+          "zeros": 87,
+          "zeros_p": 0.8787878787878788,
+          "negatives": 0,
+          "negatives_p": 0,
+          "positives": 12,
+          "positives_p": 0.12121212121212122,
+          "distinct": 11,
+          "distinct_p": 0.1111111111111111,
+          "min": 0,
+          "max": 30,
+          "sum": 205,
+          "avg": 2.0707070707070705,
+          "stddev": 6.392362351566517,
+          "duplicates": 91,
+          "duplicates_p": 0.9191919191919192,
+          "non_duplicates": 8,
+          "non_duplicates_p": 0.08080808080808081,
+          "histogram": {
+            "labels": [
+              "0",
+              "1",
+              "2",
+              "3",
+              "4",
+              "5",
+              "6",
+              "7",
+              "8",
+              "9",
+              "10",
+              "11",
+              "12",
+              "13",
+              "14",
+              "15",
+              "16",
+              "17",
+              "18",
+              "19",
+              "20",
+              "21",
+              "22",
+              "23",
+              "24",
+              "25",
+              "26",
+              "27",
+              "28",
+              "29",
+              "30"
+            ],
+            "counts": [
+              87,
+              0,
+              0,
+              1,
+              0,
+              0,
+              2,
+              0,
+              0,
+              0,
+              0,
+              1,
+              0,
+              0,
+              1,
+              0,
+              0,
+              1,
+              1,
+              0,
+              0,
+              0,
+              0,
+              2,
+              0,
+              0,
+              1,
+              0,
+              1,
+              0,
+              1
+            ],
+            "bin_edges": [
+              0,
+              1,
+              2,
+              3,
+              4,
+              5,
+              6,
+              7,
+              8,
+              9,
+              10,
+              11,
+              12,
+              13,
+              14,
+              15,
+              16,
+              17,
+              18,
+              19,
+              20,
+              21,
+              22,
+              23,
+              24,
+              25,
+              26,
+              27,
+              28,
+              29,
+              30,
+              31
+            ]
+          },
+          "p5": 0,
+          "p25": 0,
+          "p50": 0,
+          "p75": 0,
+          "p95": 21,
+          "topk": {
+            "values": [
+              "0",
+              "6",
+              "23",
+              "3",
+              "11",
+              "14",
+              "17",
+              "18",
+              "26",
+              "28",
+              "30"
+            ],
+            "counts": [
+              87,
+              2,
+              2,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1
+            ]
+          },
+          "profile_duration": "0.05",
+          "elapsed_milli": 45,
+          "description": "Amount of the order (AUD) paid for by gift card"
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "schema_type": "BIGINT",
+          "total": 99,
+          "samples": 99,
+          "samples_p": 1,
+          "non_nulls": 99,
+          "non_nulls_p": 1,
+          "nulls": 0,
+          "nulls_p": 0,
+          "valids": 99,
+          "valids_p": 1,
+          "invalids": 0,
+          "invalids_p": 0,
+          "zeros": 1,
+          "zeros_p": 0.010101010101010102,
+          "negatives": 0,
+          "negatives_p": 0,
+          "positives": 98,
+          "positives_p": 0.98989898989899,
+          "distinct": 32,
+          "distinct_p": 0.32323232323232326,
+          "min": 0,
+          "max": 58,
+          "sum": 1672,
+          "avg": 16.88888888888889,
+          "stddev": 10.736062525374603,
+          "duplicates": 91,
+          "duplicates_p": 0.9191919191919192,
+          "non_duplicates": 8,
+          "non_duplicates_p": 0.08080808080808081,
+          "histogram": {
+            "labels": [
+              "0 _ 2",
+              "2 _ 4",
+              "4 _ 6",
+              "6 _ 8",
+              "8 _ 10",
+              "10 _ 12",
+              "12 _ 14",
+              "14 _ 16",
+              "16 _ 18",
+              "18 _ 20",
+              "20 _ 22",
+              "22 _ 24",
+              "24 _ 26",
+              "26 _ 28",
+              "28 _ 30",
+              "30 _ 32",
+              "32 _ 34",
+              "34 _ 36",
+              "36 _ 38",
+              "38 _ 40",
+              "40 _ 42",
+              "42 _ 44",
+              "44 _ 46",
+              "46 _ 48",
+              "48 _ 50",
+              "50 _ 52",
+              "52 _ 54",
+              "54 _ 56",
+              "56 _ 58",
+              "58 _ 60"
+            ],
+            "counts": [
+              4,
+              11,
+              4,
+              3,
+              5,
+              4,
+              5,
+              8,
+              9,
+              7,
+              1,
+              11,
+              5,
+              9,
+              8,
+              3,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              1,
+              1
+            ],
+            "bin_edges": [
+              0,
+              2,
+              4,
+              6,
+              8,
+              10,
+              12,
+              14,
+              16,
+              18,
+              20,
+              22,
+              24,
+              26,
+              28,
+              30,
+              32,
+              34,
+              36,
+              38,
+              40,
+              42,
+              44,
+              46,
+              48,
+              50,
+              52,
+              54,
+              56,
+              58,
+              60
+            ]
+          },
+          "p5": 2,
+          "p25": 8,
+          "p50": 17,
+          "p75": 24,
+          "p95": 30,
+          "topk": {
+            "values": [
+              "23",
+              "26",
+              "3",
+              "17",
+              "19",
+              "29",
+              "2",
+              "15",
+              "8",
+              "22",
+              "1",
+              "10",
+              "12",
+              "14",
+              "16",
+              "24",
+              "30",
+              "4",
+              "5",
+              "6",
+              "13",
+              "25",
+              "27",
+              "28",
+              "0",
+              "7",
+              "9",
+              "11",
+              "18",
+              "20",
+              "56",
+              "58"
+            ],
+            "counts": [
+              7,
+              7,
+              6,
+              6,
+              6,
+              6,
+              5,
+              5,
+              4,
+              4,
+              3,
+              3,
+              3,
+              3,
+              3,
+              3,
+              3,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1
+            ]
+          },
+          "profile_duration": "0.05",
+          "elapsed_milli": 45,
+          "description": "Total amount (AUD) of the order"
+        }
+      },
+      "profile_duration": "0.05",
+      "elapsed_milli": 45,
+      "description": "This table has basic information about orders, as well as some derived facts based on payments"
+    },
+    "int_customer_order_history_joined": {
+      "name": "int_customer_order_history_joined",
+      "row_count": 100,
+      "samples": 100,
+      "samples_p": 1,
+      "col_count": 7,
+      "columns": {
+        "customer_id": {
+          "name": "customer_id",
+          "type": "integer",
+          "schema_type": "INTEGER",
+          "total": 100,
+          "samples": 100,
+          "samples_p": 1,
+          "non_nulls": 100,
+          "non_nulls_p": 1,
+          "nulls": 0,
+          "nulls_p": 0,
+          "valids": 100,
+          "valids_p": 1,
+          "invalids": 0,
+          "invalids_p": 0,
+          "zeros": 0,
+          "zeros_p": 0,
+          "negatives": 0,
+          "negatives_p": 0,
+          "positives": 100,
+          "positives_p": 1,
+          "distinct": 100,
+          "distinct_p": 1,
+          "min": 1,
+          "max": 100,
+          "sum": 5050,
+          "avg": 50.5,
+          "stddev": 29.011491975882013,
+          "duplicates": 0,
+          "duplicates_p": 0,
+          "non_duplicates": 100,
+          "non_duplicates_p": 1,
+          "histogram": {
+            "labels": [
+              "1 _ 3",
+              "3 _ 5",
+              "5 _ 7",
+              "7 _ 9",
+              "9 _ 11",
+              "11 _ 13",
+              "13 _ 15",
+              "15 _ 17",
+              "17 _ 19",
+              "19 _ 21",
+              "21 _ 23",
+              "23 _ 25",
+              "25 _ 27",
+              "27 _ 29",
+              "29 _ 31",
+              "31 _ 33",
+              "33 _ 35",
+              "35 _ 37",
+              "37 _ 39",
+              "39 _ 41",
+              "41 _ 43",
+              "43 _ 45",
+              "45 _ 47",
+              "47 _ 49",
+              "49 _ 51",
+              "51 _ 53",
+              "53 _ 55",
+              "55 _ 57",
+              "57 _ 59",
+              "59 _ 61",
+              "61 _ 63",
+              "63 _ 65",
+              "65 _ 67",
+              "67 _ 69",
+              "69 _ 71",
+              "71 _ 73",
+              "73 _ 75",
+              "75 _ 77",
+              "77 _ 79",
+              "79 _ 81",
+              "81 _ 83",
+              "83 _ 85",
+              "85 _ 87",
+              "87 _ 89",
+              "89 _ 91",
+              "91 _ 93",
+              "93 _ 95",
+              "95 _ 97",
+              "97 _ 99",
+              "99 _ 101"
+            ],
+            "counts": [
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2
+            ],
+            "bin_edges": [
+              1,
+              3,
+              5,
+              7,
+              9,
+              11,
+              13,
+              15,
+              17,
+              19,
+              21,
+              23,
+              25,
+              27,
+              29,
+              31,
+              33,
+              35,
+              37,
+              39,
+              41,
+              43,
+              45,
+              47,
+              49,
+              51,
+              53,
+              55,
+              57,
+              59,
+              61,
+              63,
+              65,
+              67,
+              69,
+              71,
+              73,
+              75,
+              77,
+              79,
+              81,
+              83,
+              85,
+              87,
+              89,
+              91,
+              93,
+              95,
+              97,
+              99,
+              101
+            ]
+          },
+          "p5": 6,
+          "p25": 26,
+          "p50": 50,
+          "p75": 76,
+          "p95": 95,
+          "topk": {
+            "values": [
+              "1",
+              "2",
+              "3",
+              "4",
+              "5",
+              "6",
+              "7",
+              "8",
+              "9",
+              "10",
+              "11",
+              "12",
+              "13",
+              "14",
+              "15",
+              "16",
+              "17",
+              "18",
+              "19",
+              "20",
+              "21",
+              "22",
+              "23",
+              "24",
+              "25",
+              "26",
+              "27",
+              "28",
+              "29",
+              "30",
+              "31",
+              "32",
+              "33",
+              "34",
+              "35",
+              "36",
+              "37",
+              "38",
+              "39",
+              "40",
+              "41",
+              "42",
+              "43",
+              "44",
+              "45",
+              "46",
+              "47",
+              "48",
+              "49",
+              "50"
+            ],
+            "counts": [
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1
+            ]
+          },
+          "profile_duration": "0.02",
+          "elapsed_milli": 21,
+          "description": "This is a unique identifier for a customer"
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "string",
+          "schema_type": "VARCHAR",
+          "total": 100,
+          "samples": 100,
+          "samples_p": 1,
+          "non_nulls": 100,
+          "non_nulls_p": 1,
+          "nulls": 0,
+          "nulls_p": 0,
+          "valids": 100,
+          "valids_p": 1,
+          "invalids": 0,
+          "invalids_p": 0,
+          "zero_length": 0,
+          "zero_length_p": 0,
+          "non_zero_length": 100,
+          "non_zero_length_p": 1,
+          "distinct": 79,
+          "distinct_p": 0.79,
+          "min": 3,
+          "min_length": 3,
+          "max": 10,
+          "max_length": 10,
+          "avg": 5.86,
+          "avg_length": 5.86,
+          "stddev": 1.5571276327412809,
+          "stddev_length": 1.5571276327412809,
+          "duplicates": 40,
+          "duplicates_p": 0.4,
+          "non_duplicates": 60,
+          "non_duplicates_p": 0.6,
+          "topk": {
+            "values": [
+              "Adam",
+              "Shirley",
+              "Michael",
+              "Kathleen",
+              "Jennifer",
+              "Virginia",
+              "Willie",
+              "Benjamin",
+              "Lisa",
+              "Christina",
+              "Jane",
+              "Katherine",
+              "Norma",
+              "Anne",
+              "Paul",
+              "David",
+              "Phillip",
+              "Kathryn",
+              "Harry",
+              "Shawn",
+              "Sarah",
+              "Martin",
+              "Frank",
+              "Fred",
+              "Amy",
+              "Amanda",
+              "Johnny",
+              "Anna",
+              "Sean",
+              "Victor",
+              "Aaron",
+              "Thomas",
+              "Sara",
+              "Harold",
+              "Dennis",
+              "Louise",
+              "Maria",
+              "Diana",
+              "Marie",
+              "Howard",
+              "Laura",
+              "Rose",
+              "Edward",
+              "Jesse",
+              "Janet",
+              "Helen",
+              "Gerald",
+              "Barbara",
+              "Jack",
+              "Theresa"
+            ],
+            "counts": [
+              3,
+              3,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1
+            ]
+          },
+          "histogram": {
+            "labels": [
+              "3",
+              "4",
+              "5",
+              "6",
+              "7",
+              "8",
+              "9",
+              "10"
+            ],
+            "counts": [
+              1,
+              22,
+              24,
+              20,
+              16,
+              11,
+              5,
+              1
+            ],
+            "bin_edges": [
+              3,
+              4,
+              5,
+              6,
+              7,
+              8,
+              9,
+              10,
+              11
+            ]
+          },
+          "histogram_length": {
+            "labels": [
+              "3",
+              "4",
+              "5",
+              "6",
+              "7",
+              "8",
+              "9",
+              "10"
+            ],
+            "counts": [
+              1,
+              22,
+              24,
+              20,
+              16,
+              11,
+              5,
+              1
+            ],
+            "bin_edges": [
+              3,
+              4,
+              5,
+              6,
+              7,
+              8,
+              9,
+              10,
+              11
+            ]
+          },
+          "profile_duration": "0.02",
+          "elapsed_milli": 23,
+          "description": "Customer's first name. PII."
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "string",
+          "schema_type": "VARCHAR",
+          "total": 100,
+          "samples": 100,
+          "samples_p": 1,
+          "non_nulls": 100,
+          "non_nulls_p": 1,
+          "nulls": 0,
+          "nulls_p": 0,
+          "valids": 100,
+          "valids_p": 1,
+          "invalids": 0,
+          "invalids_p": 0,
+          "zero_length": 0,
+          "zero_length_p": 0,
+          "non_zero_length": 100,
+          "non_zero_length_p": 1,
+          "distinct": 19,
+          "distinct_p": 0.19,
+          "min": 2,
+          "min_length": 2,
+          "max": 2,
+          "max_length": 2,
+          "avg": 2,
+          "avg_length": 2,
+          "stddev": 0,
+          "stddev_length": 0,
+          "duplicates": 98,
+          "duplicates_p": 0.98,
+          "non_duplicates": 2,
+          "non_duplicates_p": 0.02,
+          "topk": {
+            "values": [
+              "R.",
+              "H.",
+              "W.",
+              "M.",
+              "P.",
+              "C.",
+              "A.",
+              "F.",
+              "B.",
+              "K.",
+              "G.",
+              "O.",
+              "S.",
+              "D.",
+              "J.",
+              "T.",
+              "N.",
+              "E.",
+              "L."
+            ],
+            "counts": [
+              13,
+              11,
+              11,
+              8,
+              7,
+              7,
+              6,
+              5,
+              5,
+              4,
+              4,
+              4,
+              3,
+              3,
+              3,
+              2,
+              2,
+              1,
+              1
+            ]
+          },
+          "histogram": {
+            "labels": [
+              "2"
+            ],
+            "counts": [
+              100
+            ],
+            "bin_edges": [
+              2,
+              3
+            ]
+          },
+          "histogram_length": {
+            "labels": [
+              "2"
+            ],
+            "counts": [
+              100
+            ],
+            "bin_edges": [
+              2,
+              3
+            ]
+          },
+          "profile_duration": "0.02",
+          "elapsed_milli": 20,
+          "description": "Customer's last name. PII."
+        },
+        "first_order": {
+          "name": "first_order",
+          "type": "datetime",
+          "schema_type": "DATE",
+          "total": 100,
+          "samples": 100,
+          "samples_p": 1,
+          "non_nulls": 62,
+          "non_nulls_p": 0.62,
+          "nulls": 38,
+          "nulls_p": 0.38,
+          "valids": 62,
+          "valids_p": 0.62,
+          "invalids": 0,
+          "invalids_p": 0,
+          "distinct": 46,
+          "distinct_p": 0.7419354838709677,
+          "min": "2023-03-14",
+          "max": "2023-06-18",
+          "duplicates": 29,
+          "duplicates_p": 0.46774193548387094,
+          "non_duplicates": 33,
+          "non_duplicates_p": 0.532258064516129,
+          "histogram": {
+            "labels": [
+              "2023-03-01 - 2023-04-01",
+              "2023-04-01 - 2023-05-01",
+              "2023-05-01 - 2023-06-01",
+              "2023-06-01 - 2023-07-01"
+            ],
+            "counts": [
+              17,
+              19,
+              15,
+              11
+            ],
+            "bin_edges": [
+              "2023-03-01",
+              "2023-04-01",
+              "2023-05-01",
+              "2023-06-01",
+              "2023-07-01"
+            ]
+          },
+          "profile_duration": "0.02",
+          "elapsed_milli": 20,
+          "description": "Date (UTC) of a customer's first order"
+        },
+        "most_recent_order": {
+          "name": "most_recent_order",
+          "type": "datetime",
+          "schema_type": "DATE",
+          "total": 100,
+          "samples": 100,
+          "samples_p": 1,
+          "non_nulls": 62,
+          "non_nulls_p": 0.62,
+          "nulls": 38,
+          "nulls_p": 0.38,
+          "valids": 62,
+          "valids_p": 0.62,
+          "invalids": 0,
+          "invalids_p": 0,
+          "distinct": 52,
+          "distinct_p": 0.8387096774193549,
+          "min": "2023-03-22",
+          "max": "2023-06-20",
+          "duplicates": 18,
+          "duplicates_p": 0.2903225806451613,
+          "non_duplicates": 44,
+          "non_duplicates_p": 0.7096774193548387,
+          "histogram": {
+            "labels": [
+              "2023-03-01 - 2023-04-01",
+              "2023-04-01 - 2023-05-01",
+              "2023-05-01 - 2023-06-01",
+              "2023-06-01 - 2023-07-01"
+            ],
+            "counts": [
+              6,
+              14,
+              23,
+              19
+            ],
+            "bin_edges": [
+              "2023-03-01",
+              "2023-04-01",
+              "2023-05-01",
+              "2023-06-01",
+              "2023-07-01"
+            ]
+          },
+          "profile_duration": "0.02",
+          "elapsed_milli": 20,
+          "description": "Date (UTC) of a customer's most recent order"
+        },
+        "number_of_orders": {
+          "name": "number_of_orders",
+          "type": "integer",
+          "schema_type": "BIGINT",
+          "total": 100,
+          "samples": 100,
+          "samples_p": 1,
+          "non_nulls": 62,
+          "non_nulls_p": 0.62,
+          "nulls": 38,
+          "nulls_p": 0.38,
+          "valids": 62,
+          "valids_p": 0.62,
+          "invalids": 0,
+          "invalids_p": 0,
+          "zeros": 0,
+          "zeros_p": 0,
+          "negatives": 0,
+          "negatives_p": 0,
+          "positives": 62,
+          "positives_p": 0.62,
+          "distinct": 4,
+          "distinct_p": 0.06451612903225806,
+          "min": 1,
+          "max": 5,
+          "sum": 99,
+          "avg": 1.596774193548387,
+          "stddev": 0.7779687173818423,
+          "duplicates": 61,
+          "duplicates_p": 0.9838709677419355,
+          "non_duplicates": 1,
+          "non_duplicates_p": 0.016129032258064516,
+          "histogram": {
+            "labels": [
+              "1",
+              "2",
+              "3",
+              "4",
+              "5"
+            ],
+            "counts": [
+              33,
+              23,
+              5,
+              0,
+              1
+            ],
+            "bin_edges": [
+              1,
+              2,
+              3,
+              4,
+              5,
+              6
+            ]
+          },
+          "p5": 1,
+          "p25": 1,
+          "p50": 1,
+          "p75": 2,
+          "p95": 3,
+          "topk": {
+            "values": [
+              "1",
+              "2",
+              "3",
+              "5"
+            ],
+            "counts": [
+              33,
+              23,
+              5,
+              1
+            ]
+          },
+          "profile_duration": "0.03",
+          "elapsed_milli": 27,
+          "description": "Count of the number of orders a customer has placed"
+        },
+        "customer_lifetime_value": {
+          "name": "customer_lifetime_value",
+          "type": "integer",
+          "schema_type": "BIGINT",
+          "total": 100,
+          "samples": 100,
+          "samples_p": 1,
+          "non_nulls": 62,
+          "non_nulls_p": 0.62,
+          "nulls": 38,
+          "nulls_p": 0.38,
+          "valids": 62,
+          "valids_p": 0.62,
+          "invalids": 0,
+          "invalids_p": 0,
+          "zeros": 0,
+          "zeros_p": 0,
+          "negatives": 0,
+          "negatives_p": 0,
+          "positives": 62,
+          "positives_p": 0.62,
+          "distinct": 35,
+          "distinct_p": 0.5645161290322581,
+          "min": 1,
+          "max": 99,
+          "sum": 1672,
+          "avg": 26.967741935483872,
+          "stddev": 18.812245525263663,
+          "duplicates": 44,
+          "duplicates_p": 0.7096774193548387,
+          "non_duplicates": 18,
+          "non_duplicates_p": 0.2903225806451613,
+          "histogram": {
+            "labels": [
+              "1 _ 3",
+              "3 _ 5",
+              "5 _ 7",
+              "7 _ 9",
+              "9 _ 11",
+              "11 _ 13",
+              "13 _ 15",
+              "15 _ 17",
+              "17 _ 19",
+              "19 _ 21",
+              "21 _ 23",
+              "23 _ 25",
+              "25 _ 27",
+              "27 _ 29",
+              "29 _ 31",
+              "31 _ 33",
+              "33 _ 35",
+              "35 _ 37",
+              "37 _ 39",
+              "39 _ 41",
+              "41 _ 43",
+              "43 _ 45",
+              "45 _ 47",
+              "47 _ 49",
+              "49 _ 51",
+              "51 _ 53",
+              "53 _ 55",
+              "55 _ 57",
+              "57 _ 59",
+              "59 _ 61",
+              "61 _ 63",
+              "63 _ 65",
+              "65 _ 67",
+              "67 _ 69",
+              "69 _ 71",
+              "71 _ 73",
+              "73 _ 75",
+              "75 _ 77",
+              "77 _ 79",
+              "79 _ 81",
+              "81 _ 83",
+              "83 _ 85",
+              "85 _ 87",
+              "87 _ 89",
+              "89 _ 91",
+              "91 _ 93",
+              "93 _ 95",
+              "95 _ 97",
+              "97 _ 99",
+              "99 _ 101"
+            ],
+            "counts": [
+              3,
+              6,
+              0,
+              3,
+              2,
+              1,
+              2,
+              3,
+              2,
+              0,
+              1,
+              5,
+              3,
+              5,
+              6,
+              1,
+              3,
+              2,
+              0,
+              2,
+              0,
+              3,
+              1,
+              1,
+              0,
+              1,
+              1,
+              0,
+              2,
+              0,
+              0,
+              1,
+              1,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              1
+            ],
+            "bin_edges": [
+              1,
+              3,
+              5,
+              7,
+              9,
+              11,
+              13,
+              15,
+              17,
+              19,
+              21,
+              23,
+              25,
+              27,
+              29,
+              31,
+              33,
+              35,
+              37,
+              39,
+              41,
+              43,
+              45,
+              47,
+              49,
+              51,
+              53,
+              55,
+              57,
+              59,
+              61,
+              63,
+              65,
+              67,
+              69,
+              71,
+              73,
+              75,
+              77,
+              79,
+              81,
+              83,
+              85,
+              87,
+              89,
+              91,
+              93,
+              95,
+              97,
+              99,
+              101
+            ]
+          },
+          "p5": 3,
+          "p25": 14,
+          "p50": 26,
+          "p75": 36,
+          "p95": 60,
+          "topk": {
+            "values": [
+              "3",
+              "27",
+              "8",
+              "23",
+              "26",
+              "29",
+              "30",
+              "2",
+              "10",
+              "14",
+              "15",
+              "24",
+              "33",
+              "36",
+              "39",
+              "44",
+              "57",
+              "1",
+              "4",
+              "12",
+              "16",
+              "17",
+              "18",
+              "22",
+              "28",
+              "32",
+              "34",
+              "43",
+              "45",
+              "47",
+              "52",
+              "54",
+              "64",
+              "65",
+              "99"
+            ],
+            "counts": [
+              5,
+              4,
+              3,
+              3,
+              3,
+              3,
+              3,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1
+            ]
+          },
+          "profile_duration": "0.03",
+          "elapsed_milli": 30
+        }
+      },
+      "profile_duration": "0.03",
+      "elapsed_milli": 30,
+      "description": "This table has basic information about a customer, as well as some derived facts based on a customer's orders"
+    },
+    "stg_customers": {
+      "name": "stg_customers",
+      "row_count": 100,
+      "samples": 100,
+      "samples_p": 1,
+      "col_count": 3,
+      "columns": {
+        "customer_id": {
+          "name": "customer_id",
+          "type": "integer",
+          "schema_type": "INTEGER",
+          "total": 100,
+          "samples": 100,
+          "samples_p": 1,
+          "non_nulls": 100,
+          "non_nulls_p": 1,
+          "nulls": 0,
+          "nulls_p": 0,
+          "valids": 100,
+          "valids_p": 1,
+          "invalids": 0,
+          "invalids_p": 0,
+          "zeros": 0,
+          "zeros_p": 0,
+          "negatives": 0,
+          "negatives_p": 0,
+          "positives": 100,
+          "positives_p": 1,
+          "distinct": 100,
+          "distinct_p": 1,
+          "min": 1,
+          "max": 100,
+          "sum": 5050,
+          "avg": 50.5,
+          "stddev": 29.011491975882016,
+          "duplicates": 0,
+          "duplicates_p": 0,
+          "non_duplicates": 100,
+          "non_duplicates_p": 1,
+          "histogram": {
+            "labels": [
+              "1 _ 3",
+              "3 _ 5",
+              "5 _ 7",
+              "7 _ 9",
+              "9 _ 11",
+              "11 _ 13",
+              "13 _ 15",
+              "15 _ 17",
+              "17 _ 19",
+              "19 _ 21",
+              "21 _ 23",
+              "23 _ 25",
+              "25 _ 27",
+              "27 _ 29",
+              "29 _ 31",
+              "31 _ 33",
+              "33 _ 35",
+              "35 _ 37",
+              "37 _ 39",
+              "39 _ 41",
+              "41 _ 43",
+              "43 _ 45",
+              "45 _ 47",
+              "47 _ 49",
+              "49 _ 51",
+              "51 _ 53",
+              "53 _ 55",
+              "55 _ 57",
+              "57 _ 59",
+              "59 _ 61",
+              "61 _ 63",
+              "63 _ 65",
+              "65 _ 67",
+              "67 _ 69",
+              "69 _ 71",
+              "71 _ 73",
+              "73 _ 75",
+              "75 _ 77",
+              "77 _ 79",
+              "79 _ 81",
+              "81 _ 83",
+              "83 _ 85",
+              "85 _ 87",
+              "87 _ 89",
+              "89 _ 91",
+              "91 _ 93",
+              "93 _ 95",
+              "95 _ 97",
+              "97 _ 99",
+              "99 _ 101"
+            ],
+            "counts": [
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2
+            ],
+            "bin_edges": [
+              1,
+              3,
+              5,
+              7,
+              9,
+              11,
+              13,
+              15,
+              17,
+              19,
+              21,
+              23,
+              25,
+              27,
+              29,
+              31,
+              33,
+              35,
+              37,
+              39,
+              41,
+              43,
+              45,
+              47,
+              49,
+              51,
+              53,
+              55,
+              57,
+              59,
+              61,
+              63,
+              65,
+              67,
+              69,
+              71,
+              73,
+              75,
+              77,
+              79,
+              81,
+              83,
+              85,
+              87,
+              89,
+              91,
+              93,
+              95,
+              97,
+              99,
+              101
+            ]
+          },
+          "p5": 6,
+          "p25": 26,
+          "p50": 50,
+          "p75": 76,
+          "p95": 95,
+          "topk": {
+            "values": [
+              "1",
+              "2",
+              "3",
+              "4",
+              "5",
+              "6",
+              "7",
+              "8",
+              "9",
+              "10",
+              "11",
+              "12",
+              "13",
+              "14",
+              "15",
+              "16",
+              "17",
+              "18",
+              "19",
+              "20",
+              "21",
+              "22",
+              "23",
+              "24",
+              "25",
+              "26",
+              "27",
+              "28",
+              "29",
+              "30",
+              "31",
+              "32",
+              "33",
+              "34",
+              "35",
+              "36",
+              "37",
+              "38",
+              "39",
+              "40",
+              "41",
+              "42",
+              "43",
+              "44",
+              "45",
+              "46",
+              "47",
+              "48",
+              "49",
+              "50"
+            ],
+            "counts": [
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1
+            ]
+          },
+          "profile_duration": "0.01",
+          "elapsed_milli": 13
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "string",
+          "schema_type": "VARCHAR",
+          "total": 100,
+          "samples": 100,
+          "samples_p": 1,
+          "non_nulls": 100,
+          "non_nulls_p": 1,
+          "nulls": 0,
+          "nulls_p": 0,
+          "valids": 100,
+          "valids_p": 1,
+          "invalids": 0,
+          "invalids_p": 0,
+          "zero_length": 0,
+          "zero_length_p": 0,
+          "non_zero_length": 100,
+          "non_zero_length_p": 1,
+          "distinct": 79,
+          "distinct_p": 0.79,
+          "min": 3,
+          "min_length": 3,
+          "max": 10,
+          "max_length": 10,
+          "avg": 5.86,
+          "avg_length": 5.86,
+          "stddev": 1.5571276327412809,
+          "stddev_length": 1.5571276327412809,
+          "duplicates": 40,
+          "duplicates_p": 0.4,
+          "non_duplicates": 60,
+          "non_duplicates_p": 0.6,
+          "topk": {
+            "values": [
+              "Shirley",
+              "Adam",
+              "Michael",
+              "Kathleen",
+              "Katherine",
+              "Jennifer",
+              "Virginia",
+              "Willie",
+              "David",
+              "Benjamin",
+              "Lisa",
+              "Christina",
+              "Jane",
+              "Norma",
+              "Anne",
+              "Paul",
+              "Kathryn",
+              "Harry",
+              "Phillip",
+              "Shawn",
+              "Jimmy",
+              "Sarah",
+              "Martin",
+              "Frank",
+              "Henry",
+              "Fred",
+              "Amy",
+              "Steve",
+              "Teresa",
+              "Amanda",
+              "Kimberly",
+              "Johnny",
+              "Anna",
+              "Sean",
+              "Mildred",
+              "Victor",
+              "Aaron",
+              "Thomas",
+              "Sara",
+              "Harold",
+              "Dennis",
+              "Louise",
+              "Maria",
+              "Diana",
+              "Kelly",
+              "Scott",
+              "Marie",
+              "Lillian",
+              "Judy",
+              "Billy"
+            ],
+            "counts": [
+              3,
+              3,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1
+            ]
+          },
+          "histogram": {
+            "labels": [
+              "3",
+              "4",
+              "5",
+              "6",
+              "7",
+              "8",
+              "9",
+              "10"
+            ],
+            "counts": [
+              1,
+              22,
+              24,
+              20,
+              16,
+              11,
+              5,
+              1
+            ],
+            "bin_edges": [
+              3,
+              4,
+              5,
+              6,
+              7,
+              8,
+              9,
+              10,
+              11
+            ]
+          },
+          "histogram_length": {
+            "labels": [
+              "3",
+              "4",
+              "5",
+              "6",
+              "7",
+              "8",
+              "9",
+              "10"
+            ],
+            "counts": [
+              1,
+              22,
+              24,
+              20,
+              16,
+              11,
+              5,
+              1
+            ],
+            "bin_edges": [
+              3,
+              4,
+              5,
+              6,
+              7,
+              8,
+              9,
+              10,
+              11
+            ]
+          },
+          "profile_duration": "0.01",
+          "elapsed_milli": 12
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "string",
+          "schema_type": "VARCHAR",
+          "total": 100,
+          "samples": 100,
+          "samples_p": 1,
+          "non_nulls": 100,
+          "non_nulls_p": 1,
+          "nulls": 0,
+          "nulls_p": 0,
+          "valids": 100,
+          "valids_p": 1,
+          "invalids": 0,
+          "invalids_p": 0,
+          "zero_length": 0,
+          "zero_length_p": 0,
+          "non_zero_length": 100,
+          "non_zero_length_p": 1,
+          "distinct": 19,
+          "distinct_p": 0.19,
+          "min": 2,
+          "min_length": 2,
+          "max": 2,
+          "max_length": 2,
+          "avg": 2,
+          "avg_length": 2,
+          "stddev": 0,
+          "stddev_length": 0,
+          "duplicates": 98,
+          "duplicates_p": 0.98,
+          "non_duplicates": 2,
+          "non_duplicates_p": 0.02,
+          "topk": {
+            "values": [
+              "R.",
+              "W.",
+              "H.",
+              "M.",
+              "P.",
+              "C.",
+              "A.",
+              "F.",
+              "B.",
+              "K.",
+              "G.",
+              "O.",
+              "S.",
+              "D.",
+              "J.",
+              "T.",
+              "N.",
+              "L.",
+              "E."
+            ],
+            "counts": [
+              13,
+              11,
+              11,
+              8,
+              7,
+              7,
+              6,
+              5,
+              5,
+              4,
+              4,
+              4,
+              3,
+              3,
+              3,
+              2,
+              2,
+              1,
+              1
+            ]
+          },
+          "histogram": {
+            "labels": [
+              "2"
+            ],
+            "counts": [
+              100
+            ],
+            "bin_edges": [
+              2,
+              3
+            ]
+          },
+          "histogram_length": {
+            "labels": [
+              "2"
+            ],
+            "counts": [
+              100
+            ],
+            "bin_edges": [
+              2,
+              3
+            ]
+          },
+          "profile_duration": "0.01",
+          "elapsed_milli": 12
+        }
+      },
+      "profile_duration": "0.01",
+      "elapsed_milli": 13
+    },
+    "stg_payments": {
+      "name": "stg_payments",
+      "row_count": 113,
+      "samples": 113,
+      "samples_p": 1,
+      "col_count": 4,
+      "columns": {
+        "payment_id": {
+          "name": "payment_id",
+          "type": "integer",
+          "schema_type": "INTEGER",
+          "total": 113,
+          "samples": 113,
+          "samples_p": 1,
+          "non_nulls": 113,
+          "non_nulls_p": 1,
+          "nulls": 0,
+          "nulls_p": 0,
+          "valids": 113,
+          "valids_p": 1,
+          "invalids": 0,
+          "invalids_p": 0,
+          "zeros": 0,
+          "zeros_p": 0,
+          "negatives": 0,
+          "negatives_p": 0,
+          "positives": 113,
+          "positives_p": 1,
+          "distinct": 113,
+          "distinct_p": 1,
+          "min": 1,
+          "max": 113,
+          "sum": 6441,
+          "avg": 57,
+          "stddev": 32.76430985081175,
+          "duplicates": 0,
+          "duplicates_p": 0,
+          "non_duplicates": 113,
+          "non_duplicates_p": 1,
+          "histogram": {
+            "labels": [
+              "1 _ 4",
+              "4 _ 7",
+              "7 _ 10",
+              "10 _ 13",
+              "13 _ 16",
+              "16 _ 19",
+              "19 _ 22",
+              "22 _ 25",
+              "25 _ 28",
+              "28 _ 31",
+              "31 _ 34",
+              "34 _ 37",
+              "37 _ 40",
+              "40 _ 43",
+              "43 _ 46",
+              "46 _ 49",
+              "49 _ 52",
+              "52 _ 55",
+              "55 _ 58",
+              "58 _ 61",
+              "61 _ 64",
+              "64 _ 67",
+              "67 _ 70",
+              "70 _ 73",
+              "73 _ 76",
+              "76 _ 79",
+              "79 _ 82",
+              "82 _ 85",
+              "85 _ 88",
+              "88 _ 91",
+              "91 _ 94",
+              "94 _ 97",
+              "97 _ 100",
+              "100 _ 103",
+              "103 _ 106",
+              "106 _ 109",
+              "109 _ 112",
+              "112 _ 115"
+            ],
+            "counts": [
+              3,
+              3,
+              3,
+              3,
+              3,
+              3,
+              3,
+              3,
+              3,
+              3,
+              3,
+              3,
+              3,
+              3,
+              3,
+              3,
+              3,
+              3,
+              3,
+              3,
+              3,
+              3,
+              3,
+              3,
+              3,
+              3,
+              3,
+              3,
+              3,
+              3,
+              3,
+              3,
+              3,
+              3,
+              3,
+              3,
+              3,
+              2
+            ],
+            "bin_edges": [
+              1,
+              4,
+              7,
+              10,
+              13,
+              16,
+              19,
+              22,
+              25,
+              28,
+              31,
+              34,
+              37,
+              40,
+              43,
+              46,
+              49,
+              52,
+              55,
+              58,
+              61,
+              64,
+              67,
+              70,
+              73,
+              76,
+              79,
+              82,
+              85,
+              88,
+              91,
+              94,
+              97,
+              100,
+              103,
+              106,
+              109,
+              112,
+              115
+            ]
+          },
+          "p5": 6,
+          "p25": 29,
+          "p50": 57,
+          "p75": 85,
+          "p95": 108,
+          "topk": {
+            "values": [
+              "1",
+              "2",
+              "3",
+              "4",
+              "5",
+              "6",
+              "7",
+              "8",
+              "9",
+              "10",
+              "11",
+              "12",
+              "13",
+              "14",
+              "15",
+              "16",
+              "17",
+              "18",
+              "19",
+              "20",
+              "21",
+              "22",
+              "23",
+              "24",
+              "25",
+              "26",
+              "27",
+              "28",
+              "29",
+              "30",
+              "31",
+              "32",
+              "33",
+              "34",
+              "35",
+              "36",
+              "37",
+              "38",
+              "39",
+              "40",
+              "41",
+              "42",
+              "43",
+              "44",
+              "45",
+              "46",
+              "47",
+              "48",
+              "49",
+              "50"
+            ],
+            "counts": [
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1
+            ]
+          },
+          "profile_duration": "0.02",
+          "elapsed_milli": 20
+        },
+        "order_id": {
+          "name": "order_id",
+          "type": "integer",
+          "schema_type": "INTEGER",
+          "total": 113,
+          "samples": 113,
+          "samples_p": 1,
+          "non_nulls": 113,
+          "non_nulls_p": 1,
+          "nulls": 0,
+          "nulls_p": 0,
+          "valids": 113,
+          "valids_p": 1,
+          "invalids": 0,
+          "invalids_p": 0,
+          "zeros": 0,
+          "zeros_p": 0,
+          "negatives": 0,
+          "negatives_p": 0,
+          "positives": 113,
+          "positives_p": 1,
+          "distinct": 99,
+          "distinct_p": 0.8761061946902655,
+          "min": 1,
+          "max": 99,
+          "sum": 5654,
+          "avg": 50.0353982300885,
+          "stddev": 28.54317819535489,
+          "duplicates": 27,
+          "duplicates_p": 0.23893805309734514,
+          "non_duplicates": 86,
+          "non_duplicates_p": 0.7610619469026548,
+          "histogram": {
+            "labels": [
+              "1 _ 3",
+              "3 _ 5",
+              "5 _ 7",
+              "7 _ 9",
+              "9 _ 11",
+              "11 _ 13",
+              "13 _ 15",
+              "15 _ 17",
+              "17 _ 19",
+              "19 _ 21",
+              "21 _ 23",
+              "23 _ 25",
+              "25 _ 27",
+              "27 _ 29",
+              "29 _ 31",
+              "31 _ 33",
+              "33 _ 35",
+              "35 _ 37",
+              "37 _ 39",
+              "39 _ 41",
+              "41 _ 43",
+              "43 _ 45",
+              "45 _ 47",
+              "47 _ 49",
+              "49 _ 51",
+              "51 _ 53",
+              "53 _ 55",
+              "55 _ 57",
+              "57 _ 59",
+              "59 _ 61",
+              "61 _ 63",
+              "63 _ 65",
+              "65 _ 67",
+              "67 _ 69",
+              "69 _ 71",
+              "71 _ 73",
+              "73 _ 75",
+              "75 _ 77",
+              "77 _ 79",
+              "79 _ 81",
+              "81 _ 83",
+              "83 _ 85",
+              "85 _ 87",
+              "87 _ 89",
+              "89 _ 91",
+              "91 _ 93",
+              "93 _ 95",
+              "95 _ 97",
+              "97 _ 99",
+              "99 _ 101"
+            ],
+            "counts": [
+              2,
+              2,
+              2,
+              2,
+              3,
+              2,
+              3,
+              2,
+              3,
+              2,
+              2,
+              2,
+              4,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              3,
+              3,
+              3,
+              2,
+              3,
+              2,
+              2,
+              2,
+              2,
+              3,
+              2,
+              2,
+              2,
+              2,
+              3,
+              3,
+              2,
+              2,
+              2,
+              3,
+              2,
+              3,
+              2,
+              2,
+              2,
+              1
+            ],
+            "bin_edges": [
+              1,
+              3,
+              5,
+              7,
+              9,
+              11,
+              13,
+              15,
+              17,
+              19,
+              21,
+              23,
+              25,
+              27,
+              29,
+              31,
+              33,
+              35,
+              37,
+              39,
+              41,
+              43,
+              45,
+              47,
+              49,
+              51,
+              53,
+              55,
+              57,
+              59,
+              61,
+              63,
+              65,
+              67,
+              69,
+              71,
+              73,
+              75,
+              77,
+              79,
+              81,
+              83,
+              85,
+              87,
+              89,
+              91,
+              93,
+              95,
+              97,
+              99,
+              101
+            ]
+          },
+          "p5": 6,
+          "p25": 25,
+          "p50": 51,
+          "p75": 75,
+          "p95": 94,
+          "topk": {
+            "values": [
+              "25",
+              "9",
+              "13",
+              "18",
+              "49",
+              "51",
+              "54",
+              "58",
+              "67",
+              "77",
+              "79",
+              "87",
+              "92",
+              "1",
+              "2",
+              "3",
+              "4",
+              "5",
+              "6",
+              "7",
+              "8",
+              "10",
+              "11",
+              "12",
+              "14",
+              "15",
+              "16",
+              "17",
+              "19",
+              "20",
+              "21",
+              "22",
+              "23",
+              "24",
+              "26",
+              "27",
+              "28",
+              "29",
+              "30",
+              "31",
+              "32",
+              "33",
+              "34",
+              "35",
+              "36",
+              "37",
+              "38",
+              "39",
+              "40",
+              "41"
+            ],
+            "counts": [
+              3,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1
+            ]
+          },
+          "profile_duration": "0.02",
+          "elapsed_milli": 21
+        },
+        "payment_method": {
+          "name": "payment_method",
+          "type": "string",
+          "schema_type": "VARCHAR",
+          "total": 113,
+          "samples": 113,
+          "samples_p": 1,
+          "non_nulls": 113,
+          "non_nulls_p": 1,
+          "nulls": 0,
+          "nulls_p": 0,
+          "valids": 113,
+          "valids_p": 1,
+          "invalids": 0,
+          "invalids_p": 0,
+          "zero_length": 0,
+          "zero_length_p": 0,
+          "non_zero_length": 113,
+          "non_zero_length_p": 1,
+          "distinct": 4,
+          "distinct_p": 0.035398230088495575,
+          "min": 6,
+          "min_length": 6,
+          "max": 13,
+          "max_length": 13,
+          "avg": 10.79646017699115,
+          "avg_length": 10.79646017699115,
+          "stddev": 2.113558661338224,
+          "stddev_length": 2.113558661338224,
+          "duplicates": 113,
+          "duplicates_p": 1,
+          "non_duplicates": 0,
+          "non_duplicates_p": 0,
+          "topk": {
+            "values": [
+              "credit_card",
+              "bank_transfer",
+              "coupon",
+              "gift_card"
+            ],
+            "counts": [
+              55,
+              33,
+              13,
+              12
+            ]
+          },
+          "histogram": {
+            "labels": [
+              "6",
+              "7",
+              "8",
+              "9",
+              "10",
+              "11",
+              "12",
+              "13"
+            ],
+            "counts": [
+              13,
+              0,
+              0,
+              12,
+              0,
+              55,
+              0,
+              33
+            ],
+            "bin_edges": [
+              6,
+              7,
+              8,
+              9,
+              10,
+              11,
+              12,
+              13,
+              14
+            ]
+          },
+          "histogram_length": {
+            "labels": [
+              "6",
+              "7",
+              "8",
+              "9",
+              "10",
+              "11",
+              "12",
+              "13"
+            ],
+            "counts": [
+              13,
+              0,
+              0,
+              12,
+              0,
+              55,
+              0,
+              33
+            ],
+            "bin_edges": [
+              6,
+              7,
+              8,
+              9,
+              10,
+              11,
+              12,
+              13,
+              14
+            ]
+          },
+          "profile_duration": "0.02",
+          "elapsed_milli": 20
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "schema_type": "INTEGER",
+          "total": 113,
+          "samples": 113,
+          "samples_p": 1,
+          "non_nulls": 113,
+          "non_nulls_p": 1,
+          "nulls": 0,
+          "nulls_p": 0,
+          "valids": 113,
+          "valids_p": 1,
+          "invalids": 0,
+          "invalids_p": 0,
+          "zeros": 3,
+          "zeros_p": 0.02654867256637168,
+          "negatives": 0,
+          "negatives_p": 0,
+          "positives": 110,
+          "positives_p": 0.9734513274336283,
+          "distinct": 30,
+          "distinct_p": 0.26548672566371684,
+          "min": 0,
+          "max": 30,
+          "sum": 1672,
+          "avg": 14.79646017699115,
+          "stddev": 9.19836873351873,
+          "duplicates": 110,
+          "duplicates_p": 0.9734513274336283,
+          "non_duplicates": 3,
+          "non_duplicates_p": 0.02654867256637168,
+          "histogram": {
+            "labels": [
+              "0",
+              "1",
+              "2",
+              "3",
+              "4",
+              "5",
+              "6",
+              "7",
+              "8",
+              "9",
+              "10",
+              "11",
+              "12",
+              "13",
+              "14",
+              "15",
+              "16",
+              "17",
+              "18",
+              "19",
+              "20",
+              "21",
+              "22",
+              "23",
+              "24",
+              "25",
+              "26",
+              "27",
+              "28",
+              "29",
+              "30"
+            ],
+            "counts": [
+              3,
+              4,
+              6,
+              6,
+              3,
+              4,
+              4,
+              1,
+              5,
+              3,
+              3,
+              2,
+              3,
+              1,
+              4,
+              5,
+              4,
+              5,
+              4,
+              6,
+              2,
+              0,
+              5,
+              6,
+              2,
+              2,
+              8,
+              1,
+              2,
+              6,
+              3
+            ],
+            "bin_edges": [
+              0,
+              1,
+              2,
+              3,
+              4,
+              5,
+              6,
+              7,
+              8,
+              9,
+              10,
+              11,
+              12,
+              13,
+              14,
+              15,
+              16,
+              17,
+              18,
+              19,
+              20,
+              21,
+              22,
+              23,
+              24,
+              25,
+              26,
+              27,
+              28,
+              29,
+              30,
+              31
+            ]
+          },
+          "p5": 1,
+          "p25": 6,
+          "p50": 15,
+          "p75": 23,
+          "p95": 29,
+          "topk": {
+            "values": [
+              "26",
+              "23",
+              "3",
+              "2",
+              "19",
+              "29",
+              "17",
+              "22",
+              "8",
+              "15",
+              "1",
+              "6",
+              "16",
+              "5",
+              "14",
+              "18",
+              "10",
+              "0",
+              "12",
+              "30",
+              "9",
+              "4",
+              "20",
+              "25",
+              "11",
+              "28",
+              "24",
+              "27",
+              "13",
+              "7"
+            ],
+            "counts": [
+              8,
+              6,
+              6,
+              6,
+              6,
+              6,
+              5,
+              5,
+              5,
+              5,
+              4,
+              4,
+              4,
+              4,
+              4,
+              4,
+              3,
+              3,
+              3,
+              3,
+              3,
+              3,
+              2,
+              2,
+              2,
+              2,
+              2,
+              1,
+              1,
+              1
+            ]
+          },
+          "profile_duration": "0.02",
+          "elapsed_milli": 21
+        }
+      },
+      "profile_duration": "0.02",
+      "elapsed_milli": 21
+    },
+    "stg_orders": {
+      "name": "stg_orders",
+      "row_count": 99,
+      "samples": 99,
+      "samples_p": 1,
+      "col_count": 4,
+      "columns": {
+        "order_id": {
+          "name": "order_id",
+          "type": "integer",
+          "schema_type": "INTEGER",
+          "total": 99,
+          "samples": 99,
+          "samples_p": 1,
+          "non_nulls": 99,
+          "non_nulls_p": 1,
+          "nulls": 0,
+          "nulls_p": 0,
+          "valids": 99,
+          "valids_p": 1,
+          "invalids": 0,
+          "invalids_p": 0,
+          "zeros": 0,
+          "zeros_p": 0,
+          "negatives": 0,
+          "negatives_p": 0,
+          "positives": 99,
+          "positives_p": 1,
+          "distinct": 99,
+          "distinct_p": 1,
+          "min": 1,
+          "max": 99,
+          "sum": 4950,
+          "avg": 50,
+          "stddev": 28.722813232690143,
+          "duplicates": 0,
+          "duplicates_p": 0,
+          "non_duplicates": 99,
+          "non_duplicates_p": 1,
+          "histogram": {
+            "labels": [
+              "1 _ 3",
+              "3 _ 5",
+              "5 _ 7",
+              "7 _ 9",
+              "9 _ 11",
+              "11 _ 13",
+              "13 _ 15",
+              "15 _ 17",
+              "17 _ 19",
+              "19 _ 21",
+              "21 _ 23",
+              "23 _ 25",
+              "25 _ 27",
+              "27 _ 29",
+              "29 _ 31",
+              "31 _ 33",
+              "33 _ 35",
+              "35 _ 37",
+              "37 _ 39",
+              "39 _ 41",
+              "41 _ 43",
+              "43 _ 45",
+              "45 _ 47",
+              "47 _ 49",
+              "49 _ 51",
+              "51 _ 53",
+              "53 _ 55",
+              "55 _ 57",
+              "57 _ 59",
+              "59 _ 61",
+              "61 _ 63",
+              "63 _ 65",
+              "65 _ 67",
+              "67 _ 69",
+              "69 _ 71",
+              "71 _ 73",
+              "73 _ 75",
+              "75 _ 77",
+              "77 _ 79",
+              "79 _ 81",
+              "81 _ 83",
+              "83 _ 85",
+              "85 _ 87",
+              "87 _ 89",
+              "89 _ 91",
+              "91 _ 93",
+              "93 _ 95",
+              "95 _ 97",
+              "97 _ 99",
+              "99 _ 101"
+            ],
+            "counts": [
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              1
+            ],
+            "bin_edges": [
+              1,
+              3,
+              5,
+              7,
+              9,
+              11,
+              13,
+              15,
+              17,
+              19,
+              21,
+              23,
+              25,
+              27,
+              29,
+              31,
+              33,
+              35,
+              37,
+              39,
+              41,
+              43,
+              45,
+              47,
+              49,
+              51,
+              53,
+              55,
+              57,
+              59,
+              61,
+              63,
+              65,
+              67,
+              69,
+              71,
+              73,
+              75,
+              77,
+              79,
+              81,
+              83,
+              85,
+              87,
+              89,
+              91,
+              93,
+              95,
+              97,
+              99,
+              101
+            ]
+          },
+          "p5": 5,
+          "p25": 25,
+          "p50": 50,
+          "p75": 75,
+          "p95": 95,
+          "topk": {
+            "values": [
+              "1",
+              "2",
+              "3",
+              "4",
+              "5",
+              "6",
+              "7",
+              "8",
+              "9",
+              "10",
+              "11",
+              "12",
+              "13",
+              "14",
+              "15",
+              "16",
+              "17",
+              "18",
+              "19",
+              "20",
+              "21",
+              "22",
+              "23",
+              "24",
+              "25",
+              "26",
+              "27",
+              "28",
+              "29",
+              "30",
+              "31",
+              "32",
+              "33",
+              "34",
+              "35",
+              "36",
+              "37",
+              "38",
+              "39",
+              "40",
+              "41",
+              "42",
+              "43",
+              "44",
+              "45",
+              "46",
+              "47",
+              "48",
+              "49",
+              "50"
+            ],
+            "counts": [
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1
+            ]
+          },
+          "profile_duration": "0.02",
+          "elapsed_milli": 16
+        },
+        "customer_id": {
+          "name": "customer_id",
+          "type": "integer",
+          "schema_type": "INTEGER",
+          "total": 99,
+          "samples": 99,
+          "samples_p": 1,
+          "non_nulls": 99,
+          "non_nulls_p": 1,
+          "nulls": 0,
+          "nulls_p": 0,
+          "valids": 99,
+          "valids_p": 1,
+          "invalids": 0,
+          "invalids_p": 0,
+          "zeros": 0,
+          "zeros_p": 0,
+          "negatives": 0,
+          "negatives_p": 0,
+          "positives": 99,
+          "positives_p": 1,
+          "distinct": 62,
+          "distinct_p": 0.6262626262626263,
+          "min": 1,
+          "max": 99,
+          "sum": 4777,
+          "avg": 48.25252525252525,
+          "stddev": 27.781341350472957,
+          "duplicates": 66,
+          "duplicates_p": 0.6666666666666666,
+          "non_duplicates": 33,
+          "non_duplicates_p": 0.3333333333333333,
+          "histogram": {
+            "labels": [
+              "1 _ 3",
+              "3 _ 5",
+              "5 _ 7",
+              "7 _ 9",
+              "9 _ 11",
+              "11 _ 13",
+              "13 _ 15",
+              "15 _ 17",
+              "17 _ 19",
+              "19 _ 21",
+              "21 _ 23",
+              "23 _ 25",
+              "25 _ 27",
+              "27 _ 29",
+              "29 _ 31",
+              "31 _ 33",
+              "33 _ 35",
+              "35 _ 37",
+              "37 _ 39",
+              "39 _ 41",
+              "41 _ 43",
+              "43 _ 45",
+              "45 _ 47",
+              "47 _ 49",
+              "49 _ 51",
+              "51 _ 53",
+              "53 _ 55",
+              "55 _ 57",
+              "57 _ 59",
+              "59 _ 61",
+              "61 _ 63",
+              "63 _ 65",
+              "65 _ 67",
+              "67 _ 69",
+              "69 _ 71",
+              "71 _ 73",
+              "73 _ 75",
+              "75 _ 77",
+              "77 _ 79",
+              "79 _ 81",
+              "81 _ 83",
+              "83 _ 85",
+              "85 _ 87",
+              "87 _ 89",
+              "89 _ 91",
+              "91 _ 93",
+              "93 _ 95",
+              "95 _ 97",
+              "97 _ 99",
+              "99 _ 101"
+            ],
+            "counts": [
+              3,
+              3,
+              1,
+              3,
+              1,
+              2,
+              1,
+              1,
+              1,
+              2,
+              4,
+              0,
+              4,
+              3,
+              2,
+              2,
+              2,
+              3,
+              1,
+              2,
+              3,
+              0,
+              2,
+              2,
+              2,
+              4,
+              7,
+              0,
+              2,
+              1,
+              0,
+              4,
+              3,
+              1,
+              4,
+              3,
+              0,
+              1,
+              0,
+              3,
+              0,
+              2,
+              3,
+              1,
+              3,
+              2,
+              3,
+              0,
+              0,
+              2
+            ],
+            "bin_edges": [
+              1,
+              3,
+              5,
+              7,
+              9,
+              11,
+              13,
+              15,
+              17,
+              19,
+              21,
+              23,
+              25,
+              27,
+              29,
+              31,
+              33,
+              35,
+              37,
+              39,
+              41,
+              43,
+              45,
+              47,
+              49,
+              51,
+              53,
+              55,
+              57,
+              59,
+              61,
+              63,
+              65,
+              67,
+              69,
+              71,
+              73,
+              75,
+              77,
+              79,
+              81,
+              83,
+              85,
+              87,
+              89,
+              91,
+              93,
+              95,
+              97,
+              99,
+              101
+            ]
+          },
+          "p5": 3,
+          "p25": 26,
+          "p50": 50,
+          "p75": 70,
+          "p95": 93,
+          "topk": {
+            "values": [
+              "54",
+              "3",
+              "22",
+              "51",
+              "66",
+              "71",
+              "1",
+              "8",
+              "25",
+              "26",
+              "27",
+              "30",
+              "35",
+              "42",
+              "46",
+              "47",
+              "50",
+              "53",
+              "57",
+              "63",
+              "64",
+              "69",
+              "70",
+              "79",
+              "84",
+              "85",
+              "90",
+              "94",
+              "99",
+              "2",
+              "6",
+              "7",
+              "9",
+              "11",
+              "12",
+              "13",
+              "16",
+              "18",
+              "19",
+              "20",
+              "21",
+              "28",
+              "31",
+              "32",
+              "33",
+              "34",
+              "36",
+              "38",
+              "39",
+              "40"
+            ],
+            "counts": [
+              5,
+              3,
+              3,
+              3,
+              3,
+              3,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1
+            ]
+          },
+          "profile_duration": "0.02",
+          "elapsed_milli": 17
+        },
+        "order_date": {
+          "name": "order_date",
+          "type": "datetime",
+          "schema_type": "DATE",
+          "total": 99,
+          "samples": 99,
+          "samples_p": 1,
+          "non_nulls": 99,
+          "non_nulls_p": 1,
+          "nulls": 0,
+          "nulls_p": 0,
+          "valids": 99,
+          "valids_p": 1,
+          "invalids": 0,
+          "invalids_p": 0,
+          "distinct": 69,
+          "distinct_p": 0.696969696969697,
+          "min": "2023-03-14",
+          "max": "2023-06-20",
+          "duplicates": 53,
+          "duplicates_p": 0.5353535353535354,
+          "non_duplicates": 46,
+          "non_duplicates_p": 0.46464646464646464,
+          "histogram": {
+            "labels": [
+              "2023-03-01 - 2023-04-01",
+              "2023-04-01 - 2023-05-01",
+              "2023-05-01 - 2023-06-01",
+              "2023-06-01 - 2023-07-01"
+            ],
+            "counts": [
+              17,
+              28,
+              31,
+              23
+            ],
+            "bin_edges": [
+              "2023-03-01",
+              "2023-04-01",
+              "2023-05-01",
+              "2023-06-01",
+              "2023-07-01"
+            ]
+          },
+          "profile_duration": "0.01",
+          "elapsed_milli": 14
+        },
+        "status": {
+          "name": "status",
+          "type": "string",
+          "schema_type": "VARCHAR",
+          "total": 99,
+          "samples": 99,
+          "samples_p": 1,
+          "non_nulls": 99,
+          "non_nulls_p": 1,
+          "nulls": 0,
+          "nulls_p": 0,
+          "valids": 99,
+          "valids_p": 1,
+          "invalids": 0,
+          "invalids_p": 0,
+          "zero_length": 0,
+          "zero_length_p": 0,
+          "non_zero_length": 99,
+          "non_zero_length_p": 1,
+          "distinct": 5,
+          "distinct_p": 0.050505050505050504,
+          "min": 6,
+          "min_length": 6,
+          "max": 14,
+          "max_length": 14,
+          "avg": 8.404040404040405,
+          "avg_length": 8.404040404040405,
+          "stddev": 1.384455922892632,
+          "stddev_length": 1.384455922892632,
+          "duplicates": 99,
+          "duplicates_p": 1,
+          "non_duplicates": 0,
+          "non_duplicates_p": 0,
+          "topk": {
+            "values": [
+              "completed",
+              "shipped",
+              "placed",
+              "returned",
+              "return_pending"
+            ],
+            "counts": [
+              67,
+              13,
+              13,
+              4,
+              2
+            ]
+          },
+          "histogram": {
+            "labels": [
+              "6",
+              "7",
+              "8",
+              "9",
+              "10",
+              "11",
+              "12",
+              "13",
+              "14"
+            ],
+            "counts": [
+              13,
+              13,
+              4,
+              67,
+              0,
+              0,
+              0,
+              0,
+              2
+            ],
+            "bin_edges": [
+              6,
+              7,
+              8,
+              9,
+              10,
+              11,
+              12,
+              13,
+              14,
+              15
+            ]
+          },
+          "histogram_length": {
+            "labels": [
+              "6",
+              "7",
+              "8",
+              "9",
+              "10",
+              "11",
+              "12",
+              "13",
+              "14"
+            ],
+            "counts": [
+              13,
+              13,
+              4,
+              67,
+              0,
+              0,
+              0,
+              0,
+              2
+            ],
+            "bin_edges": [
+              6,
+              7,
+              8,
+              9,
+              10,
+              11,
+              12,
+              13,
+              14,
+              15
+            ]
+          },
+          "profile_duration": "0.02",
+          "elapsed_milli": 15
+        }
+      },
+      "profile_duration": "0.02",
+      "elapsed_milli": 17
+    },
+    "stg_statuses": {
+      "name": "stg_statuses",
+      "row_count": 4,
+      "samples": 4,
+      "samples_p": 1,
+      "col_count": 2,
+      "columns": {
+        "status": {
+          "name": "status",
+          "type": "string",
+          "schema_type": "VARCHAR",
+          "total": 4,
+          "samples": 4,
+          "samples_p": 1,
+          "non_nulls": 4,
+          "non_nulls_p": 1,
+          "nulls": 0,
+          "nulls_p": 0,
+          "valids": 4,
+          "valids_p": 1,
+          "invalids": 0,
+          "invalids_p": 0,
+          "zero_length": 0,
+          "zero_length_p": 0,
+          "non_zero_length": 4,
+          "non_zero_length_p": 1,
+          "distinct": 4,
+          "distinct_p": 1,
+          "min": 6,
+          "min_length": 6,
+          "max": 9,
+          "max_length": 9,
+          "avg": 7.5,
+          "avg_length": 7.5,
+          "stddev": 1.2909944487358056,
+          "stddev_length": 1.2909944487358056,
+          "duplicates": 0,
+          "duplicates_p": 0,
+          "non_duplicates": 4,
+          "non_duplicates_p": 1,
+          "topk": {
+            "values": [
+              "returned",
+              "completed",
+              "shipped",
+              "placed"
+            ],
+            "counts": [
+              1,
+              1,
+              1,
+              1
+            ]
+          },
+          "histogram": {
+            "labels": [
+              "6",
+              "7",
+              "8",
+              "9"
+            ],
+            "counts": [
+              1,
+              1,
+              1,
+              1
+            ],
+            "bin_edges": [
+              6,
+              7,
+              8,
+              9,
+              10
+            ]
+          },
+          "histogram_length": {
+            "labels": [
+              "6",
+              "7",
+              "8",
+              "9"
+            ],
+            "counts": [
+              1,
+              1,
+              1,
+              1
+            ],
+            "bin_edges": [
+              6,
+              7,
+              8,
+              9,
+              10
+            ]
+          },
+          "profile_duration": "0.01",
+          "elapsed_milli": 7
+        },
+        "status_str": {
+          "name": "status_str",
+          "type": "string",
+          "schema_type": "VARCHAR",
+          "total": 4,
+          "samples": 4,
+          "samples_p": 1,
+          "non_nulls": 4,
+          "non_nulls_p": 1,
+          "nulls": 0,
+          "nulls_p": 0,
+          "valids": 4,
+          "valids_p": 1,
+          "invalids": 0,
+          "invalids_p": 0,
+          "zero_length": 0,
+          "zero_length_p": 0,
+          "non_zero_length": 4,
+          "non_zero_length_p": 1,
+          "distinct": 4,
+          "distinct_p": 1,
+          "min": 12,
+          "min_length": 12,
+          "max": 15,
+          "max_length": 15,
+          "avg": 13.5,
+          "avg_length": 13.5,
+          "stddev": 1.2909944487358056,
+          "stddev_length": 1.2909944487358056,
+          "duplicates": 0,
+          "duplicates_p": 0,
+          "non_duplicates": 4,
+          "non_duplicates_p": 1,
+          "topk": {
+            "values": [
+              "Order returned",
+              "Order completed",
+              "Order shipped",
+              "Order placed"
+            ],
+            "counts": [
+              1,
+              1,
+              1,
+              1
+            ]
+          },
+          "histogram": {
+            "labels": [
+              "12",
+              "13",
+              "14",
+              "15"
+            ],
+            "counts": [
+              1,
+              1,
+              1,
+              1
+            ],
+            "bin_edges": [
+              12,
+              13,
+              14,
+              15,
+              16
+            ]
+          },
+          "histogram_length": {
+            "labels": [
+              "12",
+              "13",
+              "14",
+              "15"
+            ],
+            "counts": [
+              1,
+              1,
+              1,
+              1
+            ],
+            "bin_edges": [
+              12,
+              13,
+              14,
+              15,
+              16
+            ]
+          },
+          "profile_duration": "0.01",
+          "elapsed_milli": 7
+        }
+      },
+      "profile_duration": "0.01",
+      "elapsed_milli": 8
+    },
+    "orders": {
+      "name": "orders",
+      "row_count": 97,
+      "samples": 97,
+      "samples_p": 1,
+      "col_count": 16,
+      "columns": {
+        "order_id": {
+          "name": "order_id",
+          "type": "integer",
+          "schema_type": "INTEGER",
+          "total": 97,
+          "samples": 97,
+          "samples_p": 1,
+          "non_nulls": 97,
+          "non_nulls_p": 1,
+          "nulls": 0,
+          "nulls_p": 0,
+          "valids": 97,
+          "valids_p": 1,
+          "invalids": 0,
+          "invalids_p": 0,
+          "zeros": 0,
+          "zeros_p": 0,
+          "negatives": 0,
+          "negatives_p": 0,
+          "positives": 97,
+          "positives_p": 1,
+          "distinct": 97,
+          "distinct_p": 1,
+          "min": 1,
+          "max": 99,
+          "sum": 4875,
+          "avg": 50.25773195876289,
+          "stddev": 28.887453429399734,
+          "duplicates": 0,
+          "duplicates_p": 0,
+          "non_duplicates": 97,
+          "non_duplicates_p": 1,
+          "histogram": {
+            "labels": [
+              "1 _ 3",
+              "3 _ 5",
+              "5 _ 7",
+              "7 _ 9",
+              "9 _ 11",
+              "11 _ 13",
+              "13 _ 15",
+              "15 _ 17",
+              "17 _ 19",
+              "19 _ 21",
+              "21 _ 23",
+              "23 _ 25",
+              "25 _ 27",
+              "27 _ 29",
+              "29 _ 31",
+              "31 _ 33",
+              "33 _ 35",
+              "35 _ 37",
+              "37 _ 39",
+              "39 _ 41",
+              "41 _ 43",
+              "43 _ 45",
+              "45 _ 47",
+              "47 _ 49",
+              "49 _ 51",
+              "51 _ 53",
+              "53 _ 55",
+              "55 _ 57",
+              "57 _ 59",
+              "59 _ 61",
+              "61 _ 63",
+              "63 _ 65",
+              "65 _ 67",
+              "67 _ 69",
+              "69 _ 71",
+              "71 _ 73",
+              "73 _ 75",
+              "75 _ 77",
+              "77 _ 79",
+              "79 _ 81",
+              "81 _ 83",
+              "83 _ 85",
+              "85 _ 87",
+              "87 _ 89",
+              "89 _ 91",
+              "91 _ 93",
+              "93 _ 95",
+              "95 _ 97",
+              "97 _ 99",
+              "99 _ 101"
+            ],
+            "counts": [
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              1,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              1,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              1
+            ],
+            "bin_edges": [
+              1,
+              3,
+              5,
+              7,
+              9,
+              11,
+              13,
+              15,
+              17,
+              19,
+              21,
+              23,
+              25,
+              27,
+              29,
+              31,
+              33,
+              35,
+              37,
+              39,
+              41,
+              43,
+              45,
+              47,
+              49,
+              51,
+              53,
+              55,
+              57,
+              59,
+              61,
+              63,
+              65,
+              67,
+              69,
+              71,
+              73,
+              75,
+              77,
+              79,
+              81,
+              83,
+              85,
+              87,
+              89,
+              91,
+              93,
+              95,
+              97,
+              99,
+              101
+            ]
+          },
+          "p5": 5,
+          "p25": 26,
+          "p50": 50,
+          "p75": 75,
+          "p95": 95,
+          "topk": {
+            "values": [
+              "1",
+              "2",
+              "3",
+              "4",
+              "5",
+              "6",
+              "7",
+              "8",
+              "9",
+              "10",
+              "11",
+              "12",
+              "13",
+              "14",
+              "15",
+              "16",
+              "17",
+              "18",
+              "19",
+              "20",
+              "21",
+              "22",
+              "24",
+              "25",
+              "26",
+              "27",
+              "28",
+              "29",
+              "30",
+              "31",
+              "32",
+              "33",
+              "34",
+              "35",
+              "36",
+              "37",
+              "38",
+              "39",
+              "40",
+              "41",
+              "42",
+              "43",
+              "44",
+              "45",
+              "46",
+              "47",
+              "48",
+              "49",
+              "50",
+              "51"
+            ],
+            "counts": [
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1
+            ]
+          },
+          "profile_duration": "0.03",
+          "elapsed_milli": 29,
+          "description": "This is a unique identifier for an order"
+        },
+        "customer_id": {
+          "name": "customer_id",
+          "type": "integer",
+          "schema_type": "INTEGER",
+          "total": 97,
+          "samples": 97,
+          "samples_p": 1,
+          "non_nulls": 97,
+          "non_nulls_p": 1,
+          "nulls": 0,
+          "nulls_p": 0,
+          "valids": 97,
+          "valids_p": 1,
+          "invalids": 0,
+          "invalids_p": 0,
+          "zeros": 0,
+          "zeros_p": 0,
+          "negatives": 0,
+          "negatives_p": 0,
+          "positives": 97,
+          "positives_p": 1,
+          "distinct": 62,
+          "distinct_p": 0.6391752577319587,
+          "min": 1,
+          "max": 99,
+          "sum": 4701,
+          "avg": 48.4639175257732,
+          "stddev": 27.934097240823693,
+          "duplicates": 64,
+          "duplicates_p": 0.6597938144329897,
+          "non_duplicates": 33,
+          "non_duplicates_p": 0.3402061855670103,
+          "histogram": {
+            "labels": [
+              "1 _ 3",
+              "3 _ 5",
+              "5 _ 7",
+              "7 _ 9",
+              "9 _ 11",
+              "11 _ 13",
+              "13 _ 15",
+              "15 _ 17",
+              "17 _ 19",
+              "19 _ 21",
+              "21 _ 23",
+              "23 _ 25",
+              "25 _ 27",
+              "27 _ 29",
+              "29 _ 31",
+              "31 _ 33",
+              "33 _ 35",
+              "35 _ 37",
+              "37 _ 39",
+              "39 _ 41",
+              "41 _ 43",
+              "43 _ 45",
+              "45 _ 47",
+              "47 _ 49",
+              "49 _ 51",
+              "51 _ 53",
+              "53 _ 55",
+              "55 _ 57",
+              "57 _ 59",
+              "59 _ 61",
+              "61 _ 63",
+              "63 _ 65",
+              "65 _ 67",
+              "67 _ 69",
+              "69 _ 71",
+              "71 _ 73",
+              "73 _ 75",
+              "75 _ 77",
+              "77 _ 79",
+              "79 _ 81",
+              "81 _ 83",
+              "83 _ 85",
+              "85 _ 87",
+              "87 _ 89",
+              "89 _ 91",
+              "91 _ 93",
+              "93 _ 95",
+              "95 _ 97",
+              "97 _ 99",
+              "99 _ 101"
+            ],
+            "counts": [
+              3,
+              3,
+              1,
+              3,
+              1,
+              2,
+              1,
+              1,
+              1,
+              2,
+              3,
+              0,
+              4,
+              3,
+              2,
+              2,
+              2,
+              3,
+              1,
+              2,
+              3,
+              0,
+              2,
+              2,
+              2,
+              4,
+              6,
+              0,
+              2,
+              1,
+              0,
+              4,
+              3,
+              1,
+              4,
+              3,
+              0,
+              1,
+              0,
+              3,
+              0,
+              2,
+              3,
+              1,
+              3,
+              2,
+              3,
+              0,
+              0,
+              2
+            ],
+            "bin_edges": [
+              1,
+              3,
+              5,
+              7,
+              9,
+              11,
+              13,
+              15,
+              17,
+              19,
+              21,
+              23,
+              25,
+              27,
+              29,
+              31,
+              33,
+              35,
+              37,
+              39,
+              41,
+              43,
+              45,
+              47,
+              49,
+              51,
+              53,
+              55,
+              57,
+              59,
+              61,
+              63,
+              65,
+              67,
+              69,
+              71,
+              73,
+              75,
+              77,
+              79,
+              81,
+              83,
+              85,
+              87,
+              89,
+              91,
+              93,
+              95,
+              97,
+              99,
+              101
+            ]
+          },
+          "p5": 3,
+          "p25": 26,
+          "p50": 50,
+          "p75": 70,
+          "p95": 93,
+          "topk": {
+            "values": [
+              "54",
+              "3",
+              "51",
+              "66",
+              "71",
+              "1",
+              "8",
+              "22",
+              "25",
+              "26",
+              "27",
+              "30",
+              "35",
+              "42",
+              "46",
+              "47",
+              "50",
+              "53",
+              "57",
+              "63",
+              "64",
+              "69",
+              "70",
+              "79",
+              "84",
+              "85",
+              "90",
+              "94",
+              "99",
+              "2",
+              "6",
+              "7",
+              "9",
+              "11",
+              "12",
+              "13",
+              "16",
+              "18",
+              "19",
+              "20",
+              "21",
+              "28",
+              "31",
+              "32",
+              "33",
+              "34",
+              "36",
+              "38",
+              "39",
+              "40"
+            ],
+            "counts": [
+              4,
+              3,
+              3,
+              3,
+              3,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1
+            ]
+          },
+          "profile_duration": "0.03",
+          "elapsed_milli": 34,
+          "description": "This is a unique identifier for a customer"
+        },
+        "order_date": {
+          "name": "order_date",
+          "type": "datetime",
+          "schema_type": "DATE",
+          "total": 97,
+          "samples": 97,
+          "samples_p": 1,
+          "non_nulls": 97,
+          "non_nulls_p": 1,
+          "nulls": 0,
+          "nulls_p": 0,
+          "valids": 97,
+          "valids_p": 1,
+          "invalids": 0,
+          "invalids_p": 0,
+          "distinct": 67,
+          "distinct_p": 0.6907216494845361,
+          "min": "2023-03-14",
+          "max": "2023-06-20",
+          "duplicates": 53,
+          "duplicates_p": 0.5463917525773195,
+          "non_duplicates": 44,
+          "non_duplicates_p": 0.4536082474226804,
+          "histogram": {
+            "labels": [
+              "2023-03-01 - 2023-04-01",
+              "2023-04-01 - 2023-05-01",
+              "2023-05-01 - 2023-06-01",
+              "2023-06-01 - 2023-07-01"
+            ],
+            "counts": [
+              17,
+              27,
+              30,
+              23
+            ],
+            "bin_edges": [
+              "2023-03-01",
+              "2023-04-01",
+              "2023-05-01",
+              "2023-06-01",
+              "2023-07-01"
+            ]
+          },
+          "profile_duration": "0.02",
+          "elapsed_milli": 24,
+          "description": "Date (UTC) that the order was placed"
+        },
+        "status": {
+          "name": "status",
+          "type": "string",
+          "schema_type": "VARCHAR",
+          "total": 97,
+          "samples": 97,
+          "samples_p": 1,
+          "non_nulls": 97,
+          "non_nulls_p": 1,
+          "nulls": 0,
+          "nulls_p": 0,
+          "valids": 97,
+          "valids_p": 1,
+          "invalids": 0,
+          "invalids_p": 0,
+          "zero_length": 0,
+          "zero_length_p": 0,
+          "non_zero_length": 97,
+          "non_zero_length_p": 1,
+          "distinct": 4,
+          "distinct_p": 0.041237113402061855,
+          "min": 6,
+          "min_length": 6,
+          "max": 9,
+          "max_length": 9,
+          "avg": 8.288659793814434,
+          "avg_length": 8.288659793814434,
+          "stddev": 1.136137122066459,
+          "stddev_length": 1.136137122066459,
+          "duplicates": 97,
+          "duplicates_p": 1,
+          "non_duplicates": 0,
+          "non_duplicates_p": 0,
+          "topk": {
+            "values": [
+              "completed",
+              "shipped",
+              "placed",
+              "returned"
+            ],
+            "counts": [
+              67,
+              13,
+              13,
+              4
+            ]
+          },
+          "histogram": {
+            "labels": [
+              "6",
+              "7",
+              "8",
+              "9"
+            ],
+            "counts": [
+              13,
+              13,
+              4,
+              67
+            ],
+            "bin_edges": [
+              6,
+              7,
+              8,
+              9,
+              10
+            ]
+          },
+          "histogram_length": {
+            "labels": [
+              "6",
+              "7",
+              "8",
+              "9"
+            ],
+            "counts": [
+              13,
+              13,
+              4,
+              67
+            ],
+            "bin_edges": [
+              6,
+              7,
+              8,
+              9,
+              10
+            ]
+          },
+          "profile_duration": "0.02",
+          "elapsed_milli": 24,
+          "description": "Orders can be one of the following statuses:\n\n| status         | description                                                                                                            |\n|----------------|------------------------------------------------------------------------------------------------------------------------|\n| placed         | The order has been placed but has not yet left the warehouse                                                           |\n| shipped        | The order has ben shipped to the customer and is currently in transit                                                  |\n| completed      | The order has been received by the customer                                                                            |\n| return_pending | The customer has indicated that they would like to return the order, but it has not yet been received at the warehouse |\n| returned       | The order has been returned by the customer and received at the warehouse                                              |"
+        },
+        "credit_card_amount": {
+          "name": "credit_card_amount",
+          "type": "integer",
+          "schema_type": "BIGINT",
+          "total": 97,
+          "samples": 97,
+          "samples_p": 1,
+          "non_nulls": 97,
+          "non_nulls_p": 1,
+          "nulls": 0,
+          "nulls_p": 0,
+          "valids": 97,
+          "valids_p": 1,
+          "invalids": 0,
+          "invalids_p": 0,
+          "zeros": 48,
+          "zeros_p": 0.4948453608247423,
+          "negatives": 0,
+          "negatives_p": 0,
+          "positives": 49,
+          "positives_p": 0.5051546391752577,
+          "distinct": 25,
+          "distinct_p": 0.25773195876288657,
+          "min": 0,
+          "max": 30,
+          "sum": 871,
+          "avg": 8.97938144329897,
+          "stddev": 10.998086369003872,
+          "duplicates": 89,
+          "duplicates_p": 0.9175257731958762,
+          "non_duplicates": 8,
+          "non_duplicates_p": 0.08247422680412371,
+          "histogram": {
+            "labels": [
+              "0",
+              "1",
+              "2",
+              "3",
+              "4",
+              "5",
+              "6",
+              "7",
+              "8",
+              "9",
+              "10",
+              "11",
+              "12",
+              "13",
+              "14",
+              "15",
+              "16",
+              "17",
+              "18",
+              "19",
+              "20",
+              "21",
+              "22",
+              "23",
+              "24",
+              "25",
+              "26",
+              "27",
+              "28",
+              "29",
+              "30"
+            ],
+            "counts": [
+              48,
+              2,
+              0,
+              2,
+              2,
+              2,
+              1,
+              0,
+              1,
+              0,
+              2,
+              0,
+              2,
+              2,
+              1,
+              2,
+              2,
+              1,
+              1,
+              4,
+              1,
+              0,
+              3,
+              3,
+              1,
+              0,
+              3,
+              2,
+              1,
+              5,
+              3
+            ],
+            "bin_edges": [
+              0,
+              1,
+              2,
+              3,
+              4,
+              5,
+              6,
+              7,
+              8,
+              9,
+              10,
+              11,
+              12,
+              13,
+              14,
+              15,
+              16,
+              17,
+              18,
+              19,
+              20,
+              21,
+              22,
+              23,
+              24,
+              25,
+              26,
+              27,
+              28,
+              29,
+              30,
+              31
+            ]
+          },
+          "p5": 0,
+          "p25": 0,
+          "p50": 1,
+          "p75": 19,
+          "p95": 29,
+          "topk": {
+            "values": [
+              "0",
+              "29",
+              "19",
+              "22",
+              "23",
+              "26",
+              "30",
+              "1",
+              "3",
+              "4",
+              "5",
+              "10",
+              "12",
+              "13",
+              "15",
+              "16",
+              "27",
+              "6",
+              "8",
+              "14",
+              "17",
+              "18",
+              "20",
+              "24",
+              "28"
+            ],
+            "counts": [
+              48,
+              5,
+              4,
+              3,
+              3,
+              3,
+              3,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1
+            ]
+          },
+          "profile_duration": "0.04",
+          "elapsed_milli": 35,
+          "description": "Amount of the order (AUD) paid for by credit card"
+        },
+        "coupon_amount": {
+          "name": "coupon_amount",
+          "type": "integer",
+          "schema_type": "BIGINT",
+          "total": 97,
+          "samples": 97,
+          "samples_p": 1,
+          "non_nulls": 97,
+          "non_nulls_p": 1,
+          "nulls": 0,
+          "nulls_p": 0,
+          "valids": 97,
+          "valids_p": 1,
+          "invalids": 0,
+          "invalids_p": 0,
+          "zeros": 84,
+          "zeros_p": 0.865979381443299,
+          "negatives": 0,
+          "negatives_p": 0,
+          "positives": 13,
+          "positives_p": 0.13402061855670103,
+          "distinct": 12,
+          "distinct_p": 0.12371134020618557,
+          "min": 0,
+          "max": 26,
+          "sum": 185,
+          "avg": 1.907216494845361,
+          "stddev": 6.010550574869028,
+          "duplicates": 87,
+          "duplicates_p": 0.8969072164948454,
+          "non_duplicates": 10,
+          "non_duplicates_p": 0.10309278350515463,
+          "histogram": {
+            "labels": [
+              "0",
+              "1",
+              "2",
+              "3",
+              "4",
+              "5",
+              "6",
+              "7",
+              "8",
+              "9",
+              "10",
+              "11",
+              "12",
+              "13",
+              "14",
+              "15",
+              "16",
+              "17",
+              "18",
+              "19",
+              "20",
+              "21",
+              "22",
+              "23",
+              "24",
+              "25",
+              "26"
+            ],
+            "counts": [
+              84,
+              1,
+              3,
+              0,
+              0,
+              0,
+              0,
+              1,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              1,
+              1,
+              1,
+              0,
+              0,
+              0,
+              1,
+              1,
+              1,
+              1,
+              1
+            ],
+            "bin_edges": [
+              0,
+              1,
+              2,
+              3,
+              4,
+              5,
+              6,
+              7,
+              8,
+              9,
+              10,
+              11,
+              12,
+              13,
+              14,
+              15,
+              16,
+              17,
+              18,
+              19,
+              20,
+              21,
+              22,
+              23,
+              24,
+              25,
+              26,
+              27
+            ]
+          },
+          "p5": 0,
+          "p25": 0,
+          "p50": 0,
+          "p75": 0,
+          "p95": 21,
+          "topk": {
+            "values": [
+              "0",
+              "2",
+              "1",
+              "7",
+              "16",
+              "17",
+              "18",
+              "22",
+              "23",
+              "24",
+              "25",
+              "26"
+            ],
+            "counts": [
+              84,
+              3,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1
+            ]
+          },
+          "profile_duration": "0.05",
+          "elapsed_milli": 46,
+          "description": "Amount of the order (AUD) paid for by coupon"
+        },
+        "bank_transfer_amount": {
+          "name": "bank_transfer_amount",
+          "type": "integer",
+          "schema_type": "BIGINT",
+          "total": 97,
+          "samples": 97,
+          "samples_p": 1,
+          "non_nulls": 97,
+          "non_nulls_p": 1,
+          "nulls": 0,
+          "nulls_p": 0,
+          "valids": 97,
+          "valids_p": 1,
+          "invalids": 0,
+          "invalids_p": 0,
+          "zeros": 66,
+          "zeros_p": 0.6804123711340206,
+          "negatives": 0,
+          "negatives_p": 0,
+          "positives": 31,
+          "positives_p": 0.31958762886597936,
+          "distinct": 19,
+          "distinct_p": 0.1958762886597938,
+          "min": 0,
+          "max": 26,
+          "sum": 396,
+          "avg": 4.082474226804123,
+          "stddev": 7.403082273470039,
+          "duplicates": 87,
+          "duplicates_p": 0.8969072164948454,
+          "non_duplicates": 10,
+          "non_duplicates_p": 0.10309278350515463,
+          "histogram": {
+            "labels": [
+              "0",
+              "1",
+              "2",
+              "3",
+              "4",
+              "5",
+              "6",
+              "7",
+              "8",
+              "9",
+              "10",
+              "11",
+              "12",
+              "13",
+              "14",
+              "15",
+              "16",
+              "17",
+              "18",
+              "19",
+              "20",
+              "21",
+              "22",
+              "23",
+              "24",
+              "25",
+              "26"
+            ],
+            "counts": [
+              66,
+              0,
+              3,
+              3,
+              1,
+              1,
+              0,
+              0,
+              3,
+              1,
+              1,
+              1,
+              1,
+              0,
+              2,
+              3,
+              1,
+              2,
+              0,
+              2,
+              1,
+              0,
+              1,
+              0,
+              0,
+              1,
+              3
+            ],
+            "bin_edges": [
+              0,
+              1,
+              2,
+              3,
+              4,
+              5,
+              6,
+              7,
+              8,
+              9,
+              10,
+              11,
+              12,
+              13,
+              14,
+              15,
+              16,
+              17,
+              18,
+              19,
+              20,
+              21,
+              22,
+              23,
+              24,
+              25,
+              26,
+              27
+            ]
+          },
+          "p5": 0,
+          "p25": 0,
+          "p50": 0,
+          "p75": 4,
+          "p95": 21,
+          "topk": {
+            "values": [
+              "0",
+              "2",
+              "3",
+              "8",
+              "15",
+              "26",
+              "14",
+              "17",
+              "19",
+              "4",
+              "5",
+              "9",
+              "10",
+              "11",
+              "12",
+              "16",
+              "20",
+              "22",
+              "25"
+            ],
+            "counts": [
+              66,
+              3,
+              3,
+              3,
+              3,
+              3,
+              2,
+              2,
+              2,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1
+            ]
+          },
+          "profile_duration": "0.05",
+          "elapsed_milli": 48,
+          "description": "Amount of the order (AUD) paid for by bank transfer"
+        },
+        "gift_card_amount": {
+          "name": "gift_card_amount",
+          "type": "integer",
+          "schema_type": "BIGINT",
+          "total": 97,
+          "samples": 97,
+          "samples_p": 1,
+          "non_nulls": 97,
+          "non_nulls_p": 1,
+          "nulls": 0,
+          "nulls_p": 0,
+          "valids": 97,
+          "valids_p": 1,
+          "invalids": 0,
+          "invalids_p": 0,
+          "zeros": 86,
+          "zeros_p": 0.8865979381443299,
+          "negatives": 0,
+          "negatives_p": 0,
+          "positives": 11,
+          "positives_p": 0.1134020618556701,
+          "distinct": 11,
+          "distinct_p": 0.1134020618556701,
+          "min": 0,
+          "max": 30,
+          "sum": 182,
+          "avg": 1.8762886597938144,
+          "stddev": 6.088338805931185,
+          "duplicates": 88,
+          "duplicates_p": 0.9072164948453608,
+          "non_duplicates": 9,
+          "non_duplicates_p": 0.09278350515463918,
+          "histogram": {
+            "labels": [
+              "0",
+              "1",
+              "2",
+              "3",
+              "4",
+              "5",
+              "6",
+              "7",
+              "8",
+              "9",
+              "10",
+              "11",
+              "12",
+              "13",
+              "14",
+              "15",
+              "16",
+              "17",
+              "18",
+              "19",
+              "20",
+              "21",
+              "22",
+              "23",
+              "24",
+              "25",
+              "26",
+              "27",
+              "28",
+              "29",
+              "30"
+            ],
+            "counts": [
+              86,
+              0,
+              0,
+              1,
+              0,
+              0,
+              2,
+              0,
+              0,
+              0,
+              0,
+              1,
+              0,
+              0,
+              1,
+              0,
+              0,
+              1,
+              1,
+              0,
+              0,
+              0,
+              0,
+              1,
+              0,
+              0,
+              1,
+              0,
+              1,
+              0,
+              1
+            ],
+            "bin_edges": [
+              0,
+              1,
+              2,
+              3,
+              4,
+              5,
+              6,
+              7,
+              8,
+              9,
+              10,
+              11,
+              12,
+              13,
+              14,
+              15,
+              16,
+              17,
+              18,
+              19,
+              20,
+              21,
+              22,
+              23,
+              24,
+              25,
+              26,
+              27,
+              28,
+              29,
+              30,
+              31
+            ]
+          },
+          "p5": 0,
+          "p25": 0,
+          "p50": 0,
+          "p75": 0,
+          "p95": 18,
+          "topk": {
+            "values": [
+              "0",
+              "6",
+              "3",
+              "11",
+              "14",
+              "17",
+              "18",
+              "23",
+              "26",
+              "28",
+              "30"
+            ],
+            "counts": [
+              86,
+              2,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1
+            ]
+          },
+          "profile_duration": "0.05",
+          "elapsed_milli": 53,
+          "description": "Amount of the order (AUD) paid for by gift card"
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "schema_type": "BIGINT",
+          "total": 97,
+          "samples": 97,
+          "samples_p": 1,
+          "non_nulls": 97,
+          "non_nulls_p": 1,
+          "nulls": 0,
+          "nulls_p": 0,
+          "valids": 97,
+          "valids_p": 1,
+          "invalids": 0,
+          "invalids_p": 0,
+          "zeros": 1,
+          "zeros_p": 0.010309278350515464,
+          "negatives": 0,
+          "negatives_p": 0,
+          "positives": 96,
+          "positives_p": 0.9896907216494846,
+          "distinct": 32,
+          "distinct_p": 0.32989690721649484,
+          "min": 0,
+          "max": 58,
+          "sum": 1634,
+          "avg": 16.84536082474227,
+          "stddev": 10.827569177591647,
+          "duplicates": 89,
+          "duplicates_p": 0.9175257731958762,
+          "non_duplicates": 8,
+          "non_duplicates_p": 0.08247422680412371,
+          "histogram": {
+            "labels": [
+              "0 _ 2",
+              "2 _ 4",
+              "4 _ 6",
+              "6 _ 8",
+              "8 _ 10",
+              "10 _ 12",
+              "12 _ 14",
+              "14 _ 16",
+              "16 _ 18",
+              "18 _ 20",
+              "20 _ 22",
+              "22 _ 24",
+              "24 _ 26",
+              "26 _ 28",
+              "28 _ 30",
+              "30 _ 32",
+              "32 _ 34",
+              "34 _ 36",
+              "36 _ 38",
+              "38 _ 40",
+              "40 _ 42",
+              "42 _ 44",
+              "44 _ 46",
+              "46 _ 48",
+              "48 _ 50",
+              "50 _ 52",
+              "52 _ 54",
+              "54 _ 56",
+              "56 _ 58",
+              "58 _ 60"
+            ],
+            "counts": [
+              4,
+              11,
+              4,
+              3,
+              5,
+              4,
+              5,
+              7,
+              9,
+              7,
+              1,
+              10,
+              5,
+              9,
+              8,
+              3,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              1,
+              1
+            ],
+            "bin_edges": [
+              0,
+              2,
+              4,
+              6,
+              8,
+              10,
+              12,
+              14,
+              16,
+              18,
+              20,
+              22,
+              24,
+              26,
+              28,
+              30,
+              32,
+              34,
+              36,
+              38,
+              40,
+              42,
+              44,
+              46,
+              48,
+              50,
+              52,
+              54,
+              56,
+              58,
+              60
+            ]
+          },
+          "p5": 2,
+          "p25": 8,
+          "p50": 17,
+          "p75": 24,
+          "p95": 30,
+          "topk": {
+            "values": [
+              "26",
+              "3",
+              "17",
+              "19",
+              "23",
+              "29",
+              "2",
+              "8",
+              "15",
+              "22",
+              "1",
+              "10",
+              "12",
+              "14",
+              "16",
+              "24",
+              "30",
+              "4",
+              "5",
+              "6",
+              "13",
+              "25",
+              "27",
+              "28",
+              "0",
+              "7",
+              "9",
+              "11",
+              "18",
+              "20",
+              "56",
+              "58"
+            ],
+            "counts": [
+              7,
+              6,
+              6,
+              6,
+              6,
+              6,
+              5,
+              4,
+              4,
+              4,
+              3,
+              3,
+              3,
+              3,
+              3,
+              3,
+              3,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1
+            ]
+          },
+          "profile_duration": "0.05",
+          "elapsed_milli": 53,
+          "description": "Total amount (AUD) of the order"
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "string",
+          "schema_type": "VARCHAR",
+          "total": 97,
+          "samples": 97,
+          "samples_p": 1,
+          "non_nulls": 97,
+          "non_nulls_p": 1,
+          "nulls": 0,
+          "nulls_p": 0,
+          "valids": 97,
+          "valids_p": 1,
+          "invalids": 0,
+          "invalids_p": 0,
+          "zero_length": 0,
+          "zero_length_p": 0,
+          "non_zero_length": 97,
+          "non_zero_length_p": 1,
+          "distinct": 55,
+          "distinct_p": 0.5670103092783505,
+          "min": 3,
+          "min_length": 3,
+          "max": 9,
+          "max_length": 9,
+          "avg": 5.597938144329897,
+          "avg_length": 5.597938144329897,
+          "stddev": 1.5252034960841634,
+          "stddev_length": 1.5252034960841634,
+          "duplicates": 71,
+          "duplicates_p": 0.7319587628865979,
+          "non_duplicates": 26,
+          "non_duplicates_p": 0.26804123711340205,
+          "topk": {
+            "values": [
+              "Adam",
+              "Rose",
+              "Paul",
+              "Christina",
+              "Kathleen",
+              "Howard",
+              "Gerald",
+              "David",
+              "Anne",
+              "Theresa",
+              "Jack",
+              "Marie",
+              "Norma",
+              "Benjamin",
+              "Edward",
+              "Victor",
+              "Janet",
+              "Sara",
+              "Willie",
+              "Jennifer",
+              "Frank",
+              "Diana",
+              "Helen",
+              "Aaron",
+              "Sean",
+              "Billy",
+              "Mary",
+              "Gregory",
+              "Michael",
+              "Maria",
+              "Todd",
+              "Gloria",
+              "Shawn",
+              "Margaret",
+              "Barbara",
+              "Fred",
+              "Laura",
+              "Virginia",
+              "Jesse",
+              "Harold",
+              "Amy",
+              "Frances",
+              "Johnny",
+              "Sarah",
+              "Jane",
+              "Katherine",
+              "Phillip",
+              "Dennis",
+              "Lisa",
+              "Amanda"
+            ],
+            "counts": [
+              5,
+              4,
+              4,
+              4,
+              4,
+              3,
+              3,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1
+            ]
+          },
+          "histogram": {
+            "labels": [
+              "3",
+              "4",
+              "5",
+              "6",
+              "7",
+              "8",
+              "9"
+            ],
+            "counts": [
+              1,
+              28,
+              24,
+              20,
+              9,
+              10,
+              5
+            ],
+            "bin_edges": [
+              3,
+              4,
+              5,
+              6,
+              7,
+              8,
+              9,
+              10
+            ]
+          },
+          "histogram_length": {
+            "labels": [
+              "3",
+              "4",
+              "5",
+              "6",
+              "7",
+              "8",
+              "9"
+            ],
+            "counts": [
+              1,
+              28,
+              24,
+              20,
+              9,
+              10,
+              5
+            ],
+            "bin_edges": [
+              3,
+              4,
+              5,
+              6,
+              7,
+              8,
+              9,
+              10
+            ]
+          },
+          "profile_duration": "0.06",
+          "elapsed_milli": 56,
+          "description": "Customer's first name. PII."
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "string",
+          "schema_type": "VARCHAR",
+          "total": 97,
+          "samples": 97,
+          "samples_p": 1,
+          "non_nulls": 97,
+          "non_nulls_p": 1,
+          "nulls": 0,
+          "nulls_p": 0,
+          "valids": 97,
+          "valids_p": 1,
+          "invalids": 0,
+          "invalids_p": 0,
+          "zero_length": 0,
+          "zero_length_p": 0,
+          "non_zero_length": 97,
+          "non_zero_length_p": 1,
+          "distinct": 18,
+          "distinct_p": 0.18556701030927836,
+          "min": 2,
+          "min_length": 2,
+          "max": 2,
+          "max_length": 2,
+          "avg": 2,
+          "avg_length": 2,
+          "stddev": 0,
+          "stddev_length": 0,
+          "duplicates": 94,
+          "duplicates_p": 0.9690721649484536,
+          "non_duplicates": 3,
+          "non_duplicates_p": 0.030927835051546393,
+          "topk": {
+            "values": [
+              "R.",
+              "W.",
+              "P.",
+              "M.",
+              "C.",
+              "H.",
+              "G.",
+              "F.",
+              "B.",
+              "S.",
+              "A.",
+              "T.",
+              "O.",
+              "J.",
+              "L.",
+              "E.",
+              "D.",
+              "K."
+            ],
+            "counts": [
+              13,
+              11,
+              11,
+              10,
+              9,
+              9,
+              5,
+              5,
+              4,
+              4,
+              3,
+              3,
+              3,
+              2,
+              2,
+              1,
+              1,
+              1
+            ]
+          },
+          "histogram": {
+            "labels": [
+              "2"
+            ],
+            "counts": [
+              97
+            ],
+            "bin_edges": [
+              2,
+              3
+            ]
+          },
+          "histogram_length": {
+            "labels": [
+              "2"
+            ],
+            "counts": [
+              97
+            ],
+            "bin_edges": [
+              2,
+              3
+            ]
+          },
+          "profile_duration": "0.07",
+          "elapsed_milli": 66,
+          "description": "Customer's last name. PII."
+        },
+        "first_order": {
+          "name": "first_order",
+          "type": "datetime",
+          "schema_type": "DATE",
+          "total": 97,
+          "samples": 97,
+          "samples_p": 1,
+          "non_nulls": 97,
+          "non_nulls_p": 1,
+          "nulls": 0,
+          "nulls_p": 0,
+          "valids": 97,
+          "valids_p": 1,
+          "invalids": 0,
+          "invalids_p": 0,
+          "distinct": 46,
+          "distinct_p": 0.4742268041237113,
+          "min": "2023-03-14",
+          "max": "2023-06-18",
+          "duplicates": 78,
+          "duplicates_p": 0.8041237113402062,
+          "non_duplicates": 19,
+          "non_duplicates_p": 0.1958762886597938,
+          "histogram": {
+            "labels": [
+              "2023-03-01 - 2023-04-01",
+              "2023-04-01 - 2023-05-01",
+              "2023-05-01 - 2023-06-01",
+              "2023-06-01 - 2023-07-01"
+            ],
+            "counts": [
+              32,
+              30,
+              21,
+              14
+            ],
+            "bin_edges": [
+              "2023-03-01",
+              "2023-04-01",
+              "2023-05-01",
+              "2023-06-01",
+              "2023-07-01"
+            ]
+          },
+          "profile_duration": "0.06",
+          "elapsed_milli": 59,
+          "description": "Date (UTC) of a customer's first order"
+        },
+        "most_recent_order": {
+          "name": "most_recent_order",
+          "type": "datetime",
+          "schema_type": "DATE",
+          "total": 97,
+          "samples": 97,
+          "samples_p": 1,
+          "non_nulls": 97,
+          "non_nulls_p": 1,
+          "nulls": 0,
+          "nulls_p": 0,
+          "valids": 97,
+          "valids_p": 1,
+          "invalids": 0,
+          "invalids_p": 0,
+          "distinct": 52,
+          "distinct_p": 0.5360824742268041,
+          "min": "2023-03-22",
+          "max": "2023-06-20",
+          "duplicates": 72,
+          "duplicates_p": 0.7422680412371134,
+          "non_duplicates": 25,
+          "non_duplicates_p": 0.25773195876288657,
+          "histogram": {
+            "labels": [
+              "2023-03-01 - 2023-04-01",
+              "2023-04-01 - 2023-05-01",
+              "2023-05-01 - 2023-06-01",
+              "2023-06-01 - 2023-07-01"
+            ],
+            "counts": [
+              6,
+              18,
+              40,
+              33
+            ],
+            "bin_edges": [
+              "2023-03-01",
+              "2023-04-01",
+              "2023-05-01",
+              "2023-06-01",
+              "2023-07-01"
+            ]
+          },
+          "profile_duration": "0.06",
+          "elapsed_milli": 61,
+          "description": "Date (UTC) of a customer's most recent order"
+        },
+        "number_of_orders": {
+          "name": "number_of_orders",
+          "type": "integer",
+          "schema_type": "BIGINT",
+          "total": 97,
+          "samples": 97,
+          "samples_p": 1,
+          "non_nulls": 97,
+          "non_nulls_p": 1,
+          "nulls": 0,
+          "nulls_p": 0,
+          "valids": 97,
+          "valids_p": 1,
+          "invalids": 0,
+          "invalids_p": 0,
+          "zeros": 0,
+          "zeros_p": 0,
+          "negatives": 0,
+          "negatives_p": 0,
+          "positives": 97,
+          "positives_p": 1,
+          "distinct": 4,
+          "distinct_p": 0.041237113402061855,
+          "min": 1,
+          "max": 5,
+          "sum": 187,
+          "avg": 1.9278350515463918,
+          "stddev": 0.9269958499593859,
+          "duplicates": 97,
+          "duplicates_p": 1,
+          "non_duplicates": 0,
+          "non_duplicates_p": 0,
+          "histogram": {
+            "labels": [
+              "1",
+              "2",
+              "3",
+              "4",
+              "5"
+            ],
+            "counts": [
+              33,
+              46,
+              14,
+              0,
+              4
+            ],
+            "bin_edges": [
+              1,
+              2,
+              3,
+              4,
+              5,
+              6
+            ]
+          },
+          "p5": 1,
+          "p25": 1,
+          "p50": 2,
+          "p75": 2,
+          "p95": 3,
+          "topk": {
+            "values": [
+              "2",
+              "1",
+              "3",
+              "5"
+            ],
+            "counts": [
+              46,
+              33,
+              14,
+              4
+            ]
+          },
+          "profile_duration": "0.07",
+          "elapsed_milli": 67,
+          "description": "Count of the number of orders a customer has placed"
+        },
+        "customer_lifetime_value": {
+          "name": "customer_lifetime_value",
+          "type": "integer",
+          "schema_type": "BIGINT",
+          "total": 97,
+          "samples": 97,
+          "samples_p": 1,
+          "non_nulls": 97,
+          "non_nulls_p": 1,
+          "nulls": 0,
+          "nulls_p": 0,
+          "valids": 97,
+          "valids_p": 1,
+          "invalids": 0,
+          "invalids_p": 0,
+          "zeros": 0,
+          "zeros_p": 0,
+          "negatives": 0,
+          "negatives_p": 0,
+          "positives": 97,
+          "positives_p": 1,
+          "distinct": 35,
+          "distinct_p": 0.36082474226804123,
+          "min": 1,
+          "max": 99,
+          "sum": 3202,
+          "avg": 33.01030927835052,
+          "stddev": 20.57885992821316,
+          "duplicates": 89,
+          "duplicates_p": 0.9175257731958762,
+          "non_duplicates": 8,
+          "non_duplicates_p": 0.08247422680412371,
+          "histogram": {
+            "labels": [
+              "1 _ 3",
+              "3 _ 5",
+              "5 _ 7",
+              "7 _ 9",
+              "9 _ 11",
+              "11 _ 13",
+              "13 _ 15",
+              "15 _ 17",
+              "17 _ 19",
+              "19 _ 21",
+              "21 _ 23",
+              "23 _ 25",
+              "25 _ 27",
+              "27 _ 29",
+              "29 _ 31",
+              "31 _ 33",
+              "33 _ 35",
+              "35 _ 37",
+              "37 _ 39",
+              "39 _ 41",
+              "41 _ 43",
+              "43 _ 45",
+              "45 _ 47",
+              "47 _ 49",
+              "49 _ 51",
+              "51 _ 53",
+              "53 _ 55",
+              "55 _ 57",
+              "57 _ 59",
+              "59 _ 61",
+              "61 _ 63",
+              "63 _ 65",
+              "65 _ 67",
+              "67 _ 69",
+              "69 _ 71",
+              "71 _ 73",
+              "73 _ 75",
+              "75 _ 77",
+              "77 _ 79",
+              "79 _ 81",
+              "81 _ 83",
+              "83 _ 85",
+              "85 _ 87",
+              "87 _ 89",
+              "89 _ 91",
+              "91 _ 93",
+              "93 _ 95",
+              "95 _ 97",
+              "97 _ 99",
+              "99 _ 101"
+            ],
+            "counts": [
+              3,
+              6,
+              0,
+              4,
+              2,
+              1,
+              2,
+              3,
+              2,
+              0,
+              1,
+              8,
+              4,
+              8,
+              7,
+              2,
+              6,
+              4,
+              0,
+              5,
+              0,
+              7,
+              2,
+              2,
+              0,
+              2,
+              2,
+              0,
+              6,
+              0,
+              0,
+              2,
+              3,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              3
+            ],
+            "bin_edges": [
+              1,
+              3,
+              5,
+              7,
+              9,
+              11,
+              13,
+              15,
+              17,
+              19,
+              21,
+              23,
+              25,
+              27,
+              29,
+              31,
+              33,
+              35,
+              37,
+              39,
+              41,
+              43,
+              45,
+              47,
+              49,
+              51,
+              53,
+              55,
+              57,
+              59,
+              61,
+              63,
+              65,
+              67,
+              69,
+              71,
+              73,
+              75,
+              77,
+              79,
+              81,
+              83,
+              85,
+              87,
+              89,
+              91,
+              93,
+              95,
+              97,
+              99,
+              101
+            ]
+          },
+          "p5": 3,
+          "p25": 23,
+          "p50": 30,
+          "p75": 44,
+          "p95": 65,
+          "topk": {
+            "values": [
+              "27",
+              "57",
+              "3",
+              "39",
+              "44",
+              "8",
+              "23",
+              "24",
+              "26",
+              "30",
+              "33",
+              "36",
+              "29",
+              "65",
+              "99",
+              "2",
+              "10",
+              "14",
+              "15",
+              "32",
+              "34",
+              "43",
+              "45",
+              "47",
+              "52",
+              "54",
+              "64",
+              "1",
+              "4",
+              "12",
+              "16",
+              "17",
+              "18",
+              "22",
+              "28"
+            ],
+            "counts": [
+              7,
+              6,
+              5,
+              5,
+              5,
+              4,
+              4,
+              4,
+              4,
+              4,
+              4,
+              4,
+              3,
+              3,
+              3,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1
+            ]
+          },
+          "profile_duration": "0.07",
+          "elapsed_milli": 70
+        },
+        "status_str": {
+          "name": "status_str",
+          "type": "string",
+          "schema_type": "VARCHAR",
+          "total": 97,
+          "samples": 97,
+          "samples_p": 1,
+          "non_nulls": 97,
+          "non_nulls_p": 1,
+          "nulls": 0,
+          "nulls_p": 0,
+          "valids": 97,
+          "valids_p": 1,
+          "invalids": 0,
+          "invalids_p": 0,
+          "zero_length": 0,
+          "zero_length_p": 0,
+          "non_zero_length": 97,
+          "non_zero_length_p": 1,
+          "distinct": 4,
+          "distinct_p": 0.041237113402061855,
+          "min": 12,
+          "min_length": 12,
+          "max": 15,
+          "max_length": 15,
+          "avg": 14.288659793814434,
+          "avg_length": 14.288659793814434,
+          "stddev": 1.1361371220664593,
+          "stddev_length": 1.1361371220664593,
+          "duplicates": 97,
+          "duplicates_p": 1,
+          "non_duplicates": 0,
+          "non_duplicates_p": 0,
+          "topk": {
+            "values": [
+              "Order completed",
+              "Order shipped",
+              "Order placed",
+              "Order returned"
+            ],
+            "counts": [
+              67,
+              13,
+              13,
+              4
+            ]
+          },
+          "histogram": {
+            "labels": [
+              "12",
+              "13",
+              "14",
+              "15"
+            ],
+            "counts": [
+              13,
+              13,
+              4,
+              67
+            ],
+            "bin_edges": [
+              12,
+              13,
+              14,
+              15,
+              16
+            ]
+          },
+          "histogram_length": {
+            "labels": [
+              "12",
+              "13",
+              "14",
+              "15"
+            ],
+            "counts": [
+              13,
+              13,
+              4,
+              67
+            ],
+            "bin_edges": [
+              12,
+              13,
+              14,
+              15,
+              16
+            ]
+          },
+          "profile_duration": "0.07",
+          "elapsed_milli": 69
+        }
+      },
+      "profile_duration": "0.07",
+      "elapsed_milli": 70,
+      "description": "This table has basic information about orders, as well as some derived facts based on payments"
+    },
+    "raw_statuses": {
+      "name": "raw_statuses",
+      "col_count": 2,
+      "columns": {
+        "status": {
+          "name": "status",
+          "type": "string",
+          "schema_type": "VARCHAR"
+        },
+        "status_str": {
+          "name": "status_str",
+          "type": "string",
+          "schema_type": "VARCHAR"
+        }
+      }
+    },
+    "raw_customers": {
+      "name": "raw_customers",
+      "col_count": 3,
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "schema_type": "INTEGER"
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "string",
+          "schema_type": "VARCHAR"
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "string",
+          "schema_type": "VARCHAR"
+        }
+      }
+    },
+    "raw_orders": {
+      "name": "raw_orders",
+      "col_count": 4,
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "schema_type": "INTEGER"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "schema_type": "INTEGER"
+        },
+        "order_date": {
+          "name": "order_date",
+          "type": "datetime",
+          "schema_type": "DATE"
+        },
+        "status": {
+          "name": "status",
+          "type": "string",
+          "schema_type": "VARCHAR"
+        }
+      }
+    },
+    "raw_payments": {
+      "name": "raw_payments",
+      "col_count": 4,
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "schema_type": "INTEGER"
+        },
+        "order_id": {
+          "name": "order_id",
+          "type": "integer",
+          "schema_type": "INTEGER"
+        },
+        "payment_method": {
+          "name": "payment_method",
+          "type": "string",
+          "schema_type": "VARCHAR"
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "schema_type": "INTEGER"
+        }
+      }
+    }
+  },
+  "metrics": [
+    {
+      "name": "expenses_daily",
+      "label": "Expenses (Daily)",
+      "description": "The total expenses of our jaffle business",
+      "grain": "day",
+      "dimensions": [],
+      "headers": [
+        "date_day",
+        "expenses"
+      ],
+      "data": [
+        [
+          "2023-05-21",
+          7
+        ],
+        [
+          "2023-05-22",
+          13
+        ],
+        [
+          "2023-05-23",
+          6
+        ],
+        [
+          "2023-05-24",
+          0
+        ],
+        [
+          "2023-05-25",
+          0
+        ],
+        [
+          "2023-05-26",
+          0
+        ],
+        [
+          "2023-05-27",
+          0
+        ],
+        [
+          "2023-05-28",
+          0
+        ],
+        [
+          "2023-05-29",
+          4
+        ],
+        [
+          "2023-05-30",
+          0
+        ],
+        [
+          "2023-05-31",
+          0
+        ],
+        [
+          "2023-06-01",
+          0
+        ],
+        [
+          "2023-06-02",
+          0
+        ],
+        [
+          "2023-06-03",
+          0
+        ],
+        [
+          "2023-06-04",
+          0
+        ],
+        [
+          "2023-06-05",
+          0
+        ],
+        [
+          "2023-06-06",
+          0
+        ],
+        [
+          "2023-06-07",
+          0
+        ],
+        [
+          "2023-06-08",
+          0
+        ],
+        [
+          "2023-06-09",
+          0
+        ],
+        [
+          "2023-06-10",
+          0
+        ],
+        [
+          "2023-06-11",
+          0
+        ],
+        [
+          "2023-06-12",
+          0
+        ],
+        [
+          "2023-06-13",
+          0
+        ],
+        [
+          "2023-06-14",
+          0
+        ],
+        [
+          "2023-06-15",
+          0
+        ],
+        [
+          "2023-06-16",
+          0
+        ],
+        [
+          "2023-06-17",
+          0
+        ],
+        [
+          "2023-06-18",
+          0
+        ],
+        [
+          "2023-06-19",
+          0
+        ],
+        [
+          "2023-06-20",
+          0
+        ]
+      ]
+    },
+    {
+      "name": "expenses_weekly",
+      "label": "Expenses (Weekly)",
+      "description": "The total expenses of our jaffle business",
+      "grain": "week",
+      "dimensions": [],
+      "headers": [
+        "date_week",
+        "expenses"
+      ],
+      "data": [
+        [
+          "2023-03-27",
+          23
+        ],
+        [
+          "2023-04-03",
+          15
+        ],
+        [
+          "2023-04-10",
+          39
+        ],
+        [
+          "2023-04-17",
+          25
+        ],
+        [
+          "2023-04-24",
+          20
+        ],
+        [
+          "2023-05-01",
+          23
+        ],
+        [
+          "2023-05-08",
+          33
+        ],
+        [
+          "2023-05-15",
+          23
+        ],
+        [
+          "2023-05-22",
+          19
+        ],
+        [
+          "2023-05-29",
+          4
+        ],
+        [
+          "2023-06-05",
+          0
+        ],
+        [
+          "2023-06-12",
+          0
+        ],
+        [
+          "2023-06-19",
+          0
+        ]
+      ]
+    },
+    {
+      "name": "expenses_monthly",
+      "label": "Expenses (Monthly)",
+      "description": "The total expenses of our jaffle business",
+      "grain": "month",
+      "dimensions": [],
+      "headers": [
+        "date_month",
+        "expenses"
+      ],
+      "data": [
+        [
+          "2022-06-01",
+          0
+        ],
+        [
+          "2022-07-01",
+          0
+        ],
+        [
+          "2022-08-01",
+          0
+        ],
+        [
+          "2022-09-01",
+          0
+        ],
+        [
+          "2022-10-01",
+          0
+        ],
+        [
+          "2022-11-01",
+          0
+        ],
+        [
+          "2022-12-01",
+          0
+        ],
+        [
+          "2023-01-01",
+          0
+        ],
+        [
+          "2023-02-01",
+          0
+        ],
+        [
+          "2023-03-01",
+          48
+        ],
+        [
+          "2023-04-01",
+          99
+        ],
+        [
+          "2023-05-01",
+          102
+        ],
+        [
+          "2023-06-01",
+          0
+        ]
+      ]
+    },
+    {
+      "name": "expenses_yearly",
+      "label": "Expenses (Yearly)",
+      "description": "The total expenses of our jaffle business",
+      "grain": "year",
+      "dimensions": [],
+      "headers": [
+        "date_year",
+        "expenses"
+      ],
+      "data": [
+        [
+          "2013-01-01",
+          0
+        ],
+        [
+          "2014-01-01",
+          0
+        ],
+        [
+          "2015-01-01",
+          0
+        ],
+        [
+          "2016-01-01",
+          0
+        ],
+        [
+          "2017-01-01",
+          0
+        ],
+        [
+          "2018-01-01",
+          0
+        ],
+        [
+          "2019-01-01",
+          0
+        ],
+        [
+          "2020-01-01",
+          0
+        ],
+        [
+          "2021-01-01",
+          0
+        ],
+        [
+          "2022-01-01",
+          0
+        ],
+        [
+          "2023-01-01",
+          249
+        ]
+      ]
+    },
+    {
+      "name": "average_order_amount_daily",
+      "label": "Average Order Amount (Daily)",
+      "description": "The average size of a jaffle order",
+      "grain": "day",
+      "dimensions": [],
+      "headers": [
+        "date_day",
+        "average_order_amount"
+      ],
+      "data": [
+        [
+          "2023-05-21",
+          28
+        ],
+        [
+          "2023-05-22",
+          19.333333333333332
+        ],
+        [
+          "2023-05-23",
+          15.5
+        ],
+        [
+          "2023-05-24",
+          null
+        ],
+        [
+          "2023-05-25",
+          29
+        ],
+        [
+          "2023-05-26",
+          null
+        ],
+        [
+          "2023-05-27",
+          3
+        ],
+        [
+          "2023-05-28",
+          30
+        ],
+        [
+          "2023-05-29",
+          19
+        ],
+        [
+          "2023-05-30",
+          null
+        ],
+        [
+          "2023-05-31",
+          2
+        ],
+        [
+          "2023-06-01",
+          19
+        ],
+        [
+          "2023-06-02",
+          null
+        ],
+        [
+          "2023-06-03",
+          14.5
+        ],
+        [
+          "2023-06-04",
+          4.5
+        ],
+        [
+          "2023-06-05",
+          null
+        ],
+        [
+          "2023-06-06",
+          21.666666666666668
+        ],
+        [
+          "2023-06-07",
+          42.5
+        ],
+        [
+          "2023-06-08",
+          22
+        ],
+        [
+          "2023-06-09",
+          null
+        ],
+        [
+          "2023-06-10",
+          2
+        ],
+        [
+          "2023-06-11",
+          19
+        ],
+        [
+          "2023-06-12",
+          null
+        ],
+        [
+          "2023-06-13",
+          17
+        ],
+        [
+          "2023-06-14",
+          16.5
+        ],
+        [
+          "2023-06-15",
+          24
+        ],
+        [
+          "2023-06-16",
+          null
+        ],
+        [
+          "2023-06-17",
+          17
+        ],
+        [
+          "2023-06-18",
+          12
+        ],
+        [
+          "2023-06-19",
+          null
+        ],
+        [
+          "2023-06-20",
+          24
+        ]
+      ]
+    },
+    {
+      "name": "average_order_amount_weekly",
+      "label": "Average Order Amount (Weekly)",
+      "description": "The average size of a jaffle order",
+      "grain": "week",
+      "dimensions": [],
+      "headers": [
+        "date_week",
+        "average_order_amount"
+      ],
+      "data": [
+        [
+          "2023-03-27",
+          13.666666666666666
+        ],
+        [
+          "2023-04-03",
+          13.4
+        ],
+        [
+          "2023-04-10",
+          23.857142857142858
+        ],
+        [
+          "2023-04-17",
+          16.571428571428573
+        ],
+        [
+          "2023-04-24",
+          12.857142857142858
+        ],
+        [
+          "2023-05-01",
+          17.333333333333332
+        ],
+        [
+          "2023-05-08",
+          15.444444444444445
+        ],
+        [
+          "2023-05-15",
+          19.4
+        ],
+        [
+          "2023-05-22",
+          18.875
+        ],
+        [
+          "2023-05-29",
+          11.88888888888889
+        ],
+        [
+          "2023-06-05",
+          24.125
+        ],
+        [
+          "2023-06-12",
+          16.428571428571427
+        ],
+        [
+          "2023-06-19",
+          24
+        ]
+      ]
+    },
+    {
+      "name": "average_order_amount_monthly",
+      "label": "Average Order Amount (Monthly)",
+      "description": "The average size of a jaffle order",
+      "grain": "month",
+      "dimensions": [],
+      "headers": [
+        "date_month",
+        "average_order_amount"
+      ],
+      "data": [
+        [
+          "2022-06-01",
+          null
+        ],
+        [
+          "2022-07-01",
+          null
+        ],
+        [
+          "2022-08-01",
+          null
+        ],
+        [
+          "2022-09-01",
+          null
+        ],
+        [
+          "2022-10-01",
+          null
+        ],
+        [
+          "2022-11-01",
+          null
+        ],
+        [
+          "2022-12-01",
+          null
+        ],
+        [
+          "2023-01-01",
+          null
+        ],
+        [
+          "2023-02-01",
+          null
+        ],
+        [
+          "2023-03-01",
+          14.764705882352942
+        ],
+        [
+          "2023-04-01",
+          16.77777777777778
+        ],
+        [
+          "2023-05-01",
+          17.066666666666666
+        ],
+        [
+          "2023-06-01",
+          18.17391304347826
+        ]
+      ]
+    },
+    {
+      "name": "revenue_daily",
+      "label": "Revenue (Daily)",
+      "description": "The total revenue of our jaffle business",
+      "grain": "day",
+      "dimensions": [],
+      "headers": [
+        "date_day",
+        "revenue"
+      ],
+      "data": [
+        [
+          "2023-05-21",
+          28
+        ],
+        [
+          "2023-05-22",
+          58
+        ],
+        [
+          "2023-05-23",
+          26
+        ],
+        [
+          "2023-05-24",
+          0
+        ],
+        [
+          "2023-05-25",
+          0
+        ],
+        [
+          "2023-05-26",
+          0
+        ],
+        [
+          "2023-05-27",
+          3
+        ],
+        [
+          "2023-05-28",
+          0
+        ],
+        [
+          "2023-05-29",
+          19
+        ],
+        [
+          "2023-05-30",
+          0
+        ],
+        [
+          "2023-05-31",
+          2
+        ],
+        [
+          "2023-06-01",
+          0
+        ],
+        [
+          "2023-06-02",
+          0
+        ],
+        [
+          "2023-06-03",
+          0
+        ],
+        [
+          "2023-06-04",
+          0
+        ],
+        [
+          "2023-06-05",
+          0
+        ],
+        [
+          "2023-06-06",
+          0
+        ],
+        [
+          "2023-06-07",
+          0
+        ],
+        [
+          "2023-06-08",
+          0
+        ],
+        [
+          "2023-06-09",
+          0
+        ],
+        [
+          "2023-06-10",
+          0
+        ],
+        [
+          "2023-06-11",
+          0
+        ],
+        [
+          "2023-06-12",
+          0
+        ],
+        [
+          "2023-06-13",
+          0
+        ],
+        [
+          "2023-06-14",
+          0
+        ],
+        [
+          "2023-06-15",
+          0
+        ],
+        [
+          "2023-06-16",
+          0
+        ],
+        [
+          "2023-06-17",
+          0
+        ],
+        [
+          "2023-06-18",
+          0
+        ],
+        [
+          "2023-06-19",
+          0
+        ],
+        [
+          "2023-06-20",
+          0
+        ]
+      ]
+    },
+    {
+      "name": "revenue_weekly",
+      "label": "Revenue (Weekly)",
+      "description": "The total revenue of our jaffle business",
+      "grain": "week",
+      "dimensions": [],
+      "headers": [
+        "date_week",
+        "revenue"
+      ],
+      "data": [
+        [
+          "2023-03-27",
+          107
+        ],
+        [
+          "2023-04-03",
+          67
+        ],
+        [
+          "2023-04-10",
+          167
+        ],
+        [
+          "2023-04-17",
+          116
+        ],
+        [
+          "2023-04-24",
+          90
+        ],
+        [
+          "2023-05-01",
+          104
+        ],
+        [
+          "2023-05-08",
+          139
+        ],
+        [
+          "2023-05-15",
+          97
+        ],
+        [
+          "2023-05-22",
+          87
+        ],
+        [
+          "2023-05-29",
+          21
+        ],
+        [
+          "2023-06-05",
+          0
+        ],
+        [
+          "2023-06-12",
+          0
+        ],
+        [
+          "2023-06-19",
+          0
+        ]
+      ]
+    },
+    {
+      "name": "revenue_monthly",
+      "label": "Revenue (Monthly)",
+      "description": "The total revenue of our jaffle business",
+      "grain": "month",
+      "dimensions": [],
+      "headers": [
+        "date_month",
+        "revenue"
+      ],
+      "data": [
+        [
+          "2022-06-01",
+          0
+        ],
+        [
+          "2022-07-01",
+          0
+        ],
+        [
+          "2022-08-01",
+          0
+        ],
+        [
+          "2022-09-01",
+          0
+        ],
+        [
+          "2022-10-01",
+          0
+        ],
+        [
+          "2022-11-01",
+          0
+        ],
+        [
+          "2022-12-01",
+          0
+        ],
+        [
+          "2023-01-01",
+          0
+        ],
+        [
+          "2023-02-01",
+          0
+        ],
+        [
+          "2023-03-01",
+          215
+        ],
+        [
+          "2023-04-01",
+          440
+        ],
+        [
+          "2023-05-01",
+          448
+        ],
+        [
+          "2023-06-01",
+          0
+        ]
+      ]
+    },
+    {
+      "name": "revenue_yearly",
+      "label": "Revenue (Yearly)",
+      "description": "The total revenue of our jaffle business",
+      "grain": "year",
+      "dimensions": [],
+      "headers": [
+        "date_year",
+        "revenue"
+      ],
+      "data": [
+        [
+          "2013-01-01",
+          0
+        ],
+        [
+          "2014-01-01",
+          0
+        ],
+        [
+          "2015-01-01",
+          0
+        ],
+        [
+          "2016-01-01",
+          0
+        ],
+        [
+          "2017-01-01",
+          0
+        ],
+        [
+          "2018-01-01",
+          0
+        ],
+        [
+          "2019-01-01",
+          0
+        ],
+        [
+          "2020-01-01",
+          0
+        ],
+        [
+          "2021-01-01",
+          0
+        ],
+        [
+          "2022-01-01",
+          0
+        ],
+        [
+          "2023-01-01",
+          1103
+        ]
+      ]
+    },
+    {
+      "name": "profit_daily",
+      "label": "Profit (Daily)",
+      "description": "The total money we get to take home from our jaffle business",
+      "grain": "day",
+      "dimensions": [],
+      "headers": [
+        "date_day",
+        "profit"
+      ],
+      "data": [
+        [
+          "2023-05-21",
+          21
+        ],
+        [
+          "2023-05-22",
+          45
+        ],
+        [
+          "2023-05-23",
+          20
+        ],
+        [
+          "2023-05-24",
+          0
+        ],
+        [
+          "2023-05-25",
+          0
+        ],
+        [
+          "2023-05-26",
+          0
+        ],
+        [
+          "2023-05-27",
+          3
+        ],
+        [
+          "2023-05-28",
+          0
+        ],
+        [
+          "2023-05-29",
+          15
+        ],
+        [
+          "2023-05-30",
+          0
+        ],
+        [
+          "2023-05-31",
+          2
+        ],
+        [
+          "2023-06-01",
+          0
+        ],
+        [
+          "2023-06-02",
+          0
+        ],
+        [
+          "2023-06-03",
+          0
+        ],
+        [
+          "2023-06-04",
+          0
+        ],
+        [
+          "2023-06-05",
+          0
+        ],
+        [
+          "2023-06-06",
+          0
+        ],
+        [
+          "2023-06-07",
+          0
+        ],
+        [
+          "2023-06-08",
+          0
+        ],
+        [
+          "2023-06-09",
+          0
+        ],
+        [
+          "2023-06-10",
+          0
+        ],
+        [
+          "2023-06-11",
+          0
+        ],
+        [
+          "2023-06-12",
+          0
+        ],
+        [
+          "2023-06-13",
+          0
+        ],
+        [
+          "2023-06-14",
+          0
+        ],
+        [
+          "2023-06-15",
+          0
+        ],
+        [
+          "2023-06-16",
+          0
+        ],
+        [
+          "2023-06-17",
+          0
+        ],
+        [
+          "2023-06-18",
+          0
+        ],
+        [
+          "2023-06-19",
+          0
+        ],
+        [
+          "2023-06-20",
+          0
+        ]
+      ]
+    },
+    {
+      "name": "profit_weekly",
+      "label": "Profit (Weekly)",
+      "description": "The total money we get to take home from our jaffle business",
+      "grain": "week",
+      "dimensions": [],
+      "headers": [
+        "date_week",
+        "profit"
+      ],
+      "data": [
+        [
+          "2023-03-27",
+          84
+        ],
+        [
+          "2023-04-03",
+          52
+        ],
+        [
+          "2023-04-10",
+          128
+        ],
+        [
+          "2023-04-17",
+          91
+        ],
+        [
+          "2023-04-24",
+          70
+        ],
+        [
+          "2023-05-01",
+          81
+        ],
+        [
+          "2023-05-08",
+          106
+        ],
+        [
+          "2023-05-15",
+          74
+        ],
+        [
+          "2023-05-22",
+          68
+        ],
+        [
+          "2023-05-29",
+          17
+        ],
+        [
+          "2023-06-05",
+          0
+        ],
+        [
+          "2023-06-12",
+          0
+        ],
+        [
+          "2023-06-19",
+          0
+        ]
+      ]
+    },
+    {
+      "name": "profit_monthly",
+      "label": "Profit (Monthly)",
+      "description": "The total money we get to take home from our jaffle business",
+      "grain": "month",
+      "dimensions": [],
+      "headers": [
+        "date_month",
+        "profit"
+      ],
+      "data": [
+        [
+          "2022-06-01",
+          0
+        ],
+        [
+          "2022-07-01",
+          0
+        ],
+        [
+          "2022-08-01",
+          0
+        ],
+        [
+          "2022-09-01",
+          0
+        ],
+        [
+          "2022-10-01",
+          0
+        ],
+        [
+          "2022-11-01",
+          0
+        ],
+        [
+          "2022-12-01",
+          0
+        ],
+        [
+          "2023-01-01",
+          0
+        ],
+        [
+          "2023-02-01",
+          0
+        ],
+        [
+          "2023-03-01",
+          167
+        ],
+        [
+          "2023-04-01",
+          341
+        ],
+        [
+          "2023-05-01",
+          346
+        ],
+        [
+          "2023-06-01",
+          0
+        ]
+      ]
+    },
+    {
+      "name": "profit_yearly",
+      "label": "Profit (Yearly)",
+      "description": "The total money we get to take home from our jaffle business",
+      "grain": "year",
+      "dimensions": [],
+      "headers": [
+        "date_year",
+        "profit"
+      ],
+      "data": [
+        [
+          "2013-01-01",
+          0
+        ],
+        [
+          "2014-01-01",
+          0
+        ],
+        [
+          "2015-01-01",
+          0
+        ],
+        [
+          "2016-01-01",
+          0
+        ],
+        [
+          "2017-01-01",
+          0
+        ],
+        [
+          "2018-01-01",
+          0
+        ],
+        [
+          "2019-01-01",
+          0
+        ],
+        [
+          "2020-01-01",
+          0
+        ],
+        [
+          "2021-01-01",
+          0
+        ],
+        [
+          "2022-01-01",
+          0
+        ],
+        [
+          "2023-01-01",
+          854
+        ]
+      ]
+    }
+  ],
+  "tests": [
+    {
+      "id": "test.jaffle_shop.not_null_stg_customers_customer_id.e2cfb1f9aa",
+      "name": "test.jaffle_shop.not_null_stg_customers_customer_id.e2cfb1f9aa",
+      "table": "stg_customers",
+      "column": "customer_id",
+      "status": "passed",
+      "tags": [],
+      "display_name": "not_null_stg_customers_customer_id",
+      "source": "dbt"
+    },
+    {
+      "id": "test.jaffle_shop.unique_stg_customers_customer_id.c7614daada",
+      "name": "test.jaffle_shop.unique_stg_customers_customer_id.c7614daada",
+      "table": "stg_customers",
+      "column": "customer_id",
+      "status": "passed",
+      "tags": [],
+      "display_name": "unique_stg_customers_customer_id",
+      "source": "dbt"
+    },
+    {
+      "id": "test.jaffle_shop.accepted_values_stg_orders_status__placed__shipped__completed__return_pending__returned.080fb20aad",
+      "name": "test.jaffle_shop.accepted_values_stg_orders_status__placed__shipped__completed__return_pending__returned.080fb20aad",
+      "table": "stg_orders",
+      "column": "status",
+      "status": "passed",
+      "tags": [],
+      "display_name": "accepted_values_stg_orders_status__placed__shipped__completed__return_pending__returned",
+      "source": "dbt"
+    },
+    {
+      "id": "test.jaffle_shop.not_null_stg_orders_order_id.81cfe2fe64",
+      "name": "test.jaffle_shop.not_null_stg_orders_order_id.81cfe2fe64",
+      "table": "stg_orders",
+      "column": "order_id",
+      "status": "passed",
+      "tags": [],
+      "display_name": "not_null_stg_orders_order_id",
+      "source": "dbt"
+    },
+    {
+      "id": "test.jaffle_shop.unique_stg_orders_order_id.e3b841c71a",
+      "name": "test.jaffle_shop.unique_stg_orders_order_id.e3b841c71a",
+      "table": "stg_orders",
+      "column": "order_id",
+      "status": "passed",
+      "tags": [],
+      "display_name": "unique_stg_orders_order_id",
+      "source": "dbt"
+    },
+    {
+      "id": "test.jaffle_shop.accepted_values_stg_payments_payment_method__credit_card__coupon__bank_transfer__gift_card.3c3820f278",
+      "name": "test.jaffle_shop.accepted_values_stg_payments_payment_method__credit_card__coupon__bank_transfer__gift_card.3c3820f278",
+      "table": "stg_payments",
+      "column": "payment_method",
+      "status": "passed",
+      "tags": [],
+      "display_name": "accepted_values_stg_payments_payment_method__credit_card__coupon__bank_transfer__gift_card",
+      "source": "dbt"
+    },
+    {
+      "id": "test.jaffle_shop.not_null_stg_payments_payment_id.c19cc50075",
+      "name": "test.jaffle_shop.not_null_stg_payments_payment_id.c19cc50075",
+      "table": "stg_payments",
+      "column": "payment_id",
+      "status": "passed",
+      "tags": [],
+      "display_name": "not_null_stg_payments_payment_id",
+      "source": "dbt"
+    },
+    {
+      "id": "test.jaffle_shop.unique_stg_payments_payment_id.3744510712",
+      "name": "test.jaffle_shop.unique_stg_payments_payment_id.3744510712",
+      "table": "stg_payments",
+      "column": "payment_id",
+      "status": "passed",
+      "tags": [],
+      "display_name": "unique_stg_payments_payment_id",
+      "source": "dbt"
+    },
+    {
+      "id": "test.jaffle_shop.not_null_int_customer_order_history_joined_customer_id.5eeb8cdf92",
+      "name": "test.jaffle_shop.not_null_int_customer_order_history_joined_customer_id.5eeb8cdf92",
+      "table": "int_customer_order_history_joined",
+      "column": "customer_id",
+      "status": "passed",
+      "tags": [],
+      "display_name": "not_null_int_customer_order_history_joined_customer_id",
+      "source": "dbt"
+    },
+    {
+      "id": "test.jaffle_shop.unique_int_customer_order_history_joined_customer_id.995635f7d9",
+      "name": "test.jaffle_shop.unique_int_customer_order_history_joined_customer_id.995635f7d9",
+      "table": "int_customer_order_history_joined",
+      "column": "customer_id",
+      "status": "passed",
+      "tags": [],
+      "display_name": "unique_int_customer_order_history_joined_customer_id",
+      "source": "dbt"
+    },
+    {
+      "id": "test.jaffle_shop.accepted_values_int_order_payments_pivoted_status__placed__shipped__completed__return_pending__returned.0ccdff53e8",
+      "name": "test.jaffle_shop.accepted_values_int_order_payments_pivoted_status__placed__shipped__completed__return_pending__returned.0ccdff53e8",
+      "table": "int_order_payments_pivoted",
+      "column": "status",
+      "status": "passed",
+      "tags": [],
+      "display_name": "accepted_values_int_order_payments_pivoted_status__placed__shipped__completed__return_pending__returned",
+      "source": "dbt"
+    },
+    {
+      "id": "test.jaffle_shop.not_null_int_order_payments_pivoted_amount.b7598e0e3b",
+      "name": "test.jaffle_shop.not_null_int_order_payments_pivoted_amount.b7598e0e3b",
+      "table": "int_order_payments_pivoted",
+      "column": "amount",
+      "status": "passed",
+      "tags": [],
+      "display_name": "not_null_int_order_payments_pivoted_amount",
+      "source": "dbt"
+    },
+    {
+      "id": "test.jaffle_shop.not_null_int_order_payments_pivoted_bank_transfer_amount.1a9e62933b",
+      "name": "test.jaffle_shop.not_null_int_order_payments_pivoted_bank_transfer_amount.1a9e62933b",
+      "table": "int_order_payments_pivoted",
+      "column": "bank_transfer_amount",
+      "status": "passed",
+      "tags": [],
+      "display_name": "not_null_int_order_payments_pivoted_bank_transfer_amount",
+      "source": "dbt"
+    },
+    {
+      "id": "test.jaffle_shop.not_null_int_order_payments_pivoted_coupon_amount.2532b538c2",
+      "name": "test.jaffle_shop.not_null_int_order_payments_pivoted_coupon_amount.2532b538c2",
+      "table": "int_order_payments_pivoted",
+      "column": "coupon_amount",
+      "status": "passed",
+      "tags": [],
+      "display_name": "not_null_int_order_payments_pivoted_coupon_amount",
+      "source": "dbt"
+    },
+    {
+      "id": "test.jaffle_shop.not_null_int_order_payments_pivoted_credit_card_amount.ae9c42d967",
+      "name": "test.jaffle_shop.not_null_int_order_payments_pivoted_credit_card_amount.ae9c42d967",
+      "table": "int_order_payments_pivoted",
+      "column": "credit_card_amount",
+      "status": "passed",
+      "tags": [],
+      "display_name": "not_null_int_order_payments_pivoted_credit_card_amount",
+      "source": "dbt"
+    },
+    {
+      "id": "test.jaffle_shop.not_null_int_order_payments_pivoted_customer_id.3db59c6de4",
+      "name": "test.jaffle_shop.not_null_int_order_payments_pivoted_customer_id.3db59c6de4",
+      "table": "int_order_payments_pivoted",
+      "column": "customer_id",
+      "status": "passed",
+      "tags": [],
+      "display_name": "not_null_int_order_payments_pivoted_customer_id",
+      "source": "dbt"
+    },
+    {
+      "id": "test.jaffle_shop.not_null_int_order_payments_pivoted_gift_card_amount.710d789cc0",
+      "name": "test.jaffle_shop.not_null_int_order_payments_pivoted_gift_card_amount.710d789cc0",
+      "table": "int_order_payments_pivoted",
+      "column": "gift_card_amount",
+      "status": "passed",
+      "tags": [],
+      "display_name": "not_null_int_order_payments_pivoted_gift_card_amount",
+      "source": "dbt"
+    },
+    {
+      "id": "test.jaffle_shop.not_null_int_order_payments_pivoted_order_id.787ba994a8",
+      "name": "test.jaffle_shop.not_null_int_order_payments_pivoted_order_id.787ba994a8",
+      "table": "int_order_payments_pivoted",
+      "column": "order_id",
+      "status": "passed",
+      "tags": [],
+      "display_name": "not_null_int_order_payments_pivoted_order_id",
+      "source": "dbt"
+    },
+    {
+      "id": "test.jaffle_shop.relationships_int_order_payments_pivoted_customer_id__customer_id__ref_int_customer_order_history_joined_.654a1aa35d",
+      "name": "test.jaffle_shop.relationships_int_order_payments_pivoted_customer_id__customer_id__ref_int_customer_order_history_joined_.654a1aa35d",
+      "table": "int_customer_order_history_joined",
+      "column": "customer_id",
+      "status": "passed",
+      "tags": [],
+      "display_name": "relationships_int_order_payments_pivoted_customer_id__customer_id__ref_int_customer_order_history_joined_",
+      "source": "dbt"
+    },
+    {
+      "id": "test.jaffle_shop.unique_int_order_payments_pivoted_order_id.34a0f3307d",
+      "name": "test.jaffle_shop.unique_int_order_payments_pivoted_order_id.34a0f3307d",
+      "table": "int_order_payments_pivoted",
+      "column": "order_id",
+      "status": "passed",
+      "tags": [],
+      "display_name": "unique_int_order_payments_pivoted_order_id",
+      "source": "dbt"
+    },
+    {
+      "id": "test.jaffle_shop.accepted_values_orders_status__placed__shipped__completed__return_pending__returned.be6b5b5ec3",
+      "name": "test.jaffle_shop.accepted_values_orders_status__placed__shipped__completed__return_pending__returned.be6b5b5ec3",
+      "table": "orders",
+      "column": "status",
+      "status": "passed",
+      "tags": [],
+      "display_name": "accepted_values_orders_status__placed__shipped__completed__return_pending__returned",
+      "source": "dbt"
+    },
+    {
+      "id": "test.jaffle_shop.not_null_orders_amount.106140f9fd",
+      "name": "test.jaffle_shop.not_null_orders_amount.106140f9fd",
+      "table": "orders",
+      "column": "amount",
+      "status": "passed",
+      "tags": [],
+      "display_name": "not_null_orders_amount",
+      "source": "dbt"
+    },
+    {
+      "id": "test.jaffle_shop.not_null_orders_bank_transfer_amount.7743500c49",
+      "name": "test.jaffle_shop.not_null_orders_bank_transfer_amount.7743500c49",
+      "table": "orders",
+      "column": "bank_transfer_amount",
+      "status": "passed",
+      "tags": [],
+      "display_name": "not_null_orders_bank_transfer_amount",
+      "source": "dbt"
+    },
+    {
+      "id": "test.jaffle_shop.not_null_orders_coupon_amount.ab90c90625",
+      "name": "test.jaffle_shop.not_null_orders_coupon_amount.ab90c90625",
+      "table": "orders",
+      "column": "coupon_amount",
+      "status": "passed",
+      "tags": [],
+      "display_name": "not_null_orders_coupon_amount",
+      "source": "dbt"
+    },
+    {
+      "id": "test.jaffle_shop.not_null_orders_credit_card_amount.d3ca593b59",
+      "name": "test.jaffle_shop.not_null_orders_credit_card_amount.d3ca593b59",
+      "table": "orders",
+      "column": "credit_card_amount",
+      "status": "passed",
+      "tags": [],
+      "display_name": "not_null_orders_credit_card_amount",
+      "source": "dbt"
+    },
+    {
+      "id": "test.jaffle_shop.not_null_orders_customer_id.c5f02694af",
+      "name": "test.jaffle_shop.not_null_orders_customer_id.c5f02694af",
+      "table": "orders",
+      "column": "customer_id",
+      "status": "passed",
+      "tags": [],
+      "display_name": "not_null_orders_customer_id",
+      "source": "dbt"
+    },
+    {
+      "id": "test.jaffle_shop.not_null_orders_gift_card_amount.413a0d2d7a",
+      "name": "test.jaffle_shop.not_null_orders_gift_card_amount.413a0d2d7a",
+      "table": "orders",
+      "column": "gift_card_amount",
+      "status": "passed",
+      "tags": [],
+      "display_name": "not_null_orders_gift_card_amount",
+      "source": "dbt"
+    },
+    {
+      "id": "test.jaffle_shop.not_null_orders_order_id.cf6c17daed",
+      "name": "test.jaffle_shop.not_null_orders_order_id.cf6c17daed",
+      "table": "orders",
+      "column": "order_id",
+      "status": "passed",
+      "tags": [],
+      "display_name": "not_null_orders_order_id",
+      "source": "dbt"
+    },
+    {
+      "id": "test.jaffle_shop.unique_orders_order_id.fed79b3a6e",
+      "name": "test.jaffle_shop.unique_orders_order_id.fed79b3a6e",
+      "table": "orders",
+      "column": "order_id",
+      "status": "passed",
+      "tags": [],
+      "display_name": "unique_orders_order_id",
+      "source": "dbt"
+    }
+  ],
+  "dbt": {
+    "manifest": {
+      "metadata": {
+        "dbt_schema_version": "https://schemas.getdbt.com/dbt/manifest/v9.json",
+        "dbt_version": "1.5.1",
+        "generated_at": "2023-06-20T06:00:25.951467Z",
+        "invocation_id": "68dcc536-79d0-4e08-bec3-e3d2c7680f62",
+        "env": {},
+        "project_id": "06e5b98c2db46f8a72cc4f66410e9b3b",
+        "user_id": "a95e4c35-f5d4-4c37-9d87-9a331e4f18fd",
+        "send_anonymous_usage_stats": true,
+        "adapter_type": "duckdb"
+      },
+      "nodes": {
+        "model.jaffle_shop.int_order_payments_pivoted": {
+          "database": "jaffle_shop",
+          "schema": "main",
+          "name": "int_order_payments_pivoted",
+          "resource_type": "model",
+          "package_name": "jaffle_shop",
+          "path": "int_order_payments_pivoted.sql",
+          "original_file_path": "models/int_order_payments_pivoted.sql",
+          "unique_id": "model.jaffle_shop.int_order_payments_pivoted",
+          "fqn": [
+            "jaffle_shop",
+            "int_order_payments_pivoted"
+          ],
+          "alias": "int_order_payments_pivoted",
+          "checksum": {
+            "name": "sha256",
+            "checksum": "a6b3504e09200d63863bf0a4291e009271059d72174aa3742ef5dcef0d00f6ef"
+          },
+          "config": {
+            "enabled": true,
+            "tags": [
+              "piperider"
+            ],
+            "meta": {},
+            "materialized": "table",
+            "persist_docs": {},
+            "quoting": {},
+            "column_types": {},
+            "on_schema_change": "ignore",
+            "grants": {},
+            "packages": [],
+            "docs": {
+              "show": true
+            },
+            "contract": {
+              "enforced": false
+            },
+            "post-hook": [],
+            "pre-hook": []
+          },
+          "tags": [
+            "piperider"
+          ],
+          "description": "This table has basic information about orders, as well as some derived facts based on payments",
+          "columns": {
+            "order_id": {
+              "name": "order_id",
+              "description": "This is a unique identifier for an order",
+              "meta": {},
+              "constraints": [],
+              "tags": []
+            },
+            "customer_id": {
+              "name": "customer_id",
+              "description": "Foreign key to the customers table",
+              "meta": {},
+              "constraints": [],
+              "tags": []
+            },
+            "order_date": {
+              "name": "order_date",
+              "description": "Date (UTC) that the order was placed",
+              "meta": {},
+              "constraints": [],
+              "tags": []
+            },
+            "status": {
+              "name": "status",
+              "description": "Orders can be one of the following statuses:\n\n| status         | description                                                                                                            |\n|----------------|------------------------------------------------------------------------------------------------------------------------|\n| placed         | The order has been placed but has not yet left the warehouse                                                           |\n| shipped        | The order has ben shipped to the customer and is currently in transit                                                  |\n| completed      | The order has been received by the customer                                                                            |\n| return_pending | The customer has indicated that they would like to return the order, but it has not yet been received at the warehouse |\n| returned       | The order has been returned by the customer and received at the warehouse                                              |",
+              "meta": {},
+              "constraints": [],
+              "tags": []
+            },
+            "amount": {
+              "name": "amount",
+              "description": "Total amount (AUD) of the order",
+              "meta": {},
+              "constraints": [],
+              "tags": []
+            },
+            "credit_card_amount": {
+              "name": "credit_card_amount",
+              "description": "Amount of the order (AUD) paid for by credit card",
+              "meta": {},
+              "constraints": [],
+              "tags": []
+            },
+            "coupon_amount": {
+              "name": "coupon_amount",
+              "description": "Amount of the order (AUD) paid for by coupon",
+              "meta": {},
+              "constraints": [],
+              "tags": []
+            },
+            "bank_transfer_amount": {
+              "name": "bank_transfer_amount",
+              "description": "Amount of the order (AUD) paid for by bank transfer",
+              "meta": {},
+              "constraints": [],
+              "tags": []
+            },
+            "gift_card_amount": {
+              "name": "gift_card_amount",
+              "description": "Amount of the order (AUD) paid for by gift card",
+              "meta": {},
+              "constraints": [],
+              "tags": []
+            }
+          },
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "patch_path": "jaffle_shop://models/schema.yml",
+          "build_path": "target/run/jaffle_shop/models/int_order_payments_pivoted.sql",
+          "deferred": false,
+          "unrendered_config": {
+            "materialized": "table",
+            "tags": "piperider"
+          },
+          "created_at": 1687240826.3558311,
+          "relation_name": "\"jaffle_shop\".\"main\".\"int_order_payments_pivoted\"",
+          "raw_code": "{% set payment_methods = ['credit_card', 'coupon', 'bank_transfer', 'gift_card'] %}\n\nwith orders as (\n\n    select * from {{ ref('stg_orders') }}\n\n),\n\npayments as (\n\n    select * from {{ ref('stg_payments') }}\n\n),\n\norder_payments as (\n\n    select\n        order_id,\n\n        {% for payment_method in payment_methods -%}\n        sum(case when payment_method = '{{ payment_method }}' then amount else 0 end)::bigint as {{ payment_method }}_amount,\n        {% endfor -%}\n\n        sum(amount)::bigint as total_amount\n\n    from payments\n\n    group by order_id\n\n),\n\nfinal as (\n\n    select\n        orders.order_id,\n        orders.customer_id,\n        orders.order_date,\n        orders.status,\n\n        {% for payment_method in payment_methods -%}\n\n        order_payments.{{ payment_method }}_amount,\n\n        {% endfor -%}\n\n        order_payments.total_amount as amount\n\n    from orders\n\n\n    left join order_payments\n        on orders.order_id = order_payments.order_id\n\n)\n\nselect * from final",
+          "language": "sql",
+          "refs": [
+            {
+              "name": "stg_orders"
+            },
+            {
+              "name": "stg_payments"
+            }
+          ],
+          "sources": [],
+          "metrics": [],
+          "depends_on": {
+            "macros": [],
+            "nodes": [
+              "model.jaffle_shop.stg_orders",
+              "model.jaffle_shop.stg_payments"
+            ]
+          },
+          "compiled_path": "target/compiled/jaffle_shop/models/int_order_payments_pivoted.sql",
+          "compiled": true,
+          "compiled_code": "\n\nwith orders as (\n\n    select * from \"jaffle_shop\".\"main\".\"stg_orders\"\n\n),\n\npayments as (\n\n    select * from \"jaffle_shop\".\"main\".\"stg_payments\"\n\n),\n\norder_payments as (\n\n    select\n        order_id,\n\n        sum(case when payment_method = 'credit_card' then amount else 0 end)::bigint as credit_card_amount,\n        sum(case when payment_method = 'coupon' then amount else 0 end)::bigint as coupon_amount,\n        sum(case when payment_method = 'bank_transfer' then amount else 0 end)::bigint as bank_transfer_amount,\n        sum(case when payment_method = 'gift_card' then amount else 0 end)::bigint as gift_card_amount,\n        sum(amount)::bigint as total_amount\n\n    from payments\n\n    group by order_id\n\n),\n\nfinal as (\n\n    select\n        orders.order_id,\n        orders.customer_id,\n        orders.order_date,\n        orders.status,\n\n        order_payments.credit_card_amount,\n\n        order_payments.coupon_amount,\n\n        order_payments.bank_transfer_amount,\n\n        order_payments.gift_card_amount,\n\n        order_payments.total_amount as amount\n\n    from orders\n\n\n    left join order_payments\n        on orders.order_id = order_payments.order_id\n\n)\n\nselect * from final",
+          "extra_ctes_injected": true,
+          "extra_ctes": [],
+          "contract": {
+            "enforced": false
+          },
+          "access": "protected",
+          "constraints": []
+        },
+        "model.jaffle_shop.int_customer_order_history_joined": {
+          "database": "jaffle_shop",
+          "schema": "main",
+          "name": "int_customer_order_history_joined",
+          "resource_type": "model",
+          "package_name": "jaffle_shop",
+          "path": "int_customer_order_history_joined.sql",
+          "original_file_path": "models/int_customer_order_history_joined.sql",
+          "unique_id": "model.jaffle_shop.int_customer_order_history_joined",
+          "fqn": [
+            "jaffle_shop",
+            "int_customer_order_history_joined"
+          ],
+          "alias": "int_customer_order_history_joined",
+          "checksum": {
+            "name": "sha256",
+            "checksum": "d3b742d16b8ba5a1e9b7952a58fab257dd83524960d5adff6d2466a51855e41f"
+          },
+          "config": {
+            "enabled": true,
+            "tags": [
+              "piperider"
+            ],
+            "meta": {},
+            "materialized": "table",
+            "persist_docs": {},
+            "quoting": {},
+            "column_types": {},
+            "on_schema_change": "ignore",
+            "grants": {},
+            "packages": [],
+            "docs": {
+              "show": true
+            },
+            "contract": {
+              "enforced": false
+            },
+            "post-hook": [],
+            "pre-hook": []
+          },
+          "tags": [
+            "piperider"
+          ],
+          "description": "This table has basic information about a customer, as well as some derived facts based on a customer's orders",
+          "columns": {
+            "customer_id": {
+              "name": "customer_id",
+              "description": "This is a unique identifier for a customer",
+              "meta": {},
+              "constraints": [],
+              "tags": []
+            },
+            "first_name": {
+              "name": "first_name",
+              "description": "Customer's first name. PII.",
+              "meta": {},
+              "constraints": [],
+              "tags": []
+            },
+            "last_name": {
+              "name": "last_name",
+              "description": "Customer's last name. PII.",
+              "meta": {},
+              "constraints": [],
+              "tags": []
+            },
+            "first_order": {
+              "name": "first_order",
+              "description": "Date (UTC) of a customer's first order",
+              "meta": {},
+              "constraints": [],
+              "tags": []
+            },
+            "most_recent_order": {
+              "name": "most_recent_order",
+              "description": "Date (UTC) of a customer's most recent order",
+              "meta": {},
+              "constraints": [],
+              "tags": []
+            },
+            "number_of_orders": {
+              "name": "number_of_orders",
+              "description": "Count of the number of orders a customer has placed",
+              "meta": {},
+              "constraints": [],
+              "tags": []
+            },
+            "total_order_amount": {
+              "name": "total_order_amount",
+              "description": "Total value (AUD) of a customer's orders",
+              "meta": {},
+              "constraints": [],
+              "tags": []
+            }
+          },
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "patch_path": "jaffle_shop://models/schema.yml",
+          "build_path": "target/run/jaffle_shop/models/int_customer_order_history_joined.sql",
+          "deferred": false,
+          "unrendered_config": {
+            "materialized": "table",
+            "tags": "piperider"
+          },
+          "created_at": 1687240826.354059,
+          "relation_name": "\"jaffle_shop\".\"main\".\"int_customer_order_history_joined\"",
+          "raw_code": "with customers as (\n\n    select * from {{ ref('stg_customers') }}\n\n),\n\norders as (\n\n    select * from {{ ref('stg_orders') }}\n\n),\n\npayments as (\n\n    select * from {{ ref('stg_payments') }}\n\n),\n\ncustomer_orders as (\n\n        select\n        customer_id,\n\n        min(order_date) as first_order,\n        max(order_date) as most_recent_order,\n        count(order_id) as number_of_orders\n    from orders\n\n    group by customer_id\n\n),\n\ncustomer_payments as (\n\n    select\n        orders.customer_id,\n        sum(amount)::bigint as total_amount\n\n    from payments\n\n    left join orders on\n         payments.order_id = orders.order_id\n\n    group by orders.customer_id\n\n),\n\nfinal as (\n\n    select\n        customers.customer_id,\n        customers.first_name,\n        customers.last_name,\n        customer_orders.first_order,\n        customer_orders.most_recent_order,\n        customer_orders.number_of_orders,\n        customer_payments.total_amount as customer_lifetime_value\n\n    from customers\n\n    left join customer_orders\n        on customers.customer_id = customer_orders.customer_id\n\n    left join customer_payments\n        on  customers.customer_id = customer_payments.customer_id\n\n)\n\nselect * from final",
+          "language": "sql",
+          "refs": [
+            {
+              "name": "stg_customers"
+            },
+            {
+              "name": "stg_orders"
+            },
+            {
+              "name": "stg_payments"
+            }
+          ],
+          "sources": [],
+          "metrics": [],
+          "depends_on": {
+            "macros": [],
+            "nodes": [
+              "model.jaffle_shop.stg_customers",
+              "model.jaffle_shop.stg_orders",
+              "model.jaffle_shop.stg_payments"
+            ]
+          },
+          "compiled_path": "target/compiled/jaffle_shop/models/int_customer_order_history_joined.sql",
+          "compiled": true,
+          "compiled_code": "with customers as (\n\n    select * from \"jaffle_shop\".\"main\".\"stg_customers\"\n\n),\n\norders as (\n\n    select * from \"jaffle_shop\".\"main\".\"stg_orders\"\n\n),\n\npayments as (\n\n    select * from \"jaffle_shop\".\"main\".\"stg_payments\"\n\n),\n\ncustomer_orders as (\n\n        select\n        customer_id,\n\n        min(order_date) as first_order,\n        max(order_date) as most_recent_order,\n        count(order_id) as number_of_orders\n    from orders\n\n    group by customer_id\n\n),\n\ncustomer_payments as (\n\n    select\n        orders.customer_id,\n        sum(amount)::bigint as total_amount\n\n    from payments\n\n    left join orders on\n         payments.order_id = orders.order_id\n\n    group by orders.customer_id\n\n),\n\nfinal as (\n\n    select\n        customers.customer_id,\n        customers.first_name,\n        customers.last_name,\n        customer_orders.first_order,\n        customer_orders.most_recent_order,\n        customer_orders.number_of_orders,\n        customer_payments.total_amount as customer_lifetime_value\n\n    from customers\n\n    left join customer_orders\n        on customers.customer_id = customer_orders.customer_id\n\n    left join customer_payments\n        on  customers.customer_id = customer_payments.customer_id\n\n)\n\nselect * from final",
+          "extra_ctes_injected": true,
+          "extra_ctes": [],
+          "contract": {
+            "enforced": false
+          },
+          "access": "protected",
+          "constraints": []
+        },
+        "model.jaffle_shop.stg_customers": {
+          "database": "jaffle_shop",
+          "schema": "main",
+          "name": "stg_customers",
+          "resource_type": "model",
+          "package_name": "jaffle_shop",
+          "path": "staging/stg_customers.sql",
+          "original_file_path": "models/staging/stg_customers.sql",
+          "unique_id": "model.jaffle_shop.stg_customers",
+          "fqn": [
+            "jaffle_shop",
+            "staging",
+            "stg_customers"
+          ],
+          "alias": "stg_customers",
+          "checksum": {
+            "name": "sha256",
+            "checksum": "80e3223cd54387e11fa16cd0f4cbe15f8ff74dcd9900b93856b9e39416178c9d"
+          },
+          "config": {
+            "enabled": true,
+            "tags": [
+              "piperider",
+              "piperider"
+            ],
+            "meta": {},
+            "materialized": "view",
+            "persist_docs": {},
+            "quoting": {},
+            "column_types": {},
+            "on_schema_change": "ignore",
+            "grants": {},
+            "packages": [],
+            "docs": {
+              "show": true
+            },
+            "contract": {
+              "enforced": false
+            },
+            "post-hook": [],
+            "pre-hook": []
+          },
+          "tags": [
+            "piperider"
+          ],
+          "description": "",
+          "columns": {
+            "customer_id": {
+              "name": "customer_id",
+              "description": "",
+              "meta": {},
+              "constraints": [],
+              "tags": []
+            }
+          },
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "patch_path": "jaffle_shop://models/staging/schema.yml",
+          "build_path": "target/run/jaffle_shop/models/staging/stg_customers.sql",
+          "deferred": false,
+          "unrendered_config": {
+            "materialized": "view",
+            "tags": "piperider"
+          },
+          "created_at": 1687240826.406902,
+          "relation_name": "\"jaffle_shop\".\"main\".\"stg_customers\"",
+          "raw_code": "with source as (\n\n    {#-\n    Normally we would select from the table here, but we are using seeds to load\n    our data in this project\n    #}\n    select * from {{ ref('raw_customers') }}\n\n),\n\nrenamed as (\n\n    select\n        id as customer_id,\n        first_name,\n        last_name\n\n    from source\n\n)\n\nselect * from renamed",
+          "language": "sql",
+          "refs": [
+            {
+              "name": "raw_customers"
+            }
+          ],
+          "sources": [],
+          "metrics": [],
+          "depends_on": {
+            "macros": [],
+            "nodes": [
+              "seed.jaffle_shop.raw_customers"
+            ]
+          },
+          "compiled_path": "target/compiled/jaffle_shop/models/staging/stg_customers.sql",
+          "compiled": true,
+          "compiled_code": "with source as (\n    select * from \"jaffle_shop\".\"main\".\"raw_customers\"\n\n),\n\nrenamed as (\n\n    select\n        id as customer_id,\n        first_name,\n        last_name\n\n    from source\n\n)\n\nselect * from renamed",
+          "extra_ctes_injected": true,
+          "extra_ctes": [],
+          "contract": {
+            "enforced": false
+          },
+          "access": "protected",
+          "constraints": []
+        },
+        "model.jaffle_shop.stg_payments": {
+          "database": "jaffle_shop",
+          "schema": "main",
+          "name": "stg_payments",
+          "resource_type": "model",
+          "package_name": "jaffle_shop",
+          "path": "staging/stg_payments.sql",
+          "original_file_path": "models/staging/stg_payments.sql",
+          "unique_id": "model.jaffle_shop.stg_payments",
+          "fqn": [
+            "jaffle_shop",
+            "staging",
+            "stg_payments"
+          ],
+          "alias": "stg_payments",
+          "checksum": {
+            "name": "sha256",
+            "checksum": "9c1ee3bfb10e07c2dfc325d55925da0e521887136d9051768cb8acf09dc86bda"
+          },
+          "config": {
+            "enabled": true,
+            "tags": [
+              "piperider",
+              "piperider"
+            ],
+            "meta": {},
+            "materialized": "view",
+            "persist_docs": {},
+            "quoting": {},
+            "column_types": {},
+            "on_schema_change": "ignore",
+            "grants": {},
+            "packages": [],
+            "docs": {
+              "show": true
+            },
+            "contract": {
+              "enforced": false
+            },
+            "post-hook": [],
+            "pre-hook": []
+          },
+          "tags": [
+            "piperider"
+          ],
+          "description": "",
+          "columns": {
+            "payment_id": {
+              "name": "payment_id",
+              "description": "",
+              "meta": {},
+              "constraints": [],
+              "tags": []
+            },
+            "payment_method": {
+              "name": "payment_method",
+              "description": "",
+              "meta": {},
+              "constraints": [],
+              "tags": []
+            }
+          },
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "patch_path": "jaffle_shop://models/staging/schema.yml",
+          "build_path": "target/run/jaffle_shop/models/staging/stg_payments.sql",
+          "deferred": false,
+          "unrendered_config": {
+            "materialized": "view",
+            "tags": "piperider"
+          },
+          "created_at": 1687240826.408064,
+          "relation_name": "\"jaffle_shop\".\"main\".\"stg_payments\"",
+          "raw_code": "with source as (\n    \n    {#-\n    Normally we would select from the table here, but we are using seeds to load\n    our data in this project\n    #}\n    select * from {{ ref('raw_payments') }}\n\n),\n\nrenamed as (\n\n    select\n        id as payment_id,\n        order_id,\n        payment_method,\n\n        -- `amount` is currently stored in cents, so we convert it to dollars\n        amount / 100 as amount\n\n    from source\n\n)\n\nselect * from renamed",
+          "language": "sql",
+          "refs": [
+            {
+              "name": "raw_payments"
+            }
+          ],
+          "sources": [],
+          "metrics": [],
+          "depends_on": {
+            "macros": [],
+            "nodes": [
+              "seed.jaffle_shop.raw_payments"
+            ]
+          },
+          "compiled_path": "target/compiled/jaffle_shop/models/staging/stg_payments.sql",
+          "compiled": true,
+          "compiled_code": "with source as (\n    select * from \"jaffle_shop\".\"main\".\"raw_payments\"\n\n),\n\nrenamed as (\n\n    select\n        id as payment_id,\n        order_id,\n        payment_method,\n\n        -- `amount` is currently stored in cents, so we convert it to dollars\n        amount / 100 as amount\n\n    from source\n\n)\n\nselect * from renamed",
+          "extra_ctes_injected": true,
+          "extra_ctes": [],
+          "contract": {
+            "enforced": false
+          },
+          "access": "protected",
+          "constraints": []
+        },
+        "model.jaffle_shop.stg_orders": {
+          "database": "jaffle_shop",
+          "schema": "main",
+          "name": "stg_orders",
+          "resource_type": "model",
+          "package_name": "jaffle_shop",
+          "path": "staging/stg_orders.sql",
+          "original_file_path": "models/staging/stg_orders.sql",
+          "unique_id": "model.jaffle_shop.stg_orders",
+          "fqn": [
+            "jaffle_shop",
+            "staging",
+            "stg_orders"
+          ],
+          "alias": "stg_orders",
+          "checksum": {
+            "name": "sha256",
+            "checksum": "0bc34d953a33548e7476302e43e2d1a3e97a91506ef644ce93406ac57844c767"
+          },
+          "config": {
+            "enabled": true,
+            "tags": [
+              "piperider",
+              "piperider"
+            ],
+            "meta": {},
+            "materialized": "view",
+            "persist_docs": {},
+            "quoting": {},
+            "column_types": {},
+            "on_schema_change": "ignore",
+            "grants": {},
+            "packages": [],
+            "docs": {
+              "show": true
+            },
+            "contract": {
+              "enforced": false
+            },
+            "post-hook": [],
+            "pre-hook": []
+          },
+          "tags": [
+            "piperider"
+          ],
+          "description": "",
+          "columns": {
+            "order_id": {
+              "name": "order_id",
+              "description": "",
+              "meta": {},
+              "constraints": [],
+              "tags": []
+            },
+            "status": {
+              "name": "status",
+              "description": "",
+              "meta": {},
+              "constraints": [],
+              "tags": []
+            }
+          },
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "patch_path": "jaffle_shop://models/staging/schema.yml",
+          "build_path": "target/run/jaffle_shop/models/staging/stg_orders.sql",
+          "deferred": false,
+          "unrendered_config": {
+            "materialized": "view",
+            "tags": "piperider"
+          },
+          "created_at": 1687240826.407497,
+          "relation_name": "\"jaffle_shop\".\"main\".\"stg_orders\"",
+          "raw_code": "with source as (\n\n    {#-\n    Normally we would select from the table here, but we are using seeds to load\n    our data in this project\n    #}\n    select * from {{ ref('raw_orders') }}\n\n),\n\nrenamed as (\n\n    select\n        id as order_id,\n        user_id as customer_id,\n        order_date,\n        status\n\n    from source\n\n),\n\n-- Shift the order_date by the number of days since 2018-04-09 (the max order_date in the raw data)\nshift_date as (\n    \n    select\n        order_id,\n        customer_id,\n        (order_date + datediff('day', date '2018-04-09', CURRENT_DATE)::int) as order_date,\n        status        \n\n    from renamed\n)\n\nselect * from shift_date",
+          "language": "sql",
+          "refs": [
+            {
+              "name": "raw_orders"
+            }
+          ],
+          "sources": [],
+          "metrics": [],
+          "depends_on": {
+            "macros": [],
+            "nodes": [
+              "seed.jaffle_shop.raw_orders"
+            ]
+          },
+          "compiled_path": "target/compiled/jaffle_shop/models/staging/stg_orders.sql",
+          "compiled": true,
+          "compiled_code": "with source as (\n    select * from \"jaffle_shop\".\"main\".\"raw_orders\"\n\n),\n\nrenamed as (\n\n    select\n        id as order_id,\n        user_id as customer_id,\n        order_date,\n        status\n\n    from source\n\n),\n\n-- Shift the order_date by the number of days since 2018-04-09 (the max order_date in the raw data)\nshift_date as (\n    \n    select\n        order_id,\n        customer_id,\n        (order_date + datediff('day', date '2018-04-09', CURRENT_DATE)::int) as order_date,\n        status        \n\n    from renamed\n)\n\nselect * from shift_date",
+          "extra_ctes_injected": true,
+          "extra_ctes": [],
+          "contract": {
+            "enforced": false
+          },
+          "access": "protected",
+          "constraints": []
+        },
+        "model.jaffle_shop.stg_statuses": {
+          "database": "jaffle_shop",
+          "schema": "main",
+          "name": "stg_statuses",
+          "resource_type": "model",
+          "package_name": "jaffle_shop",
+          "path": "staging/stg_statuses.sql",
+          "original_file_path": "models/staging/stg_statuses.sql",
+          "unique_id": "model.jaffle_shop.stg_statuses",
+          "fqn": [
+            "jaffle_shop",
+            "staging",
+            "stg_statuses"
+          ],
+          "alias": "stg_statuses",
+          "checksum": {
+            "name": "sha256",
+            "checksum": "abee788d115f06ad9ca45d5202c513c80f9c59b37575c4f1b946ade36dfeaedb"
+          },
+          "config": {
+            "enabled": true,
+            "tags": [
+              "piperider",
+              "piperider"
+            ],
+            "meta": {},
+            "materialized": "view",
+            "persist_docs": {},
+            "quoting": {},
+            "column_types": {},
+            "on_schema_change": "ignore",
+            "grants": {},
+            "packages": [],
+            "docs": {
+              "show": true
+            },
+            "contract": {
+              "enforced": false
+            },
+            "post-hook": [],
+            "pre-hook": []
+          },
+          "tags": [
+            "piperider"
+          ],
+          "description": "",
+          "columns": {},
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "build_path": "target/run/jaffle_shop/models/staging/stg_statuses.sql",
+          "deferred": false,
+          "unrendered_config": {
+            "materialized": "view",
+            "tags": "piperider"
+          },
+          "created_at": 1687240826.326926,
+          "relation_name": "\"jaffle_shop\".\"main\".\"stg_statuses\"",
+          "raw_code": "select * from {{ ref('raw_statuses') }}",
+          "language": "sql",
+          "refs": [
+            {
+              "name": "raw_statuses"
+            }
+          ],
+          "sources": [],
+          "metrics": [],
+          "depends_on": {
+            "macros": [],
+            "nodes": [
+              "seed.jaffle_shop.raw_statuses"
+            ]
+          },
+          "compiled_path": "target/compiled/jaffle_shop/models/staging/stg_statuses.sql",
+          "compiled": true,
+          "compiled_code": "select * from \"jaffle_shop\".\"main\".\"raw_statuses\"",
+          "extra_ctes_injected": true,
+          "extra_ctes": [],
+          "contract": {
+            "enforced": false
+          },
+          "access": "protected",
+          "constraints": []
+        },
+        "model.jaffle_shop.orders": {
+          "database": "jaffle_shop",
+          "schema": "main",
+          "name": "orders",
+          "resource_type": "model",
+          "package_name": "jaffle_shop",
+          "path": "marts/orders.sql",
+          "original_file_path": "models/marts/orders.sql",
+          "unique_id": "model.jaffle_shop.orders",
+          "fqn": [
+            "jaffle_shop",
+            "marts",
+            "orders"
+          ],
+          "alias": "orders",
+          "checksum": {
+            "name": "sha256",
+            "checksum": "c7ebcdfa0e91b127f1095bd788794f24b866a234c47cd6686b0efb95af58b6e6"
+          },
+          "config": {
+            "enabled": true,
+            "tags": [
+              "piperider",
+              "piperider"
+            ],
+            "meta": {},
+            "materialized": "table",
+            "persist_docs": {},
+            "quoting": {},
+            "column_types": {},
+            "on_schema_change": "ignore",
+            "grants": {},
+            "packages": [],
+            "docs": {
+              "show": true
+            },
+            "contract": {
+              "enforced": false
+            },
+            "post-hook": [],
+            "pre-hook": []
+          },
+          "tags": [
+            "piperider"
+          ],
+          "description": "This table has basic information about orders, as well as some derived facts based on payments",
+          "columns": {
+            "order_id": {
+              "name": "order_id",
+              "description": "This is a unique identifier for an order",
+              "meta": {},
+              "constraints": [],
+              "tags": []
+            },
+            "customer_id": {
+              "name": "customer_id",
+              "description": "This is a unique identifier for a customer",
+              "meta": {},
+              "constraints": [],
+              "tags": []
+            },
+            "order_date": {
+              "name": "order_date",
+              "description": "Date (UTC) that the order was placed",
+              "meta": {},
+              "constraints": [],
+              "tags": []
+            },
+            "status": {
+              "name": "status",
+              "description": "Orders can be one of the following statuses:\n\n| status         | description                                                                                                            |\n|----------------|------------------------------------------------------------------------------------------------------------------------|\n| placed         | The order has been placed but has not yet left the warehouse                                                           |\n| shipped        | The order has ben shipped to the customer and is currently in transit                                                  |\n| completed      | The order has been received by the customer                                                                            |\n| return_pending | The customer has indicated that they would like to return the order, but it has not yet been received at the warehouse |\n| returned       | The order has been returned by the customer and received at the warehouse                                              |",
+              "meta": {},
+              "constraints": [],
+              "tags": []
+            },
+            "amount": {
+              "name": "amount",
+              "description": "Total amount (AUD) of the order",
+              "meta": {},
+              "constraints": [],
+              "tags": []
+            },
+            "credit_card_amount": {
+              "name": "credit_card_amount",
+              "description": "Amount of the order (AUD) paid for by credit card",
+              "meta": {},
+              "constraints": [],
+              "tags": []
+            },
+            "coupon_amount": {
+              "name": "coupon_amount",
+              "description": "Amount of the order (AUD) paid for by coupon",
+              "meta": {},
+              "constraints": [],
+              "tags": []
+            },
+            "bank_transfer_amount": {
+              "name": "bank_transfer_amount",
+              "description": "Amount of the order (AUD) paid for by bank transfer",
+              "meta": {},
+              "constraints": [],
+              "tags": []
+            },
+            "gift_card_amount": {
+              "name": "gift_card_amount",
+              "description": "Amount of the order (AUD) paid for by gift card",
+              "meta": {},
+              "constraints": [],
+              "tags": []
+            },
+            "first_name": {
+              "name": "first_name",
+              "description": "Customer's first name. PII.",
+              "meta": {},
+              "constraints": [],
+              "tags": []
+            },
+            "last_name": {
+              "name": "last_name",
+              "description": "Customer's last name. PII.",
+              "meta": {},
+              "constraints": [],
+              "tags": []
+            },
+            "first_order": {
+              "name": "first_order",
+              "description": "Date (UTC) of a customer's first order",
+              "meta": {},
+              "constraints": [],
+              "tags": []
+            },
+            "most_recent_order": {
+              "name": "most_recent_order",
+              "description": "Date (UTC) of a customer's most recent order",
+              "meta": {},
+              "constraints": [],
+              "tags": []
+            },
+            "number_of_orders": {
+              "name": "number_of_orders",
+              "description": "Count of the number of orders a customer has placed",
+              "meta": {},
+              "constraints": [],
+              "tags": []
+            },
+            "total_order_amount": {
+              "name": "total_order_amount",
+              "description": "Total value (AUD) of a customer's orders",
+              "meta": {},
+              "constraints": [],
+              "tags": []
+            }
+          },
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "patch_path": "jaffle_shop://models/marts/orders.yml",
+          "build_path": "target/run/jaffle_shop/models/marts/orders.sql",
+          "deferred": false,
+          "unrendered_config": {
+            "materialized": "table",
+            "tags": "piperider"
+          },
+          "created_at": 1687240826.429204,
+          "relation_name": "\"jaffle_shop\".\"main\".\"orders\"",
+          "raw_code": "with orders as (\n\n    select * from {{ ref('int_order_payments_pivoted') }}\n\n)\n,\ncustomers as (\n\n    select * from {{ ref('int_customer_order_history_joined') }}\n\n)\n,\nstatuses as (\n    select * from {{ ref('stg_statuses') }}\n),\nfinal as (\n\n    select \n        *\n    from orders \n    left join customers using (customer_id)\n    inner join statuses using (status)\n)\n\nselect * from final",
+          "language": "sql",
+          "refs": [
+            {
+              "name": "int_order_payments_pivoted"
+            },
+            {
+              "name": "int_customer_order_history_joined"
+            },
+            {
+              "name": "stg_statuses"
+            }
+          ],
+          "sources": [],
+          "metrics": [],
+          "depends_on": {
+            "macros": [],
+            "nodes": [
+              "model.jaffle_shop.int_order_payments_pivoted",
+              "model.jaffle_shop.int_customer_order_history_joined",
+              "model.jaffle_shop.stg_statuses"
+            ]
+          },
+          "compiled_path": "target/compiled/jaffle_shop/models/marts/orders.sql",
+          "compiled": true,
+          "compiled_code": "with orders as (\n\n    select * from \"jaffle_shop\".\"main\".\"int_order_payments_pivoted\"\n\n)\n,\ncustomers as (\n\n    select * from \"jaffle_shop\".\"main\".\"int_customer_order_history_joined\"\n\n)\n,\nstatuses as (\n    select * from \"jaffle_shop\".\"main\".\"stg_statuses\"\n),\nfinal as (\n\n    select \n        *\n    from orders \n    left join customers using (customer_id)\n    inner join statuses using (status)\n)\n\nselect * from final",
+          "extra_ctes_injected": true,
+          "extra_ctes": [],
+          "contract": {
+            "enforced": false
+          },
+          "access": "protected",
+          "constraints": []
+        },
+        "seed.jaffle_shop.raw_statuses": {
+          "database": "jaffle_shop",
+          "schema": "main",
+          "name": "raw_statuses",
+          "resource_type": "seed",
+          "package_name": "jaffle_shop",
+          "path": "raw_statuses.csv",
+          "original_file_path": "seeds/raw_statuses.csv",
+          "unique_id": "seed.jaffle_shop.raw_statuses",
+          "fqn": [
+            "jaffle_shop",
+            "raw_statuses"
+          ],
+          "alias": "raw_statuses",
+          "checksum": {
+            "name": "sha256",
+            "checksum": "0910f08a686f4fb87ecd5a01ccda5c54ee706615fd9bf8088d0130db1f0cb83b"
+          },
+          "config": {
+            "enabled": true,
+            "tags": [],
+            "meta": {},
+            "materialized": "seed",
+            "persist_docs": {},
+            "quoting": {},
+            "column_types": {},
+            "on_schema_change": "ignore",
+            "grants": {},
+            "packages": [],
+            "docs": {
+              "show": true
+            },
+            "contract": {
+              "enforced": false
+            },
+            "post-hook": [],
+            "pre-hook": []
+          },
+          "tags": [],
+          "description": "",
+          "columns": {},
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "build_path": "target/run/jaffle_shop/seeds/raw_statuses.csv",
+          "deferred": false,
+          "unrendered_config": {},
+          "created_at": 1687240826.3369422,
+          "relation_name": "\"jaffle_shop\".\"main\".\"raw_statuses\"",
+          "raw_code": "",
+          "root_path": "/Users/popcorny/Documents/infuseai/repo/jaffle_shop",
+          "depends_on": {
+            "macros": []
+          }
+        },
+        "seed.jaffle_shop.raw_customers": {
+          "database": "jaffle_shop",
+          "schema": "main",
+          "name": "raw_customers",
+          "resource_type": "seed",
+          "package_name": "jaffle_shop",
+          "path": "raw_customers.csv",
+          "original_file_path": "seeds/raw_customers.csv",
+          "unique_id": "seed.jaffle_shop.raw_customers",
+          "fqn": [
+            "jaffle_shop",
+            "raw_customers"
+          ],
+          "alias": "raw_customers",
+          "checksum": {
+            "name": "sha256",
+            "checksum": "357d173dda65a741ad97d6683502286cc2655bb396ab5f4dfad12b8c39bd2a63"
+          },
+          "config": {
+            "enabled": true,
+            "tags": [],
+            "meta": {},
+            "materialized": "seed",
+            "persist_docs": {},
+            "quoting": {},
+            "column_types": {},
+            "on_schema_change": "ignore",
+            "grants": {},
+            "packages": [],
+            "docs": {
+              "show": true
+            },
+            "contract": {
+              "enforced": false
+            },
+            "post-hook": [],
+            "pre-hook": []
+          },
+          "tags": [],
+          "description": "",
+          "columns": {},
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "build_path": "target/run/jaffle_shop/seeds/raw_customers.csv",
+          "deferred": false,
+          "unrendered_config": {},
+          "created_at": 1687240826.338455,
+          "relation_name": "\"jaffle_shop\".\"main\".\"raw_customers\"",
+          "raw_code": "",
+          "root_path": "/Users/popcorny/Documents/infuseai/repo/jaffle_shop",
+          "depends_on": {
+            "macros": []
+          }
+        },
+        "seed.jaffle_shop.raw_orders": {
+          "database": "jaffle_shop",
+          "schema": "main",
+          "name": "raw_orders",
+          "resource_type": "seed",
+          "package_name": "jaffle_shop",
+          "path": "raw_orders.csv",
+          "original_file_path": "seeds/raw_orders.csv",
+          "unique_id": "seed.jaffle_shop.raw_orders",
+          "fqn": [
+            "jaffle_shop",
+            "raw_orders"
+          ],
+          "alias": "raw_orders",
+          "checksum": {
+            "name": "sha256",
+            "checksum": "ddecd7adf70a07a88b9c302aec2a03fce615b925c2c06f2d5ef99a5c97b41250"
+          },
+          "config": {
+            "enabled": true,
+            "tags": [],
+            "meta": {},
+            "materialized": "seed",
+            "persist_docs": {},
+            "quoting": {},
+            "column_types": {},
+            "on_schema_change": "ignore",
+            "grants": {},
+            "packages": [],
+            "docs": {
+              "show": true
+            },
+            "contract": {
+              "enforced": false
+            },
+            "post-hook": [],
+            "pre-hook": []
+          },
+          "tags": [],
+          "description": "",
+          "columns": {},
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "build_path": "target/run/jaffle_shop/seeds/raw_orders.csv",
+          "deferred": false,
+          "unrendered_config": {},
+          "created_at": 1687240826.339823,
+          "relation_name": "\"jaffle_shop\".\"main\".\"raw_orders\"",
+          "raw_code": "",
+          "root_path": "/Users/popcorny/Documents/infuseai/repo/jaffle_shop",
+          "depends_on": {
+            "macros": []
+          }
+        },
+        "seed.jaffle_shop.raw_payments": {
+          "database": "jaffle_shop",
+          "schema": "main",
+          "name": "raw_payments",
+          "resource_type": "seed",
+          "package_name": "jaffle_shop",
+          "path": "raw_payments.csv",
+          "original_file_path": "seeds/raw_payments.csv",
+          "unique_id": "seed.jaffle_shop.raw_payments",
+          "fqn": [
+            "jaffle_shop",
+            "raw_payments"
+          ],
+          "alias": "raw_payments",
+          "checksum": {
+            "name": "sha256",
+            "checksum": "6de0626a8db9c1750eefd1b2e17fac4c2a4b9f778eb50532d8b377b90de395e6"
+          },
+          "config": {
+            "enabled": true,
+            "tags": [],
+            "meta": {},
+            "materialized": "seed",
+            "persist_docs": {},
+            "quoting": {},
+            "column_types": {},
+            "on_schema_change": "ignore",
+            "grants": {},
+            "packages": [],
+            "docs": {
+              "show": true
+            },
+            "contract": {
+              "enforced": false
+            },
+            "post-hook": [],
+            "pre-hook": []
+          },
+          "tags": [],
+          "description": "",
+          "columns": {},
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "build_path": "target/run/jaffle_shop/seeds/raw_payments.csv",
+          "deferred": false,
+          "unrendered_config": {},
+          "created_at": 1687240826.3411782,
+          "relation_name": "\"jaffle_shop\".\"main\".\"raw_payments\"",
+          "raw_code": "",
+          "root_path": "/Users/popcorny/Documents/infuseai/repo/jaffle_shop",
+          "depends_on": {
+            "macros": []
+          }
+        },
+        "test.jaffle_shop.unique_int_customer_order_history_joined_customer_id.995635f7d9": {
+          "test_metadata": {
+            "name": "unique",
+            "kwargs": {
+              "column_name": "customer_id",
+              "model": "{{ get_where_subquery(ref('int_customer_order_history_joined')) }}"
+            }
+          },
+          "database": "jaffle_shop",
+          "schema": "main_dbt_test__audit",
+          "name": "unique_int_customer_order_history_joined_customer_id",
+          "resource_type": "test",
+          "package_name": "jaffle_shop",
+          "path": "unique_int_customer_order_history_joined_customer_id.sql",
+          "original_file_path": "models/schema.yml",
+          "unique_id": "test.jaffle_shop.unique_int_customer_order_history_joined_customer_id.995635f7d9",
+          "fqn": [
+            "jaffle_shop",
+            "unique_int_customer_order_history_joined_customer_id"
+          ],
+          "alias": "unique_int_customer_order_history_joined_customer_id",
+          "checksum": {
+            "name": "none",
+            "checksum": ""
+          },
+          "config": {
+            "enabled": true,
+            "schema": "dbt_test__audit",
+            "tags": [],
+            "meta": {},
+            "materialized": "test",
+            "severity": "ERROR",
+            "fail_calc": "count(*)",
+            "warn_if": "!= 0",
+            "error_if": "!= 0"
+          },
+          "tags": [],
+          "description": "",
+          "columns": {},
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "build_path": "target/run/jaffle_shop/models/schema.yml/unique_int_customer_order_history_joined_customer_id.sql",
+          "deferred": false,
+          "unrendered_config": {},
+          "created_at": 1687240826.360508,
+          "raw_code": "{{ test_unique(**_dbt_generic_test_kwargs) }}",
+          "language": "sql",
+          "refs": [
+            {
+              "name": "int_customer_order_history_joined"
+            }
+          ],
+          "sources": [],
+          "metrics": [],
+          "depends_on": {
+            "macros": [
+              "macro.dbt.test_unique",
+              "macro.dbt.get_where_subquery",
+              "macro.dbt.should_store_failures",
+              "macro.dbt.statement"
+            ],
+            "nodes": [
+              "model.jaffle_shop.int_customer_order_history_joined"
+            ]
+          },
+          "compiled_path": "target/compiled/jaffle_shop/models/schema.yml/unique_int_customer_order_history_joined_customer_id.sql",
+          "compiled": true,
+          "compiled_code": "\n    \n    \n\nselect\n    customer_id as unique_field,\n    count(*) as n_records\n\nfrom \"jaffle_shop\".\"main\".\"int_customer_order_history_joined\"\nwhere customer_id is not null\ngroup by customer_id\nhaving count(*) > 1\n\n\n",
+          "extra_ctes_injected": true,
+          "extra_ctes": [],
+          "contract": {
+            "enforced": false
+          },
+          "column_name": "customer_id",
+          "file_key_name": "models.int_customer_order_history_joined",
+          "attached_node": "model.jaffle_shop.int_customer_order_history_joined"
+        },
+        "test.jaffle_shop.not_null_int_customer_order_history_joined_customer_id.5eeb8cdf92": {
+          "test_metadata": {
+            "name": "not_null",
+            "kwargs": {
+              "column_name": "customer_id",
+              "model": "{{ get_where_subquery(ref('int_customer_order_history_joined')) }}"
+            }
+          },
+          "database": "jaffle_shop",
+          "schema": "main_dbt_test__audit",
+          "name": "not_null_int_customer_order_history_joined_customer_id",
+          "resource_type": "test",
+          "package_name": "jaffle_shop",
+          "path": "not_null_int_customer_order_history_joined_customer_id.sql",
+          "original_file_path": "models/schema.yml",
+          "unique_id": "test.jaffle_shop.not_null_int_customer_order_history_joined_customer_id.5eeb8cdf92",
+          "fqn": [
+            "jaffle_shop",
+            "not_null_int_customer_order_history_joined_customer_id"
+          ],
+          "alias": "not_null_int_customer_order_history_joined_customer_id",
+          "checksum": {
+            "name": "none",
+            "checksum": ""
+          },
+          "config": {
+            "enabled": true,
+            "schema": "dbt_test__audit",
+            "tags": [],
+            "meta": {},
+            "materialized": "test",
+            "severity": "ERROR",
+            "fail_calc": "count(*)",
+            "warn_if": "!= 0",
+            "error_if": "!= 0"
+          },
+          "tags": [],
+          "description": "",
+          "columns": {},
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "build_path": "target/run/jaffle_shop/models/schema.yml/not_null_int_customer_order_history_joined_customer_id.sql",
+          "deferred": false,
+          "unrendered_config": {},
+          "created_at": 1687240826.361815,
+          "raw_code": "{{ test_not_null(**_dbt_generic_test_kwargs) }}",
+          "language": "sql",
+          "refs": [
+            {
+              "name": "int_customer_order_history_joined"
+            }
+          ],
+          "sources": [],
+          "metrics": [],
+          "depends_on": {
+            "macros": [
+              "macro.dbt.test_not_null",
+              "macro.dbt.get_where_subquery",
+              "macro.dbt.should_store_failures",
+              "macro.dbt.statement"
+            ],
+            "nodes": [
+              "model.jaffle_shop.int_customer_order_history_joined"
+            ]
+          },
+          "compiled_path": "target/compiled/jaffle_shop/models/schema.yml/not_null_int_customer_order_history_joined_customer_id.sql",
+          "compiled": true,
+          "compiled_code": "\n    \n    \n\n\n\nselect customer_id\nfrom \"jaffle_shop\".\"main\".\"int_customer_order_history_joined\"\nwhere customer_id is null\n\n\n",
+          "extra_ctes_injected": true,
+          "extra_ctes": [],
+          "contract": {
+            "enforced": false
+          },
+          "column_name": "customer_id",
+          "file_key_name": "models.int_customer_order_history_joined",
+          "attached_node": "model.jaffle_shop.int_customer_order_history_joined"
+        },
+        "test.jaffle_shop.unique_int_order_payments_pivoted_order_id.34a0f3307d": {
+          "test_metadata": {
+            "name": "unique",
+            "kwargs": {
+              "column_name": "order_id",
+              "model": "{{ get_where_subquery(ref('int_order_payments_pivoted')) }}"
+            }
+          },
+          "database": "jaffle_shop",
+          "schema": "main_dbt_test__audit",
+          "name": "unique_int_order_payments_pivoted_order_id",
+          "resource_type": "test",
+          "package_name": "jaffle_shop",
+          "path": "unique_int_order_payments_pivoted_order_id.sql",
+          "original_file_path": "models/schema.yml",
+          "unique_id": "test.jaffle_shop.unique_int_order_payments_pivoted_order_id.34a0f3307d",
+          "fqn": [
+            "jaffle_shop",
+            "unique_int_order_payments_pivoted_order_id"
+          ],
+          "alias": "unique_int_order_payments_pivoted_order_id",
+          "checksum": {
+            "name": "none",
+            "checksum": ""
+          },
+          "config": {
+            "enabled": true,
+            "schema": "dbt_test__audit",
+            "tags": [],
+            "meta": {},
+            "materialized": "test",
+            "severity": "ERROR",
+            "fail_calc": "count(*)",
+            "warn_if": "!= 0",
+            "error_if": "!= 0"
+          },
+          "tags": [],
+          "description": "",
+          "columns": {},
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "build_path": "target/run/jaffle_shop/models/schema.yml/unique_int_order_payments_pivoted_order_id.sql",
+          "deferred": false,
+          "unrendered_config": {},
+          "created_at": 1687240826.3629708,
+          "raw_code": "{{ test_unique(**_dbt_generic_test_kwargs) }}",
+          "language": "sql",
+          "refs": [
+            {
+              "name": "int_order_payments_pivoted"
+            }
+          ],
+          "sources": [],
+          "metrics": [],
+          "depends_on": {
+            "macros": [
+              "macro.dbt.test_unique",
+              "macro.dbt.get_where_subquery",
+              "macro.dbt.should_store_failures",
+              "macro.dbt.statement"
+            ],
+            "nodes": [
+              "model.jaffle_shop.int_order_payments_pivoted"
+            ]
+          },
+          "compiled_path": "target/compiled/jaffle_shop/models/schema.yml/unique_int_order_payments_pivoted_order_id.sql",
+          "compiled": true,
+          "compiled_code": "\n    \n    \n\nselect\n    order_id as unique_field,\n    count(*) as n_records\n\nfrom \"jaffle_shop\".\"main\".\"int_order_payments_pivoted\"\nwhere order_id is not null\ngroup by order_id\nhaving count(*) > 1\n\n\n",
+          "extra_ctes_injected": true,
+          "extra_ctes": [],
+          "contract": {
+            "enforced": false
+          },
+          "column_name": "order_id",
+          "file_key_name": "models.int_order_payments_pivoted",
+          "attached_node": "model.jaffle_shop.int_order_payments_pivoted"
+        },
+        "test.jaffle_shop.not_null_int_order_payments_pivoted_order_id.787ba994a8": {
+          "test_metadata": {
+            "name": "not_null",
+            "kwargs": {
+              "column_name": "order_id",
+              "model": "{{ get_where_subquery(ref('int_order_payments_pivoted')) }}"
+            }
+          },
+          "database": "jaffle_shop",
+          "schema": "main_dbt_test__audit",
+          "name": "not_null_int_order_payments_pivoted_order_id",
+          "resource_type": "test",
+          "package_name": "jaffle_shop",
+          "path": "not_null_int_order_payments_pivoted_order_id.sql",
+          "original_file_path": "models/schema.yml",
+          "unique_id": "test.jaffle_shop.not_null_int_order_payments_pivoted_order_id.787ba994a8",
+          "fqn": [
+            "jaffle_shop",
+            "not_null_int_order_payments_pivoted_order_id"
+          ],
+          "alias": "not_null_int_order_payments_pivoted_order_id",
+          "checksum": {
+            "name": "none",
+            "checksum": ""
+          },
+          "config": {
+            "enabled": true,
+            "schema": "dbt_test__audit",
+            "tags": [],
+            "meta": {},
+            "materialized": "test",
+            "severity": "ERROR",
+            "fail_calc": "count(*)",
+            "warn_if": "!= 0",
+            "error_if": "!= 0"
+          },
+          "tags": [],
+          "description": "",
+          "columns": {},
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "build_path": "target/run/jaffle_shop/models/schema.yml/not_null_int_order_payments_pivoted_order_id.sql",
+          "deferred": false,
+          "unrendered_config": {},
+          "created_at": 1687240826.364091,
+          "raw_code": "{{ test_not_null(**_dbt_generic_test_kwargs) }}",
+          "language": "sql",
+          "refs": [
+            {
+              "name": "int_order_payments_pivoted"
+            }
+          ],
+          "sources": [],
+          "metrics": [],
+          "depends_on": {
+            "macros": [
+              "macro.dbt.test_not_null",
+              "macro.dbt.get_where_subquery",
+              "macro.dbt.should_store_failures",
+              "macro.dbt.statement"
+            ],
+            "nodes": [
+              "model.jaffle_shop.int_order_payments_pivoted"
+            ]
+          },
+          "compiled_path": "target/compiled/jaffle_shop/models/schema.yml/not_null_int_order_payments_pivoted_order_id.sql",
+          "compiled": true,
+          "compiled_code": "\n    \n    \n\n\n\nselect order_id\nfrom \"jaffle_shop\".\"main\".\"int_order_payments_pivoted\"\nwhere order_id is null\n\n\n",
+          "extra_ctes_injected": true,
+          "extra_ctes": [],
+          "contract": {
+            "enforced": false
+          },
+          "column_name": "order_id",
+          "file_key_name": "models.int_order_payments_pivoted",
+          "attached_node": "model.jaffle_shop.int_order_payments_pivoted"
+        },
+        "test.jaffle_shop.not_null_int_order_payments_pivoted_customer_id.3db59c6de4": {
+          "test_metadata": {
+            "name": "not_null",
+            "kwargs": {
+              "column_name": "customer_id",
+              "model": "{{ get_where_subquery(ref('int_order_payments_pivoted')) }}"
+            }
+          },
+          "database": "jaffle_shop",
+          "schema": "main_dbt_test__audit",
+          "name": "not_null_int_order_payments_pivoted_customer_id",
+          "resource_type": "test",
+          "package_name": "jaffle_shop",
+          "path": "not_null_int_order_payments_pivoted_customer_id.sql",
+          "original_file_path": "models/schema.yml",
+          "unique_id": "test.jaffle_shop.not_null_int_order_payments_pivoted_customer_id.3db59c6de4",
+          "fqn": [
+            "jaffle_shop",
+            "not_null_int_order_payments_pivoted_customer_id"
+          ],
+          "alias": "not_null_int_order_payments_pivoted_customer_id",
+          "checksum": {
+            "name": "none",
+            "checksum": ""
+          },
+          "config": {
+            "enabled": true,
+            "schema": "dbt_test__audit",
+            "tags": [],
+            "meta": {},
+            "materialized": "test",
+            "severity": "ERROR",
+            "fail_calc": "count(*)",
+            "warn_if": "!= 0",
+            "error_if": "!= 0"
+          },
+          "tags": [],
+          "description": "",
+          "columns": {},
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "build_path": "target/run/jaffle_shop/models/schema.yml/not_null_int_order_payments_pivoted_customer_id.sql",
+          "deferred": false,
+          "unrendered_config": {},
+          "created_at": 1687240826.365271,
+          "raw_code": "{{ test_not_null(**_dbt_generic_test_kwargs) }}",
+          "language": "sql",
+          "refs": [
+            {
+              "name": "int_order_payments_pivoted"
+            }
+          ],
+          "sources": [],
+          "metrics": [],
+          "depends_on": {
+            "macros": [
+              "macro.dbt.test_not_null",
+              "macro.dbt.get_where_subquery",
+              "macro.dbt.should_store_failures",
+              "macro.dbt.statement"
+            ],
+            "nodes": [
+              "model.jaffle_shop.int_order_payments_pivoted"
+            ]
+          },
+          "compiled_path": "target/compiled/jaffle_shop/models/schema.yml/not_null_int_order_payments_pivoted_customer_id.sql",
+          "compiled": true,
+          "compiled_code": "\n    \n    \n\n\n\nselect customer_id\nfrom \"jaffle_shop\".\"main\".\"int_order_payments_pivoted\"\nwhere customer_id is null\n\n\n",
+          "extra_ctes_injected": true,
+          "extra_ctes": [],
+          "contract": {
+            "enforced": false
+          },
+          "column_name": "customer_id",
+          "file_key_name": "models.int_order_payments_pivoted",
+          "attached_node": "model.jaffle_shop.int_order_payments_pivoted"
+        },
+        "test.jaffle_shop.relationships_int_order_payments_pivoted_customer_id__customer_id__ref_int_customer_order_history_joined_.654a1aa35d": {
+          "test_metadata": {
+            "name": "relationships",
+            "kwargs": {
+              "to": "ref('int_customer_order_history_joined')",
+              "field": "customer_id",
+              "column_name": "customer_id",
+              "model": "{{ get_where_subquery(ref('int_order_payments_pivoted')) }}"
+            }
+          },
+          "database": "jaffle_shop",
+          "schema": "main_dbt_test__audit",
+          "name": "relationships_int_order_payments_pivoted_customer_id__customer_id__ref_int_customer_order_history_joined_",
+          "resource_type": "test",
+          "package_name": "jaffle_shop",
+          "path": "relationships_int_order_paymen_0a5fcb40aa1fc18dbd520bbf52b44924.sql",
+          "original_file_path": "models/schema.yml",
+          "unique_id": "test.jaffle_shop.relationships_int_order_payments_pivoted_customer_id__customer_id__ref_int_customer_order_history_joined_.654a1aa35d",
+          "fqn": [
+            "jaffle_shop",
+            "relationships_int_order_payments_pivoted_customer_id__customer_id__ref_int_customer_order_history_joined_"
+          ],
+          "alias": "relationships_int_order_paymen_0a5fcb40aa1fc18dbd520bbf52b44924",
+          "checksum": {
+            "name": "none",
+            "checksum": ""
+          },
+          "config": {
+            "enabled": true,
+            "alias": "relationships_int_order_paymen_0a5fcb40aa1fc18dbd520bbf52b44924",
+            "schema": "dbt_test__audit",
+            "tags": [],
+            "meta": {},
+            "materialized": "test",
+            "severity": "ERROR",
+            "fail_calc": "count(*)",
+            "warn_if": "!= 0",
+            "error_if": "!= 0"
+          },
+          "tags": [],
+          "description": "",
+          "columns": {},
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "build_path": "target/run/jaffle_shop/models/schema.yml/relationships_int_order_paymen_0a5fcb40aa1fc18dbd520bbf52b44924.sql",
+          "deferred": false,
+          "unrendered_config": {
+            "alias": "relationships_int_order_paymen_0a5fcb40aa1fc18dbd520bbf52b44924"
+          },
+          "created_at": 1687240826.366596,
+          "raw_code": "{{ test_relationships(**_dbt_generic_test_kwargs) }}{{ config(alias=\"relationships_int_order_paymen_0a5fcb40aa1fc18dbd520bbf52b44924\") }}",
+          "language": "sql",
+          "refs": [
+            {
+              "name": "int_customer_order_history_joined"
+            },
+            {
+              "name": "int_order_payments_pivoted"
+            }
+          ],
+          "sources": [],
+          "metrics": [],
+          "depends_on": {
+            "macros": [
+              "macro.dbt.test_relationships",
+              "macro.dbt.get_where_subquery",
+              "macro.dbt.should_store_failures",
+              "macro.dbt.statement"
+            ],
+            "nodes": [
+              "model.jaffle_shop.int_customer_order_history_joined",
+              "model.jaffle_shop.int_order_payments_pivoted"
+            ]
+          },
+          "compiled_path": "target/compiled/jaffle_shop/models/schema.yml/relationships_int_order_paymen_0a5fcb40aa1fc18dbd520bbf52b44924.sql",
+          "compiled": true,
+          "compiled_code": "\n    \n    \n\nwith child as (\n    select customer_id as from_field\n    from \"jaffle_shop\".\"main\".\"int_order_payments_pivoted\"\n    where customer_id is not null\n),\n\nparent as (\n    select customer_id as to_field\n    from \"jaffle_shop\".\"main\".\"int_customer_order_history_joined\"\n)\n\nselect\n    from_field\n\nfrom child\nleft join parent\n    on child.from_field = parent.to_field\n\nwhere parent.to_field is null\n\n\n",
+          "extra_ctes_injected": true,
+          "extra_ctes": [],
+          "contract": {
+            "enforced": false
+          },
+          "column_name": "customer_id",
+          "file_key_name": "models.int_order_payments_pivoted",
+          "attached_node": "model.jaffle_shop.int_order_payments_pivoted"
+        },
+        "test.jaffle_shop.accepted_values_int_order_payments_pivoted_status__placed__shipped__completed__return_pending__returned.0ccdff53e8": {
+          "test_metadata": {
+            "name": "accepted_values",
+            "kwargs": {
+              "values": [
+                "placed",
+                "shipped",
+                "completed",
+                "return_pending",
+                "returned"
+              ],
+              "column_name": "status",
+              "model": "{{ get_where_subquery(ref('int_order_payments_pivoted')) }}"
+            }
+          },
+          "database": "jaffle_shop",
+          "schema": "main_dbt_test__audit",
+          "name": "accepted_values_int_order_payments_pivoted_status__placed__shipped__completed__return_pending__returned",
+          "resource_type": "test",
+          "package_name": "jaffle_shop",
+          "path": "accepted_values_int_order_paym_9fe2727f303988bdfad8f1fd2813d0f2.sql",
+          "original_file_path": "models/schema.yml",
+          "unique_id": "test.jaffle_shop.accepted_values_int_order_payments_pivoted_status__placed__shipped__completed__return_pending__returned.0ccdff53e8",
+          "fqn": [
+            "jaffle_shop",
+            "accepted_values_int_order_payments_pivoted_status__placed__shipped__completed__return_pending__returned"
+          ],
+          "alias": "accepted_values_int_order_paym_9fe2727f303988bdfad8f1fd2813d0f2",
+          "checksum": {
+            "name": "none",
+            "checksum": ""
+          },
+          "config": {
+            "enabled": true,
+            "alias": "accepted_values_int_order_paym_9fe2727f303988bdfad8f1fd2813d0f2",
+            "schema": "dbt_test__audit",
+            "tags": [],
+            "meta": {},
+            "materialized": "test",
+            "severity": "ERROR",
+            "fail_calc": "count(*)",
+            "warn_if": "!= 0",
+            "error_if": "!= 0"
+          },
+          "tags": [],
+          "description": "",
+          "columns": {},
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "build_path": "target/run/jaffle_shop/models/schema.yml/accepted_values_int_order_paym_9fe2727f303988bdfad8f1fd2813d0f2.sql",
+          "deferred": false,
+          "unrendered_config": {
+            "alias": "accepted_values_int_order_paym_9fe2727f303988bdfad8f1fd2813d0f2"
+          },
+          "created_at": 1687240826.373487,
+          "raw_code": "{{ test_accepted_values(**_dbt_generic_test_kwargs) }}{{ config(alias=\"accepted_values_int_order_paym_9fe2727f303988bdfad8f1fd2813d0f2\") }}",
+          "language": "sql",
+          "refs": [
+            {
+              "name": "int_order_payments_pivoted"
+            }
+          ],
+          "sources": [],
+          "metrics": [],
+          "depends_on": {
+            "macros": [
+              "macro.dbt.test_accepted_values",
+              "macro.dbt.get_where_subquery",
+              "macro.dbt.should_store_failures",
+              "macro.dbt.statement"
+            ],
+            "nodes": [
+              "model.jaffle_shop.int_order_payments_pivoted"
+            ]
+          },
+          "compiled_path": "target/compiled/jaffle_shop/models/schema.yml/accepted_values_int_order_paym_9fe2727f303988bdfad8f1fd2813d0f2.sql",
+          "compiled": true,
+          "compiled_code": "\n    \n    \n\nwith all_values as (\n\n    select\n        status as value_field,\n        count(*) as n_records\n\n    from \"jaffle_shop\".\"main\".\"int_order_payments_pivoted\"\n    group by status\n\n)\n\nselect *\nfrom all_values\nwhere value_field not in (\n    'placed','shipped','completed','return_pending','returned'\n)\n\n\n",
+          "extra_ctes_injected": true,
+          "extra_ctes": [],
+          "contract": {
+            "enforced": false
+          },
+          "column_name": "status",
+          "file_key_name": "models.int_order_payments_pivoted",
+          "attached_node": "model.jaffle_shop.int_order_payments_pivoted"
+        },
+        "test.jaffle_shop.not_null_int_order_payments_pivoted_amount.b7598e0e3b": {
+          "test_metadata": {
+            "name": "not_null",
+            "kwargs": {
+              "column_name": "amount",
+              "model": "{{ get_where_subquery(ref('int_order_payments_pivoted')) }}"
+            }
+          },
+          "database": "jaffle_shop",
+          "schema": "main_dbt_test__audit",
+          "name": "not_null_int_order_payments_pivoted_amount",
+          "resource_type": "test",
+          "package_name": "jaffle_shop",
+          "path": "not_null_int_order_payments_pivoted_amount.sql",
+          "original_file_path": "models/schema.yml",
+          "unique_id": "test.jaffle_shop.not_null_int_order_payments_pivoted_amount.b7598e0e3b",
+          "fqn": [
+            "jaffle_shop",
+            "not_null_int_order_payments_pivoted_amount"
+          ],
+          "alias": "not_null_int_order_payments_pivoted_amount",
+          "checksum": {
+            "name": "none",
+            "checksum": ""
+          },
+          "config": {
+            "enabled": true,
+            "schema": "dbt_test__audit",
+            "tags": [],
+            "meta": {},
+            "materialized": "test",
+            "severity": "ERROR",
+            "fail_calc": "count(*)",
+            "warn_if": "!= 0",
+            "error_if": "!= 0"
+          },
+          "tags": [],
+          "description": "",
+          "columns": {},
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "build_path": "target/run/jaffle_shop/models/schema.yml/not_null_int_order_payments_pivoted_amount.sql",
+          "deferred": false,
+          "unrendered_config": {},
+          "created_at": 1687240826.400733,
+          "raw_code": "{{ test_not_null(**_dbt_generic_test_kwargs) }}",
+          "language": "sql",
+          "refs": [
+            {
+              "name": "int_order_payments_pivoted"
+            }
+          ],
+          "sources": [],
+          "metrics": [],
+          "depends_on": {
+            "macros": [
+              "macro.dbt.test_not_null",
+              "macro.dbt.get_where_subquery",
+              "macro.dbt.should_store_failures",
+              "macro.dbt.statement"
+            ],
+            "nodes": [
+              "model.jaffle_shop.int_order_payments_pivoted"
+            ]
+          },
+          "compiled_path": "target/compiled/jaffle_shop/models/schema.yml/not_null_int_order_payments_pivoted_amount.sql",
+          "compiled": true,
+          "compiled_code": "\n    \n    \n\n\n\nselect amount\nfrom \"jaffle_shop\".\"main\".\"int_order_payments_pivoted\"\nwhere amount is null\n\n\n",
+          "extra_ctes_injected": true,
+          "extra_ctes": [],
+          "contract": {
+            "enforced": false
+          },
+          "column_name": "amount",
+          "file_key_name": "models.int_order_payments_pivoted",
+          "attached_node": "model.jaffle_shop.int_order_payments_pivoted"
+        },
+        "test.jaffle_shop.not_null_int_order_payments_pivoted_credit_card_amount.ae9c42d967": {
+          "test_metadata": {
+            "name": "not_null",
+            "kwargs": {
+              "column_name": "credit_card_amount",
+              "model": "{{ get_where_subquery(ref('int_order_payments_pivoted')) }}"
+            }
+          },
+          "database": "jaffle_shop",
+          "schema": "main_dbt_test__audit",
+          "name": "not_null_int_order_payments_pivoted_credit_card_amount",
+          "resource_type": "test",
+          "package_name": "jaffle_shop",
+          "path": "not_null_int_order_payments_pivoted_credit_card_amount.sql",
+          "original_file_path": "models/schema.yml",
+          "unique_id": "test.jaffle_shop.not_null_int_order_payments_pivoted_credit_card_amount.ae9c42d967",
+          "fqn": [
+            "jaffle_shop",
+            "not_null_int_order_payments_pivoted_credit_card_amount"
+          ],
+          "alias": "not_null_int_order_payments_pivoted_credit_card_amount",
+          "checksum": {
+            "name": "none",
+            "checksum": ""
+          },
+          "config": {
+            "enabled": true,
+            "schema": "dbt_test__audit",
+            "tags": [],
+            "meta": {},
+            "materialized": "test",
+            "severity": "ERROR",
+            "fail_calc": "count(*)",
+            "warn_if": "!= 0",
+            "error_if": "!= 0"
+          },
+          "tags": [],
+          "description": "",
+          "columns": {},
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "build_path": "target/run/jaffle_shop/models/schema.yml/not_null_int_order_payments_pivoted_credit_card_amount.sql",
+          "deferred": false,
+          "unrendered_config": {},
+          "created_at": 1687240826.4018931,
+          "raw_code": "{{ test_not_null(**_dbt_generic_test_kwargs) }}",
+          "language": "sql",
+          "refs": [
+            {
+              "name": "int_order_payments_pivoted"
+            }
+          ],
+          "sources": [],
+          "metrics": [],
+          "depends_on": {
+            "macros": [
+              "macro.dbt.test_not_null",
+              "macro.dbt.get_where_subquery",
+              "macro.dbt.should_store_failures",
+              "macro.dbt.statement"
+            ],
+            "nodes": [
+              "model.jaffle_shop.int_order_payments_pivoted"
+            ]
+          },
+          "compiled_path": "target/compiled/jaffle_shop/models/schema.yml/not_null_int_order_payments_pivoted_credit_card_amount.sql",
+          "compiled": true,
+          "compiled_code": "\n    \n    \n\n\n\nselect credit_card_amount\nfrom \"jaffle_shop\".\"main\".\"int_order_payments_pivoted\"\nwhere credit_card_amount is null\n\n\n",
+          "extra_ctes_injected": true,
+          "extra_ctes": [],
+          "contract": {
+            "enforced": false
+          },
+          "column_name": "credit_card_amount",
+          "file_key_name": "models.int_order_payments_pivoted",
+          "attached_node": "model.jaffle_shop.int_order_payments_pivoted"
+        },
+        "test.jaffle_shop.not_null_int_order_payments_pivoted_coupon_amount.2532b538c2": {
+          "test_metadata": {
+            "name": "not_null",
+            "kwargs": {
+              "column_name": "coupon_amount",
+              "model": "{{ get_where_subquery(ref('int_order_payments_pivoted')) }}"
+            }
+          },
+          "database": "jaffle_shop",
+          "schema": "main_dbt_test__audit",
+          "name": "not_null_int_order_payments_pivoted_coupon_amount",
+          "resource_type": "test",
+          "package_name": "jaffle_shop",
+          "path": "not_null_int_order_payments_pivoted_coupon_amount.sql",
+          "original_file_path": "models/schema.yml",
+          "unique_id": "test.jaffle_shop.not_null_int_order_payments_pivoted_coupon_amount.2532b538c2",
+          "fqn": [
+            "jaffle_shop",
+            "not_null_int_order_payments_pivoted_coupon_amount"
+          ],
+          "alias": "not_null_int_order_payments_pivoted_coupon_amount",
+          "checksum": {
+            "name": "none",
+            "checksum": ""
+          },
+          "config": {
+            "enabled": true,
+            "schema": "dbt_test__audit",
+            "tags": [],
+            "meta": {},
+            "materialized": "test",
+            "severity": "ERROR",
+            "fail_calc": "count(*)",
+            "warn_if": "!= 0",
+            "error_if": "!= 0"
+          },
+          "tags": [],
+          "description": "",
+          "columns": {},
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "build_path": "target/run/jaffle_shop/models/schema.yml/not_null_int_order_payments_pivoted_coupon_amount.sql",
+          "deferred": false,
+          "unrendered_config": {},
+          "created_at": 1687240826.403085,
+          "raw_code": "{{ test_not_null(**_dbt_generic_test_kwargs) }}",
+          "language": "sql",
+          "refs": [
+            {
+              "name": "int_order_payments_pivoted"
+            }
+          ],
+          "sources": [],
+          "metrics": [],
+          "depends_on": {
+            "macros": [
+              "macro.dbt.test_not_null",
+              "macro.dbt.get_where_subquery",
+              "macro.dbt.should_store_failures",
+              "macro.dbt.statement"
+            ],
+            "nodes": [
+              "model.jaffle_shop.int_order_payments_pivoted"
+            ]
+          },
+          "compiled_path": "target/compiled/jaffle_shop/models/schema.yml/not_null_int_order_payments_pivoted_coupon_amount.sql",
+          "compiled": true,
+          "compiled_code": "\n    \n    \n\n\n\nselect coupon_amount\nfrom \"jaffle_shop\".\"main\".\"int_order_payments_pivoted\"\nwhere coupon_amount is null\n\n\n",
+          "extra_ctes_injected": true,
+          "extra_ctes": [],
+          "contract": {
+            "enforced": false
+          },
+          "column_name": "coupon_amount",
+          "file_key_name": "models.int_order_payments_pivoted",
+          "attached_node": "model.jaffle_shop.int_order_payments_pivoted"
+        },
+        "test.jaffle_shop.not_null_int_order_payments_pivoted_bank_transfer_amount.1a9e62933b": {
+          "test_metadata": {
+            "name": "not_null",
+            "kwargs": {
+              "column_name": "bank_transfer_amount",
+              "model": "{{ get_where_subquery(ref('int_order_payments_pivoted')) }}"
+            }
+          },
+          "database": "jaffle_shop",
+          "schema": "main_dbt_test__audit",
+          "name": "not_null_int_order_payments_pivoted_bank_transfer_amount",
+          "resource_type": "test",
+          "package_name": "jaffle_shop",
+          "path": "not_null_int_order_payments_pivoted_bank_transfer_amount.sql",
+          "original_file_path": "models/schema.yml",
+          "unique_id": "test.jaffle_shop.not_null_int_order_payments_pivoted_bank_transfer_amount.1a9e62933b",
+          "fqn": [
+            "jaffle_shop",
+            "not_null_int_order_payments_pivoted_bank_transfer_amount"
+          ],
+          "alias": "not_null_int_order_payments_pivoted_bank_transfer_amount",
+          "checksum": {
+            "name": "none",
+            "checksum": ""
+          },
+          "config": {
+            "enabled": true,
+            "schema": "dbt_test__audit",
+            "tags": [],
+            "meta": {},
+            "materialized": "test",
+            "severity": "ERROR",
+            "fail_calc": "count(*)",
+            "warn_if": "!= 0",
+            "error_if": "!= 0"
+          },
+          "tags": [],
+          "description": "",
+          "columns": {},
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "build_path": "target/run/jaffle_shop/models/schema.yml/not_null_int_order_payments_pivoted_bank_transfer_amount.sql",
+          "deferred": false,
+          "unrendered_config": {},
+          "created_at": 1687240826.404279,
+          "raw_code": "{{ test_not_null(**_dbt_generic_test_kwargs) }}",
+          "language": "sql",
+          "refs": [
+            {
+              "name": "int_order_payments_pivoted"
+            }
+          ],
+          "sources": [],
+          "metrics": [],
+          "depends_on": {
+            "macros": [
+              "macro.dbt.test_not_null",
+              "macro.dbt.get_where_subquery",
+              "macro.dbt.should_store_failures",
+              "macro.dbt.statement"
+            ],
+            "nodes": [
+              "model.jaffle_shop.int_order_payments_pivoted"
+            ]
+          },
+          "compiled_path": "target/compiled/jaffle_shop/models/schema.yml/not_null_int_order_payments_pivoted_bank_transfer_amount.sql",
+          "compiled": true,
+          "compiled_code": "\n    \n    \n\n\n\nselect bank_transfer_amount\nfrom \"jaffle_shop\".\"main\".\"int_order_payments_pivoted\"\nwhere bank_transfer_amount is null\n\n\n",
+          "extra_ctes_injected": true,
+          "extra_ctes": [],
+          "contract": {
+            "enforced": false
+          },
+          "column_name": "bank_transfer_amount",
+          "file_key_name": "models.int_order_payments_pivoted",
+          "attached_node": "model.jaffle_shop.int_order_payments_pivoted"
+        },
+        "test.jaffle_shop.not_null_int_order_payments_pivoted_gift_card_amount.710d789cc0": {
+          "test_metadata": {
+            "name": "not_null",
+            "kwargs": {
+              "column_name": "gift_card_amount",
+              "model": "{{ get_where_subquery(ref('int_order_payments_pivoted')) }}"
+            }
+          },
+          "database": "jaffle_shop",
+          "schema": "main_dbt_test__audit",
+          "name": "not_null_int_order_payments_pivoted_gift_card_amount",
+          "resource_type": "test",
+          "package_name": "jaffle_shop",
+          "path": "not_null_int_order_payments_pivoted_gift_card_amount.sql",
+          "original_file_path": "models/schema.yml",
+          "unique_id": "test.jaffle_shop.not_null_int_order_payments_pivoted_gift_card_amount.710d789cc0",
+          "fqn": [
+            "jaffle_shop",
+            "not_null_int_order_payments_pivoted_gift_card_amount"
+          ],
+          "alias": "not_null_int_order_payments_pivoted_gift_card_amount",
+          "checksum": {
+            "name": "none",
+            "checksum": ""
+          },
+          "config": {
+            "enabled": true,
+            "schema": "dbt_test__audit",
+            "tags": [],
+            "meta": {},
+            "materialized": "test",
+            "severity": "ERROR",
+            "fail_calc": "count(*)",
+            "warn_if": "!= 0",
+            "error_if": "!= 0"
+          },
+          "tags": [],
+          "description": "",
+          "columns": {},
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "build_path": "target/run/jaffle_shop/models/schema.yml/not_null_int_order_payments_pivoted_gift_card_amount.sql",
+          "deferred": false,
+          "unrendered_config": {},
+          "created_at": 1687240826.405523,
+          "raw_code": "{{ test_not_null(**_dbt_generic_test_kwargs) }}",
+          "language": "sql",
+          "refs": [
+            {
+              "name": "int_order_payments_pivoted"
+            }
+          ],
+          "sources": [],
+          "metrics": [],
+          "depends_on": {
+            "macros": [
+              "macro.dbt.test_not_null",
+              "macro.dbt.get_where_subquery",
+              "macro.dbt.should_store_failures",
+              "macro.dbt.statement"
+            ],
+            "nodes": [
+              "model.jaffle_shop.int_order_payments_pivoted"
+            ]
+          },
+          "compiled_path": "target/compiled/jaffle_shop/models/schema.yml/not_null_int_order_payments_pivoted_gift_card_amount.sql",
+          "compiled": true,
+          "compiled_code": "\n    \n    \n\n\n\nselect gift_card_amount\nfrom \"jaffle_shop\".\"main\".\"int_order_payments_pivoted\"\nwhere gift_card_amount is null\n\n\n",
+          "extra_ctes_injected": true,
+          "extra_ctes": [],
+          "contract": {
+            "enforced": false
+          },
+          "column_name": "gift_card_amount",
+          "file_key_name": "models.int_order_payments_pivoted",
+          "attached_node": "model.jaffle_shop.int_order_payments_pivoted"
+        },
+        "test.jaffle_shop.unique_stg_customers_customer_id.c7614daada": {
+          "test_metadata": {
+            "name": "unique",
+            "kwargs": {
+              "column_name": "customer_id",
+              "model": "{{ get_where_subquery(ref('stg_customers')) }}"
+            }
+          },
+          "database": "jaffle_shop",
+          "schema": "main_dbt_test__audit",
+          "name": "unique_stg_customers_customer_id",
+          "resource_type": "test",
+          "package_name": "jaffle_shop",
+          "path": "unique_stg_customers_customer_id.sql",
+          "original_file_path": "models/staging/schema.yml",
+          "unique_id": "test.jaffle_shop.unique_stg_customers_customer_id.c7614daada",
+          "fqn": [
+            "jaffle_shop",
+            "staging",
+            "unique_stg_customers_customer_id"
+          ],
+          "alias": "unique_stg_customers_customer_id",
+          "checksum": {
+            "name": "none",
+            "checksum": ""
+          },
+          "config": {
+            "enabled": true,
+            "schema": "dbt_test__audit",
+            "tags": [],
+            "meta": {},
+            "materialized": "test",
+            "severity": "ERROR",
+            "fail_calc": "count(*)",
+            "warn_if": "!= 0",
+            "error_if": "!= 0"
+          },
+          "tags": [],
+          "description": "",
+          "columns": {},
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "build_path": "target/run/jaffle_shop/models/staging/schema.yml/unique_stg_customers_customer_id.sql",
+          "deferred": false,
+          "unrendered_config": {},
+          "created_at": 1687240826.408467,
+          "raw_code": "{{ test_unique(**_dbt_generic_test_kwargs) }}",
+          "language": "sql",
+          "refs": [
+            {
+              "name": "stg_customers"
+            }
+          ],
+          "sources": [],
+          "metrics": [],
+          "depends_on": {
+            "macros": [
+              "macro.dbt.test_unique",
+              "macro.dbt.get_where_subquery",
+              "macro.dbt.should_store_failures",
+              "macro.dbt.statement"
+            ],
+            "nodes": [
+              "model.jaffle_shop.stg_customers"
+            ]
+          },
+          "compiled_path": "target/compiled/jaffle_shop/models/staging/schema.yml/unique_stg_customers_customer_id.sql",
+          "compiled": true,
+          "compiled_code": "\n    \n    \n\nselect\n    customer_id as unique_field,\n    count(*) as n_records\n\nfrom \"jaffle_shop\".\"main\".\"stg_customers\"\nwhere customer_id is not null\ngroup by customer_id\nhaving count(*) > 1\n\n\n",
+          "extra_ctes_injected": true,
+          "extra_ctes": [],
+          "contract": {
+            "enforced": false
+          },
+          "column_name": "customer_id",
+          "file_key_name": "models.stg_customers",
+          "attached_node": "model.jaffle_shop.stg_customers"
+        },
+        "test.jaffle_shop.not_null_stg_customers_customer_id.e2cfb1f9aa": {
+          "test_metadata": {
+            "name": "not_null",
+            "kwargs": {
+              "column_name": "customer_id",
+              "model": "{{ get_where_subquery(ref('stg_customers')) }}"
+            }
+          },
+          "database": "jaffle_shop",
+          "schema": "main_dbt_test__audit",
+          "name": "not_null_stg_customers_customer_id",
+          "resource_type": "test",
+          "package_name": "jaffle_shop",
+          "path": "not_null_stg_customers_customer_id.sql",
+          "original_file_path": "models/staging/schema.yml",
+          "unique_id": "test.jaffle_shop.not_null_stg_customers_customer_id.e2cfb1f9aa",
+          "fqn": [
+            "jaffle_shop",
+            "staging",
+            "not_null_stg_customers_customer_id"
+          ],
+          "alias": "not_null_stg_customers_customer_id",
+          "checksum": {
+            "name": "none",
+            "checksum": ""
+          },
+          "config": {
+            "enabled": true,
+            "schema": "dbt_test__audit",
+            "tags": [],
+            "meta": {},
+            "materialized": "test",
+            "severity": "ERROR",
+            "fail_calc": "count(*)",
+            "warn_if": "!= 0",
+            "error_if": "!= 0"
+          },
+          "tags": [],
+          "description": "",
+          "columns": {},
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "build_path": "target/run/jaffle_shop/models/staging/schema.yml/not_null_stg_customers_customer_id.sql",
+          "deferred": false,
+          "unrendered_config": {},
+          "created_at": 1687240826.4098141,
+          "raw_code": "{{ test_not_null(**_dbt_generic_test_kwargs) }}",
+          "language": "sql",
+          "refs": [
+            {
+              "name": "stg_customers"
+            }
+          ],
+          "sources": [],
+          "metrics": [],
+          "depends_on": {
+            "macros": [
+              "macro.dbt.test_not_null",
+              "macro.dbt.get_where_subquery",
+              "macro.dbt.should_store_failures",
+              "macro.dbt.statement"
+            ],
+            "nodes": [
+              "model.jaffle_shop.stg_customers"
+            ]
+          },
+          "compiled_path": "target/compiled/jaffle_shop/models/staging/schema.yml/not_null_stg_customers_customer_id.sql",
+          "compiled": true,
+          "compiled_code": "\n    \n    \n\n\n\nselect customer_id\nfrom \"jaffle_shop\".\"main\".\"stg_customers\"\nwhere customer_id is null\n\n\n",
+          "extra_ctes_injected": true,
+          "extra_ctes": [],
+          "contract": {
+            "enforced": false
+          },
+          "column_name": "customer_id",
+          "file_key_name": "models.stg_customers",
+          "attached_node": "model.jaffle_shop.stg_customers"
+        },
+        "test.jaffle_shop.unique_stg_orders_order_id.e3b841c71a": {
+          "test_metadata": {
+            "name": "unique",
+            "kwargs": {
+              "column_name": "order_id",
+              "model": "{{ get_where_subquery(ref('stg_orders')) }}"
+            }
+          },
+          "database": "jaffle_shop",
+          "schema": "main_dbt_test__audit",
+          "name": "unique_stg_orders_order_id",
+          "resource_type": "test",
+          "package_name": "jaffle_shop",
+          "path": "unique_stg_orders_order_id.sql",
+          "original_file_path": "models/staging/schema.yml",
+          "unique_id": "test.jaffle_shop.unique_stg_orders_order_id.e3b841c71a",
+          "fqn": [
+            "jaffle_shop",
+            "staging",
+            "unique_stg_orders_order_id"
+          ],
+          "alias": "unique_stg_orders_order_id",
+          "checksum": {
+            "name": "none",
+            "checksum": ""
+          },
+          "config": {
+            "enabled": true,
+            "schema": "dbt_test__audit",
+            "tags": [],
+            "meta": {},
+            "materialized": "test",
+            "severity": "ERROR",
+            "fail_calc": "count(*)",
+            "warn_if": "!= 0",
+            "error_if": "!= 0"
+          },
+          "tags": [],
+          "description": "",
+          "columns": {},
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "build_path": "target/run/jaffle_shop/models/staging/schema.yml/unique_stg_orders_order_id.sql",
+          "deferred": false,
+          "unrendered_config": {},
+          "created_at": 1687240826.410976,
+          "raw_code": "{{ test_unique(**_dbt_generic_test_kwargs) }}",
+          "language": "sql",
+          "refs": [
+            {
+              "name": "stg_orders"
+            }
+          ],
+          "sources": [],
+          "metrics": [],
+          "depends_on": {
+            "macros": [
+              "macro.dbt.test_unique",
+              "macro.dbt.get_where_subquery",
+              "macro.dbt.should_store_failures",
+              "macro.dbt.statement"
+            ],
+            "nodes": [
+              "model.jaffle_shop.stg_orders"
+            ]
+          },
+          "compiled_path": "target/compiled/jaffle_shop/models/staging/schema.yml/unique_stg_orders_order_id.sql",
+          "compiled": true,
+          "compiled_code": "\n    \n    \n\nselect\n    order_id as unique_field,\n    count(*) as n_records\n\nfrom \"jaffle_shop\".\"main\".\"stg_orders\"\nwhere order_id is not null\ngroup by order_id\nhaving count(*) > 1\n\n\n",
+          "extra_ctes_injected": true,
+          "extra_ctes": [],
+          "contract": {
+            "enforced": false
+          },
+          "column_name": "order_id",
+          "file_key_name": "models.stg_orders",
+          "attached_node": "model.jaffle_shop.stg_orders"
+        },
+        "test.jaffle_shop.not_null_stg_orders_order_id.81cfe2fe64": {
+          "test_metadata": {
+            "name": "not_null",
+            "kwargs": {
+              "column_name": "order_id",
+              "model": "{{ get_where_subquery(ref('stg_orders')) }}"
+            }
+          },
+          "database": "jaffle_shop",
+          "schema": "main_dbt_test__audit",
+          "name": "not_null_stg_orders_order_id",
+          "resource_type": "test",
+          "package_name": "jaffle_shop",
+          "path": "not_null_stg_orders_order_id.sql",
+          "original_file_path": "models/staging/schema.yml",
+          "unique_id": "test.jaffle_shop.not_null_stg_orders_order_id.81cfe2fe64",
+          "fqn": [
+            "jaffle_shop",
+            "staging",
+            "not_null_stg_orders_order_id"
+          ],
+          "alias": "not_null_stg_orders_order_id",
+          "checksum": {
+            "name": "none",
+            "checksum": ""
+          },
+          "config": {
+            "enabled": true,
+            "schema": "dbt_test__audit",
+            "tags": [],
+            "meta": {},
+            "materialized": "test",
+            "severity": "ERROR",
+            "fail_calc": "count(*)",
+            "warn_if": "!= 0",
+            "error_if": "!= 0"
+          },
+          "tags": [],
+          "description": "",
+          "columns": {},
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "build_path": "target/run/jaffle_shop/models/staging/schema.yml/not_null_stg_orders_order_id.sql",
+          "deferred": false,
+          "unrendered_config": {},
+          "created_at": 1687240826.412127,
+          "raw_code": "{{ test_not_null(**_dbt_generic_test_kwargs) }}",
+          "language": "sql",
+          "refs": [
+            {
+              "name": "stg_orders"
+            }
+          ],
+          "sources": [],
+          "metrics": [],
+          "depends_on": {
+            "macros": [
+              "macro.dbt.test_not_null",
+              "macro.dbt.get_where_subquery",
+              "macro.dbt.should_store_failures",
+              "macro.dbt.statement"
+            ],
+            "nodes": [
+              "model.jaffle_shop.stg_orders"
+            ]
+          },
+          "compiled_path": "target/compiled/jaffle_shop/models/staging/schema.yml/not_null_stg_orders_order_id.sql",
+          "compiled": true,
+          "compiled_code": "\n    \n    \n\n\n\nselect order_id\nfrom \"jaffle_shop\".\"main\".\"stg_orders\"\nwhere order_id is null\n\n\n",
+          "extra_ctes_injected": true,
+          "extra_ctes": [],
+          "contract": {
+            "enforced": false
+          },
+          "column_name": "order_id",
+          "file_key_name": "models.stg_orders",
+          "attached_node": "model.jaffle_shop.stg_orders"
+        },
+        "test.jaffle_shop.accepted_values_stg_orders_status__placed__shipped__completed__return_pending__returned.080fb20aad": {
+          "test_metadata": {
+            "name": "accepted_values",
+            "kwargs": {
+              "values": [
+                "placed",
+                "shipped",
+                "completed",
+                "return_pending",
+                "returned"
+              ],
+              "column_name": "status",
+              "model": "{{ get_where_subquery(ref('stg_orders')) }}"
+            }
+          },
+          "database": "jaffle_shop",
+          "schema": "main_dbt_test__audit",
+          "name": "accepted_values_stg_orders_status__placed__shipped__completed__return_pending__returned",
+          "resource_type": "test",
+          "package_name": "jaffle_shop",
+          "path": "accepted_values_stg_orders_4f514bf94b77b7ea437830eec4421c58.sql",
+          "original_file_path": "models/staging/schema.yml",
+          "unique_id": "test.jaffle_shop.accepted_values_stg_orders_status__placed__shipped__completed__return_pending__returned.080fb20aad",
+          "fqn": [
+            "jaffle_shop",
+            "staging",
+            "accepted_values_stg_orders_status__placed__shipped__completed__return_pending__returned"
+          ],
+          "alias": "accepted_values_stg_orders_4f514bf94b77b7ea437830eec4421c58",
+          "checksum": {
+            "name": "none",
+            "checksum": ""
+          },
+          "config": {
+            "enabled": true,
+            "alias": "accepted_values_stg_orders_4f514bf94b77b7ea437830eec4421c58",
+            "schema": "dbt_test__audit",
+            "tags": [],
+            "meta": {},
+            "materialized": "test",
+            "severity": "ERROR",
+            "fail_calc": "count(*)",
+            "warn_if": "!= 0",
+            "error_if": "!= 0"
+          },
+          "tags": [],
+          "description": "",
+          "columns": {},
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "build_path": "target/run/jaffle_shop/models/staging/schema.yml/accepted_values_stg_orders_4f514bf94b77b7ea437830eec4421c58.sql",
+          "deferred": false,
+          "unrendered_config": {
+            "alias": "accepted_values_stg_orders_4f514bf94b77b7ea437830eec4421c58"
+          },
+          "created_at": 1687240826.413384,
+          "raw_code": "{{ test_accepted_values(**_dbt_generic_test_kwargs) }}{{ config(alias=\"accepted_values_stg_orders_4f514bf94b77b7ea437830eec4421c58\") }}",
+          "language": "sql",
+          "refs": [
+            {
+              "name": "stg_orders"
+            }
+          ],
+          "sources": [],
+          "metrics": [],
+          "depends_on": {
+            "macros": [
+              "macro.dbt.test_accepted_values",
+              "macro.dbt.get_where_subquery",
+              "macro.dbt.should_store_failures",
+              "macro.dbt.statement"
+            ],
+            "nodes": [
+              "model.jaffle_shop.stg_orders"
+            ]
+          },
+          "compiled_path": "target/compiled/jaffle_shop/models/staging/schema.yml/accepted_values_stg_orders_4f514bf94b77b7ea437830eec4421c58.sql",
+          "compiled": true,
+          "compiled_code": "\n    \n    \n\nwith all_values as (\n\n    select\n        status as value_field,\n        count(*) as n_records\n\n    from \"jaffle_shop\".\"main\".\"stg_orders\"\n    group by status\n\n)\n\nselect *\nfrom all_values\nwhere value_field not in (\n    'placed','shipped','completed','return_pending','returned'\n)\n\n\n",
+          "extra_ctes_injected": true,
+          "extra_ctes": [],
+          "contract": {
+            "enforced": false
+          },
+          "column_name": "status",
+          "file_key_name": "models.stg_orders",
+          "attached_node": "model.jaffle_shop.stg_orders"
+        },
+        "test.jaffle_shop.unique_stg_payments_payment_id.3744510712": {
+          "test_metadata": {
+            "name": "unique",
+            "kwargs": {
+              "column_name": "payment_id",
+              "model": "{{ get_where_subquery(ref('stg_payments')) }}"
+            }
+          },
+          "database": "jaffle_shop",
+          "schema": "main_dbt_test__audit",
+          "name": "unique_stg_payments_payment_id",
+          "resource_type": "test",
+          "package_name": "jaffle_shop",
+          "path": "unique_stg_payments_payment_id.sql",
+          "original_file_path": "models/staging/schema.yml",
+          "unique_id": "test.jaffle_shop.unique_stg_payments_payment_id.3744510712",
+          "fqn": [
+            "jaffle_shop",
+            "staging",
+            "unique_stg_payments_payment_id"
+          ],
+          "alias": "unique_stg_payments_payment_id",
+          "checksum": {
+            "name": "none",
+            "checksum": ""
+          },
+          "config": {
+            "enabled": true,
+            "schema": "dbt_test__audit",
+            "tags": [],
+            "meta": {},
+            "materialized": "test",
+            "severity": "ERROR",
+            "fail_calc": "count(*)",
+            "warn_if": "!= 0",
+            "error_if": "!= 0"
+          },
+          "tags": [],
+          "description": "",
+          "columns": {},
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "build_path": "target/run/jaffle_shop/models/staging/schema.yml/unique_stg_payments_payment_id.sql",
+          "deferred": false,
+          "unrendered_config": {},
+          "created_at": 1687240826.416929,
+          "raw_code": "{{ test_unique(**_dbt_generic_test_kwargs) }}",
+          "language": "sql",
+          "refs": [
+            {
+              "name": "stg_payments"
+            }
+          ],
+          "sources": [],
+          "metrics": [],
+          "depends_on": {
+            "macros": [
+              "macro.dbt.test_unique",
+              "macro.dbt.get_where_subquery",
+              "macro.dbt.should_store_failures",
+              "macro.dbt.statement"
+            ],
+            "nodes": [
+              "model.jaffle_shop.stg_payments"
+            ]
+          },
+          "compiled_path": "target/compiled/jaffle_shop/models/staging/schema.yml/unique_stg_payments_payment_id.sql",
+          "compiled": true,
+          "compiled_code": "\n    \n    \n\nselect\n    payment_id as unique_field,\n    count(*) as n_records\n\nfrom \"jaffle_shop\".\"main\".\"stg_payments\"\nwhere payment_id is not null\ngroup by payment_id\nhaving count(*) > 1\n\n\n",
+          "extra_ctes_injected": true,
+          "extra_ctes": [],
+          "contract": {
+            "enforced": false
+          },
+          "column_name": "payment_id",
+          "file_key_name": "models.stg_payments",
+          "attached_node": "model.jaffle_shop.stg_payments"
+        },
+        "test.jaffle_shop.not_null_stg_payments_payment_id.c19cc50075": {
+          "test_metadata": {
+            "name": "not_null",
+            "kwargs": {
+              "column_name": "payment_id",
+              "model": "{{ get_where_subquery(ref('stg_payments')) }}"
+            }
+          },
+          "database": "jaffle_shop",
+          "schema": "main_dbt_test__audit",
+          "name": "not_null_stg_payments_payment_id",
+          "resource_type": "test",
+          "package_name": "jaffle_shop",
+          "path": "not_null_stg_payments_payment_id.sql",
+          "original_file_path": "models/staging/schema.yml",
+          "unique_id": "test.jaffle_shop.not_null_stg_payments_payment_id.c19cc50075",
+          "fqn": [
+            "jaffle_shop",
+            "staging",
+            "not_null_stg_payments_payment_id"
+          ],
+          "alias": "not_null_stg_payments_payment_id",
+          "checksum": {
+            "name": "none",
+            "checksum": ""
+          },
+          "config": {
+            "enabled": true,
+            "schema": "dbt_test__audit",
+            "tags": [],
+            "meta": {},
+            "materialized": "test",
+            "severity": "ERROR",
+            "fail_calc": "count(*)",
+            "warn_if": "!= 0",
+            "error_if": "!= 0"
+          },
+          "tags": [],
+          "description": "",
+          "columns": {},
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "build_path": "target/run/jaffle_shop/models/staging/schema.yml/not_null_stg_payments_payment_id.sql",
+          "deferred": false,
+          "unrendered_config": {},
+          "created_at": 1687240826.418236,
+          "raw_code": "{{ test_not_null(**_dbt_generic_test_kwargs) }}",
+          "language": "sql",
+          "refs": [
+            {
+              "name": "stg_payments"
+            }
+          ],
+          "sources": [],
+          "metrics": [],
+          "depends_on": {
+            "macros": [
+              "macro.dbt.test_not_null",
+              "macro.dbt.get_where_subquery",
+              "macro.dbt.should_store_failures",
+              "macro.dbt.statement"
+            ],
+            "nodes": [
+              "model.jaffle_shop.stg_payments"
+            ]
+          },
+          "compiled_path": "target/compiled/jaffle_shop/models/staging/schema.yml/not_null_stg_payments_payment_id.sql",
+          "compiled": true,
+          "compiled_code": "\n    \n    \n\n\n\nselect payment_id\nfrom \"jaffle_shop\".\"main\".\"stg_payments\"\nwhere payment_id is null\n\n\n",
+          "extra_ctes_injected": true,
+          "extra_ctes": [],
+          "contract": {
+            "enforced": false
+          },
+          "column_name": "payment_id",
+          "file_key_name": "models.stg_payments",
+          "attached_node": "model.jaffle_shop.stg_payments"
+        },
+        "test.jaffle_shop.accepted_values_stg_payments_payment_method__credit_card__coupon__bank_transfer__gift_card.3c3820f278": {
+          "test_metadata": {
+            "name": "accepted_values",
+            "kwargs": {
+              "values": [
+                "credit_card",
+                "coupon",
+                "bank_transfer",
+                "gift_card"
+              ],
+              "column_name": "payment_method",
+              "model": "{{ get_where_subquery(ref('stg_payments')) }}"
+            }
+          },
+          "database": "jaffle_shop",
+          "schema": "main_dbt_test__audit",
+          "name": "accepted_values_stg_payments_payment_method__credit_card__coupon__bank_transfer__gift_card",
+          "resource_type": "test",
+          "package_name": "jaffle_shop",
+          "path": "accepted_values_stg_payments_c7909fb19b1f0177c2bf99c7912f06ef.sql",
+          "original_file_path": "models/staging/schema.yml",
+          "unique_id": "test.jaffle_shop.accepted_values_stg_payments_payment_method__credit_card__coupon__bank_transfer__gift_card.3c3820f278",
+          "fqn": [
+            "jaffle_shop",
+            "staging",
+            "accepted_values_stg_payments_payment_method__credit_card__coupon__bank_transfer__gift_card"
+          ],
+          "alias": "accepted_values_stg_payments_c7909fb19b1f0177c2bf99c7912f06ef",
+          "checksum": {
+            "name": "none",
+            "checksum": ""
+          },
+          "config": {
+            "enabled": true,
+            "alias": "accepted_values_stg_payments_c7909fb19b1f0177c2bf99c7912f06ef",
+            "schema": "dbt_test__audit",
+            "tags": [],
+            "meta": {},
+            "materialized": "test",
+            "severity": "ERROR",
+            "fail_calc": "count(*)",
+            "warn_if": "!= 0",
+            "error_if": "!= 0"
+          },
+          "tags": [],
+          "description": "",
+          "columns": {},
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "build_path": "target/run/jaffle_shop/models/staging/schema.yml/accepted_values_stg_payments_c7909fb19b1f0177c2bf99c7912f06ef.sql",
+          "deferred": false,
+          "unrendered_config": {
+            "alias": "accepted_values_stg_payments_c7909fb19b1f0177c2bf99c7912f06ef"
+          },
+          "created_at": 1687240826.4194272,
+          "raw_code": "{{ test_accepted_values(**_dbt_generic_test_kwargs) }}{{ config(alias=\"accepted_values_stg_payments_c7909fb19b1f0177c2bf99c7912f06ef\") }}",
+          "language": "sql",
+          "refs": [
+            {
+              "name": "stg_payments"
+            }
+          ],
+          "sources": [],
+          "metrics": [],
+          "depends_on": {
+            "macros": [
+              "macro.dbt.test_accepted_values",
+              "macro.dbt.get_where_subquery",
+              "macro.dbt.should_store_failures",
+              "macro.dbt.statement"
+            ],
+            "nodes": [
+              "model.jaffle_shop.stg_payments"
+            ]
+          },
+          "compiled_path": "target/compiled/jaffle_shop/models/staging/schema.yml/accepted_values_stg_payments_c7909fb19b1f0177c2bf99c7912f06ef.sql",
+          "compiled": true,
+          "compiled_code": "\n    \n    \n\nwith all_values as (\n\n    select\n        payment_method as value_field,\n        count(*) as n_records\n\n    from \"jaffle_shop\".\"main\".\"stg_payments\"\n    group by payment_method\n\n)\n\nselect *\nfrom all_values\nwhere value_field not in (\n    'credit_card','coupon','bank_transfer','gift_card'\n)\n\n\n",
+          "extra_ctes_injected": true,
+          "extra_ctes": [],
+          "contract": {
+            "enforced": false
+          },
+          "column_name": "payment_method",
+          "file_key_name": "models.stg_payments",
+          "attached_node": "model.jaffle_shop.stg_payments"
+        },
+        "test.jaffle_shop.unique_orders_order_id.fed79b3a6e": {
+          "test_metadata": {
+            "name": "unique",
+            "kwargs": {
+              "column_name": "order_id",
+              "model": "{{ get_where_subquery(ref('orders')) }}"
+            }
+          },
+          "database": "jaffle_shop",
+          "schema": "main_dbt_test__audit",
+          "name": "unique_orders_order_id",
+          "resource_type": "test",
+          "package_name": "jaffle_shop",
+          "path": "unique_orders_order_id.sql",
+          "original_file_path": "models/marts/orders.yml",
+          "unique_id": "test.jaffle_shop.unique_orders_order_id.fed79b3a6e",
+          "fqn": [
+            "jaffle_shop",
+            "marts",
+            "unique_orders_order_id"
+          ],
+          "alias": "unique_orders_order_id",
+          "checksum": {
+            "name": "none",
+            "checksum": ""
+          },
+          "config": {
+            "enabled": true,
+            "schema": "dbt_test__audit",
+            "tags": [],
+            "meta": {},
+            "materialized": "test",
+            "severity": "ERROR",
+            "fail_calc": "count(*)",
+            "warn_if": "!= 0",
+            "error_if": "!= 0"
+          },
+          "tags": [],
+          "description": "",
+          "columns": {},
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "build_path": "target/run/jaffle_shop/models/marts/orders.yml/unique_orders_order_id.sql",
+          "deferred": false,
+          "unrendered_config": {},
+          "created_at": 1687240826.4296262,
+          "raw_code": "{{ test_unique(**_dbt_generic_test_kwargs) }}",
+          "language": "sql",
+          "refs": [
+            {
+              "name": "orders"
+            }
+          ],
+          "sources": [],
+          "metrics": [],
+          "depends_on": {
+            "macros": [
+              "macro.dbt.test_unique",
+              "macro.dbt.get_where_subquery",
+              "macro.dbt.should_store_failures",
+              "macro.dbt.statement"
+            ],
+            "nodes": [
+              "model.jaffle_shop.orders"
+            ]
+          },
+          "compiled_path": "target/compiled/jaffle_shop/models/marts/orders.yml/unique_orders_order_id.sql",
+          "compiled": true,
+          "compiled_code": "\n    \n    \n\nselect\n    order_id as unique_field,\n    count(*) as n_records\n\nfrom \"jaffle_shop\".\"main\".\"orders\"\nwhere order_id is not null\ngroup by order_id\nhaving count(*) > 1\n\n\n",
+          "extra_ctes_injected": true,
+          "extra_ctes": [],
+          "contract": {
+            "enforced": false
+          },
+          "column_name": "order_id",
+          "file_key_name": "models.orders",
+          "attached_node": "model.jaffle_shop.orders"
+        },
+        "test.jaffle_shop.not_null_orders_order_id.cf6c17daed": {
+          "test_metadata": {
+            "name": "not_null",
+            "kwargs": {
+              "column_name": "order_id",
+              "model": "{{ get_where_subquery(ref('orders')) }}"
+            }
+          },
+          "database": "jaffle_shop",
+          "schema": "main_dbt_test__audit",
+          "name": "not_null_orders_order_id",
+          "resource_type": "test",
+          "package_name": "jaffle_shop",
+          "path": "not_null_orders_order_id.sql",
+          "original_file_path": "models/marts/orders.yml",
+          "unique_id": "test.jaffle_shop.not_null_orders_order_id.cf6c17daed",
+          "fqn": [
+            "jaffle_shop",
+            "marts",
+            "not_null_orders_order_id"
+          ],
+          "alias": "not_null_orders_order_id",
+          "checksum": {
+            "name": "none",
+            "checksum": ""
+          },
+          "config": {
+            "enabled": true,
+            "schema": "dbt_test__audit",
+            "tags": [],
+            "meta": {},
+            "materialized": "test",
+            "severity": "ERROR",
+            "fail_calc": "count(*)",
+            "warn_if": "!= 0",
+            "error_if": "!= 0"
+          },
+          "tags": [],
+          "description": "",
+          "columns": {},
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "build_path": "target/run/jaffle_shop/models/marts/orders.yml/not_null_orders_order_id.sql",
+          "deferred": false,
+          "unrendered_config": {},
+          "created_at": 1687240826.43083,
+          "raw_code": "{{ test_not_null(**_dbt_generic_test_kwargs) }}",
+          "language": "sql",
+          "refs": [
+            {
+              "name": "orders"
+            }
+          ],
+          "sources": [],
+          "metrics": [],
+          "depends_on": {
+            "macros": [
+              "macro.dbt.test_not_null",
+              "macro.dbt.get_where_subquery",
+              "macro.dbt.should_store_failures",
+              "macro.dbt.statement"
+            ],
+            "nodes": [
+              "model.jaffle_shop.orders"
+            ]
+          },
+          "compiled_path": "target/compiled/jaffle_shop/models/marts/orders.yml/not_null_orders_order_id.sql",
+          "compiled": true,
+          "compiled_code": "\n    \n    \n\n\n\nselect order_id\nfrom \"jaffle_shop\".\"main\".\"orders\"\nwhere order_id is null\n\n\n",
+          "extra_ctes_injected": true,
+          "extra_ctes": [],
+          "contract": {
+            "enforced": false
+          },
+          "column_name": "order_id",
+          "file_key_name": "models.orders",
+          "attached_node": "model.jaffle_shop.orders"
+        },
+        "test.jaffle_shop.not_null_orders_customer_id.c5f02694af": {
+          "test_metadata": {
+            "name": "not_null",
+            "kwargs": {
+              "column_name": "customer_id",
+              "model": "{{ get_where_subquery(ref('orders')) }}"
+            }
+          },
+          "database": "jaffle_shop",
+          "schema": "main_dbt_test__audit",
+          "name": "not_null_orders_customer_id",
+          "resource_type": "test",
+          "package_name": "jaffle_shop",
+          "path": "not_null_orders_customer_id.sql",
+          "original_file_path": "models/marts/orders.yml",
+          "unique_id": "test.jaffle_shop.not_null_orders_customer_id.c5f02694af",
+          "fqn": [
+            "jaffle_shop",
+            "marts",
+            "not_null_orders_customer_id"
+          ],
+          "alias": "not_null_orders_customer_id",
+          "checksum": {
+            "name": "none",
+            "checksum": ""
+          },
+          "config": {
+            "enabled": true,
+            "schema": "dbt_test__audit",
+            "tags": [],
+            "meta": {},
+            "materialized": "test",
+            "severity": "ERROR",
+            "fail_calc": "count(*)",
+            "warn_if": "!= 0",
+            "error_if": "!= 0"
+          },
+          "tags": [],
+          "description": "",
+          "columns": {},
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "build_path": "target/run/jaffle_shop/models/marts/orders.yml/not_null_orders_customer_id.sql",
+          "deferred": false,
+          "unrendered_config": {},
+          "created_at": 1687240826.431974,
+          "raw_code": "{{ test_not_null(**_dbt_generic_test_kwargs) }}",
+          "language": "sql",
+          "refs": [
+            {
+              "name": "orders"
+            }
+          ],
+          "sources": [],
+          "metrics": [],
+          "depends_on": {
+            "macros": [
+              "macro.dbt.test_not_null",
+              "macro.dbt.get_where_subquery",
+              "macro.dbt.should_store_failures",
+              "macro.dbt.statement"
+            ],
+            "nodes": [
+              "model.jaffle_shop.orders"
+            ]
+          },
+          "compiled_path": "target/compiled/jaffle_shop/models/marts/orders.yml/not_null_orders_customer_id.sql",
+          "compiled": true,
+          "compiled_code": "\n    \n    \n\n\n\nselect customer_id\nfrom \"jaffle_shop\".\"main\".\"orders\"\nwhere customer_id is null\n\n\n",
+          "extra_ctes_injected": true,
+          "extra_ctes": [],
+          "contract": {
+            "enforced": false
+          },
+          "column_name": "customer_id",
+          "file_key_name": "models.orders",
+          "attached_node": "model.jaffle_shop.orders"
+        },
+        "test.jaffle_shop.accepted_values_orders_status__placed__shipped__completed__return_pending__returned.be6b5b5ec3": {
+          "test_metadata": {
+            "name": "accepted_values",
+            "kwargs": {
+              "values": [
+                "placed",
+                "shipped",
+                "completed",
+                "return_pending",
+                "returned"
+              ],
+              "column_name": "status",
+              "model": "{{ get_where_subquery(ref('orders')) }}"
+            }
+          },
+          "database": "jaffle_shop",
+          "schema": "main_dbt_test__audit",
+          "name": "accepted_values_orders_status__placed__shipped__completed__return_pending__returned",
+          "resource_type": "test",
+          "package_name": "jaffle_shop",
+          "path": "accepted_values_orders_1ce6ab157c285f7cd2ac656013faf758.sql",
+          "original_file_path": "models/marts/orders.yml",
+          "unique_id": "test.jaffle_shop.accepted_values_orders_status__placed__shipped__completed__return_pending__returned.be6b5b5ec3",
+          "fqn": [
+            "jaffle_shop",
+            "marts",
+            "accepted_values_orders_status__placed__shipped__completed__return_pending__returned"
+          ],
+          "alias": "accepted_values_orders_1ce6ab157c285f7cd2ac656013faf758",
+          "checksum": {
+            "name": "none",
+            "checksum": ""
+          },
+          "config": {
+            "enabled": true,
+            "alias": "accepted_values_orders_1ce6ab157c285f7cd2ac656013faf758",
+            "schema": "dbt_test__audit",
+            "tags": [],
+            "meta": {},
+            "materialized": "test",
+            "severity": "ERROR",
+            "fail_calc": "count(*)",
+            "warn_if": "!= 0",
+            "error_if": "!= 0"
+          },
+          "tags": [],
+          "description": "",
+          "columns": {},
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "build_path": "target/run/jaffle_shop/models/marts/orders.yml/accepted_values_orders_1ce6ab157c285f7cd2ac656013faf758.sql",
+          "deferred": false,
+          "unrendered_config": {
+            "alias": "accepted_values_orders_1ce6ab157c285f7cd2ac656013faf758"
+          },
+          "created_at": 1687240826.433218,
+          "raw_code": "{{ test_accepted_values(**_dbt_generic_test_kwargs) }}{{ config(alias=\"accepted_values_orders_1ce6ab157c285f7cd2ac656013faf758\") }}",
+          "language": "sql",
+          "refs": [
+            {
+              "name": "orders"
+            }
+          ],
+          "sources": [],
+          "metrics": [],
+          "depends_on": {
+            "macros": [
+              "macro.dbt.test_accepted_values",
+              "macro.dbt.get_where_subquery",
+              "macro.dbt.should_store_failures",
+              "macro.dbt.statement"
+            ],
+            "nodes": [
+              "model.jaffle_shop.orders"
+            ]
+          },
+          "compiled_path": "target/compiled/jaffle_shop/models/marts/orders.yml/accepted_values_orders_1ce6ab157c285f7cd2ac656013faf758.sql",
+          "compiled": true,
+          "compiled_code": "\n    \n    \n\nwith all_values as (\n\n    select\n        status as value_field,\n        count(*) as n_records\n\n    from \"jaffle_shop\".\"main\".\"orders\"\n    group by status\n\n)\n\nselect *\nfrom all_values\nwhere value_field not in (\n    'placed','shipped','completed','return_pending','returned'\n)\n\n\n",
+          "extra_ctes_injected": true,
+          "extra_ctes": [],
+          "contract": {
+            "enforced": false
+          },
+          "column_name": "status",
+          "file_key_name": "models.orders",
+          "attached_node": "model.jaffle_shop.orders"
+        },
+        "test.jaffle_shop.not_null_orders_amount.106140f9fd": {
+          "test_metadata": {
+            "name": "not_null",
+            "kwargs": {
+              "column_name": "amount",
+              "model": "{{ get_where_subquery(ref('orders')) }}"
+            }
+          },
+          "database": "jaffle_shop",
+          "schema": "main_dbt_test__audit",
+          "name": "not_null_orders_amount",
+          "resource_type": "test",
+          "package_name": "jaffle_shop",
+          "path": "not_null_orders_amount.sql",
+          "original_file_path": "models/marts/orders.yml",
+          "unique_id": "test.jaffle_shop.not_null_orders_amount.106140f9fd",
+          "fqn": [
+            "jaffle_shop",
+            "marts",
+            "not_null_orders_amount"
+          ],
+          "alias": "not_null_orders_amount",
+          "checksum": {
+            "name": "none",
+            "checksum": ""
+          },
+          "config": {
+            "enabled": true,
+            "schema": "dbt_test__audit",
+            "tags": [],
+            "meta": {},
+            "materialized": "test",
+            "severity": "ERROR",
+            "fail_calc": "count(*)",
+            "warn_if": "!= 0",
+            "error_if": "!= 0"
+          },
+          "tags": [],
+          "description": "",
+          "columns": {},
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "build_path": "target/run/jaffle_shop/models/marts/orders.yml/not_null_orders_amount.sql",
+          "deferred": false,
+          "unrendered_config": {},
+          "created_at": 1687240826.4367151,
+          "raw_code": "{{ test_not_null(**_dbt_generic_test_kwargs) }}",
+          "language": "sql",
+          "refs": [
+            {
+              "name": "orders"
+            }
+          ],
+          "sources": [],
+          "metrics": [],
+          "depends_on": {
+            "macros": [
+              "macro.dbt.test_not_null",
+              "macro.dbt.get_where_subquery",
+              "macro.dbt.should_store_failures",
+              "macro.dbt.statement"
+            ],
+            "nodes": [
+              "model.jaffle_shop.orders"
+            ]
+          },
+          "compiled_path": "target/compiled/jaffle_shop/models/marts/orders.yml/not_null_orders_amount.sql",
+          "compiled": true,
+          "compiled_code": "\n    \n    \n\n\n\nselect amount\nfrom \"jaffle_shop\".\"main\".\"orders\"\nwhere amount is null\n\n\n",
+          "extra_ctes_injected": true,
+          "extra_ctes": [],
+          "contract": {
+            "enforced": false
+          },
+          "column_name": "amount",
+          "file_key_name": "models.orders",
+          "attached_node": "model.jaffle_shop.orders"
+        },
+        "test.jaffle_shop.not_null_orders_credit_card_amount.d3ca593b59": {
+          "test_metadata": {
+            "name": "not_null",
+            "kwargs": {
+              "column_name": "credit_card_amount",
+              "model": "{{ get_where_subquery(ref('orders')) }}"
+            }
+          },
+          "database": "jaffle_shop",
+          "schema": "main_dbt_test__audit",
+          "name": "not_null_orders_credit_card_amount",
+          "resource_type": "test",
+          "package_name": "jaffle_shop",
+          "path": "not_null_orders_credit_card_amount.sql",
+          "original_file_path": "models/marts/orders.yml",
+          "unique_id": "test.jaffle_shop.not_null_orders_credit_card_amount.d3ca593b59",
+          "fqn": [
+            "jaffle_shop",
+            "marts",
+            "not_null_orders_credit_card_amount"
+          ],
+          "alias": "not_null_orders_credit_card_amount",
+          "checksum": {
+            "name": "none",
+            "checksum": ""
+          },
+          "config": {
+            "enabled": true,
+            "schema": "dbt_test__audit",
+            "tags": [],
+            "meta": {},
+            "materialized": "test",
+            "severity": "ERROR",
+            "fail_calc": "count(*)",
+            "warn_if": "!= 0",
+            "error_if": "!= 0"
+          },
+          "tags": [],
+          "description": "",
+          "columns": {},
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "build_path": "target/run/jaffle_shop/models/marts/orders.yml/not_null_orders_credit_card_amount.sql",
+          "deferred": false,
+          "unrendered_config": {},
+          "created_at": 1687240826.437857,
+          "raw_code": "{{ test_not_null(**_dbt_generic_test_kwargs) }}",
+          "language": "sql",
+          "refs": [
+            {
+              "name": "orders"
+            }
+          ],
+          "sources": [],
+          "metrics": [],
+          "depends_on": {
+            "macros": [
+              "macro.dbt.test_not_null",
+              "macro.dbt.get_where_subquery",
+              "macro.dbt.should_store_failures",
+              "macro.dbt.statement"
+            ],
+            "nodes": [
+              "model.jaffle_shop.orders"
+            ]
+          },
+          "compiled_path": "target/compiled/jaffle_shop/models/marts/orders.yml/not_null_orders_credit_card_amount.sql",
+          "compiled": true,
+          "compiled_code": "\n    \n    \n\n\n\nselect credit_card_amount\nfrom \"jaffle_shop\".\"main\".\"orders\"\nwhere credit_card_amount is null\n\n\n",
+          "extra_ctes_injected": true,
+          "extra_ctes": [],
+          "contract": {
+            "enforced": false
+          },
+          "column_name": "credit_card_amount",
+          "file_key_name": "models.orders",
+          "attached_node": "model.jaffle_shop.orders"
+        },
+        "test.jaffle_shop.not_null_orders_coupon_amount.ab90c90625": {
+          "test_metadata": {
+            "name": "not_null",
+            "kwargs": {
+              "column_name": "coupon_amount",
+              "model": "{{ get_where_subquery(ref('orders')) }}"
+            }
+          },
+          "database": "jaffle_shop",
+          "schema": "main_dbt_test__audit",
+          "name": "not_null_orders_coupon_amount",
+          "resource_type": "test",
+          "package_name": "jaffle_shop",
+          "path": "not_null_orders_coupon_amount.sql",
+          "original_file_path": "models/marts/orders.yml",
+          "unique_id": "test.jaffle_shop.not_null_orders_coupon_amount.ab90c90625",
+          "fqn": [
+            "jaffle_shop",
+            "marts",
+            "not_null_orders_coupon_amount"
+          ],
+          "alias": "not_null_orders_coupon_amount",
+          "checksum": {
+            "name": "none",
+            "checksum": ""
+          },
+          "config": {
+            "enabled": true,
+            "schema": "dbt_test__audit",
+            "tags": [],
+            "meta": {},
+            "materialized": "test",
+            "severity": "ERROR",
+            "fail_calc": "count(*)",
+            "warn_if": "!= 0",
+            "error_if": "!= 0"
+          },
+          "tags": [],
+          "description": "",
+          "columns": {},
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "build_path": "target/run/jaffle_shop/models/marts/orders.yml/not_null_orders_coupon_amount.sql",
+          "deferred": false,
+          "unrendered_config": {},
+          "created_at": 1687240826.438974,
+          "raw_code": "{{ test_not_null(**_dbt_generic_test_kwargs) }}",
+          "language": "sql",
+          "refs": [
+            {
+              "name": "orders"
+            }
+          ],
+          "sources": [],
+          "metrics": [],
+          "depends_on": {
+            "macros": [
+              "macro.dbt.test_not_null",
+              "macro.dbt.get_where_subquery",
+              "macro.dbt.should_store_failures",
+              "macro.dbt.statement"
+            ],
+            "nodes": [
+              "model.jaffle_shop.orders"
+            ]
+          },
+          "compiled_path": "target/compiled/jaffle_shop/models/marts/orders.yml/not_null_orders_coupon_amount.sql",
+          "compiled": true,
+          "compiled_code": "\n    \n    \n\n\n\nselect coupon_amount\nfrom \"jaffle_shop\".\"main\".\"orders\"\nwhere coupon_amount is null\n\n\n",
+          "extra_ctes_injected": true,
+          "extra_ctes": [],
+          "contract": {
+            "enforced": false
+          },
+          "column_name": "coupon_amount",
+          "file_key_name": "models.orders",
+          "attached_node": "model.jaffle_shop.orders"
+        },
+        "test.jaffle_shop.not_null_orders_bank_transfer_amount.7743500c49": {
+          "test_metadata": {
+            "name": "not_null",
+            "kwargs": {
+              "column_name": "bank_transfer_amount",
+              "model": "{{ get_where_subquery(ref('orders')) }}"
+            }
+          },
+          "database": "jaffle_shop",
+          "schema": "main_dbt_test__audit",
+          "name": "not_null_orders_bank_transfer_amount",
+          "resource_type": "test",
+          "package_name": "jaffle_shop",
+          "path": "not_null_orders_bank_transfer_amount.sql",
+          "original_file_path": "models/marts/orders.yml",
+          "unique_id": "test.jaffle_shop.not_null_orders_bank_transfer_amount.7743500c49",
+          "fqn": [
+            "jaffle_shop",
+            "marts",
+            "not_null_orders_bank_transfer_amount"
+          ],
+          "alias": "not_null_orders_bank_transfer_amount",
+          "checksum": {
+            "name": "none",
+            "checksum": ""
+          },
+          "config": {
+            "enabled": true,
+            "schema": "dbt_test__audit",
+            "tags": [],
+            "meta": {},
+            "materialized": "test",
+            "severity": "ERROR",
+            "fail_calc": "count(*)",
+            "warn_if": "!= 0",
+            "error_if": "!= 0"
+          },
+          "tags": [],
+          "description": "",
+          "columns": {},
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "build_path": "target/run/jaffle_shop/models/marts/orders.yml/not_null_orders_bank_transfer_amount.sql",
+          "deferred": false,
+          "unrendered_config": {},
+          "created_at": 1687240826.4404202,
+          "raw_code": "{{ test_not_null(**_dbt_generic_test_kwargs) }}",
+          "language": "sql",
+          "refs": [
+            {
+              "name": "orders"
+            }
+          ],
+          "sources": [],
+          "metrics": [],
+          "depends_on": {
+            "macros": [
+              "macro.dbt.test_not_null",
+              "macro.dbt.get_where_subquery",
+              "macro.dbt.should_store_failures",
+              "macro.dbt.statement"
+            ],
+            "nodes": [
+              "model.jaffle_shop.orders"
+            ]
+          },
+          "compiled_path": "target/compiled/jaffle_shop/models/marts/orders.yml/not_null_orders_bank_transfer_amount.sql",
+          "compiled": true,
+          "compiled_code": "\n    \n    \n\n\n\nselect bank_transfer_amount\nfrom \"jaffle_shop\".\"main\".\"orders\"\nwhere bank_transfer_amount is null\n\n\n",
+          "extra_ctes_injected": true,
+          "extra_ctes": [],
+          "contract": {
+            "enforced": false
+          },
+          "column_name": "bank_transfer_amount",
+          "file_key_name": "models.orders",
+          "attached_node": "model.jaffle_shop.orders"
+        },
+        "test.jaffle_shop.not_null_orders_gift_card_amount.413a0d2d7a": {
+          "test_metadata": {
+            "name": "not_null",
+            "kwargs": {
+              "column_name": "gift_card_amount",
+              "model": "{{ get_where_subquery(ref('orders')) }}"
+            }
+          },
+          "database": "jaffle_shop",
+          "schema": "main_dbt_test__audit",
+          "name": "not_null_orders_gift_card_amount",
+          "resource_type": "test",
+          "package_name": "jaffle_shop",
+          "path": "not_null_orders_gift_card_amount.sql",
+          "original_file_path": "models/marts/orders.yml",
+          "unique_id": "test.jaffle_shop.not_null_orders_gift_card_amount.413a0d2d7a",
+          "fqn": [
+            "jaffle_shop",
+            "marts",
+            "not_null_orders_gift_card_amount"
+          ],
+          "alias": "not_null_orders_gift_card_amount",
+          "checksum": {
+            "name": "none",
+            "checksum": ""
+          },
+          "config": {
+            "enabled": true,
+            "schema": "dbt_test__audit",
+            "tags": [],
+            "meta": {},
+            "materialized": "test",
+            "severity": "ERROR",
+            "fail_calc": "count(*)",
+            "warn_if": "!= 0",
+            "error_if": "!= 0"
+          },
+          "tags": [],
+          "description": "",
+          "columns": {},
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "build_path": "target/run/jaffle_shop/models/marts/orders.yml/not_null_orders_gift_card_amount.sql",
+          "deferred": false,
+          "unrendered_config": {},
+          "created_at": 1687240826.441638,
+          "raw_code": "{{ test_not_null(**_dbt_generic_test_kwargs) }}",
+          "language": "sql",
+          "refs": [
+            {
+              "name": "orders"
+            }
+          ],
+          "sources": [],
+          "metrics": [],
+          "depends_on": {
+            "macros": [
+              "macro.dbt.test_not_null",
+              "macro.dbt.get_where_subquery",
+              "macro.dbt.should_store_failures",
+              "macro.dbt.statement"
+            ],
+            "nodes": [
+              "model.jaffle_shop.orders"
+            ]
+          },
+          "compiled_path": "target/compiled/jaffle_shop/models/marts/orders.yml/not_null_orders_gift_card_amount.sql",
+          "compiled": true,
+          "compiled_code": "\n    \n    \n\n\n\nselect gift_card_amount\nfrom \"jaffle_shop\".\"main\".\"orders\"\nwhere gift_card_amount is null\n\n\n",
+          "extra_ctes_injected": true,
+          "extra_ctes": [],
+          "contract": {
+            "enforced": false
+          },
+          "column_name": "gift_card_amount",
+          "file_key_name": "models.orders",
+          "attached_node": "model.jaffle_shop.orders"
+        }
+      },
+      "sources": {},
+      "macros": {
+        "macro.dbt_duckdb.duckdb__get_binding_char": {
+          "name": "duckdb__get_binding_char",
+          "resource_type": "macro",
+          "package_name": "dbt_duckdb",
+          "path": "macros/seed.sql",
+          "original_file_path": "macros/seed.sql",
+          "unique_id": "macro.dbt_duckdb.duckdb__get_binding_char",
+          "macro_sql": "{% macro duckdb__get_binding_char() %}\n  {{ return(adapter.get_binding_char()) }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": []
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240825.9807858
+        },
+        "macro.dbt_duckdb.duckdb__get_batch_size": {
+          "name": "duckdb__get_batch_size",
+          "resource_type": "macro",
+          "package_name": "dbt_duckdb",
+          "path": "macros/seed.sql",
+          "original_file_path": "macros/seed.sql",
+          "unique_id": "macro.dbt_duckdb.duckdb__get_batch_size",
+          "macro_sql": "{% macro duckdb__get_batch_size() %}\n  {{ return(10000) }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": []
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240825.980926
+        },
+        "macro.dbt_duckdb.duckdb__load_csv_rows": {
+          "name": "duckdb__load_csv_rows",
+          "resource_type": "macro",
+          "package_name": "dbt_duckdb",
+          "path": "macros/seed.sql",
+          "original_file_path": "macros/seed.sql",
+          "unique_id": "macro.dbt_duckdb.duckdb__load_csv_rows",
+          "macro_sql": "{% macro duckdb__load_csv_rows(model, agate_table) %}\n    {% set batch_size = get_batch_size() %}\n    {% set agate_table = adapter.convert_datetimes_to_strs(agate_table) %}\n    {% set cols_sql = get_seed_column_quoted_csv(model, agate_table.column_names) %}\n    {% set bindings = [] %}\n\n    {% set statements = [] %}\n\n    {% for chunk in agate_table.rows | batch(batch_size) %}\n        {% set bindings = [] %}\n\n        {% for row in chunk %}\n            {% do bindings.extend(row) %}\n        {% endfor %}\n\n        {% set sql %}\n            insert into {{ this.render() }} ({{ cols_sql }}) values\n            {% for row in chunk -%}\n                ({%- for column in agate_table.column_names -%}\n                    {{ get_binding_char() }}\n                    {%- if not loop.last%},{%- endif %}\n                {%- endfor -%})\n                {%- if not loop.last%},{%- endif %}\n            {%- endfor %}\n        {% endset %}\n\n        {% do adapter.add_query(sql, bindings=bindings, abridge_sql_log=True) %}\n\n        {% if loop.index0 == 0 %}\n            {% do statements.append(sql) %}\n        {% endif %}\n    {% endfor %}\n\n    {# Return SQL so we can render it out into the compiled files #}\n    {{ return(statements[0]) }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.get_batch_size",
+              "macro.dbt.get_seed_column_quoted_csv",
+              "macro.dbt.get_binding_char"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240825.982412
+        },
+        "macro.dbt_duckdb.duckdb__snapshot_merge_sql": {
+          "name": "duckdb__snapshot_merge_sql",
+          "resource_type": "macro",
+          "package_name": "dbt_duckdb",
+          "path": "macros/snapshot_merge.sql",
+          "original_file_path": "macros/snapshot_merge.sql",
+          "unique_id": "macro.dbt_duckdb.duckdb__snapshot_merge_sql",
+          "macro_sql": "{% macro duckdb__snapshot_merge_sql(target, source, insert_cols) -%}\n    {%- set insert_cols_csv = insert_cols | join(', ') -%}\n\n    update {{ target }}\n    set dbt_valid_to = DBT_INTERNAL_SOURCE.dbt_valid_to\n    from {{ source }} as DBT_INTERNAL_SOURCE\n    where DBT_INTERNAL_SOURCE.dbt_scd_id::text = {{ target }}.dbt_scd_id::text\n      and DBT_INTERNAL_SOURCE.dbt_change_type::text in ('update'::text, 'delete'::text)\n      and {{ target }}.dbt_valid_to is null;\n\n    insert into {{ target }} ({{ insert_cols_csv }})\n    select {% for column in insert_cols -%}\n        DBT_INTERNAL_SOURCE.{{ column }} {%- if not loop.last %}, {%- endif %}\n    {%- endfor %}\n    from {{ source }} as DBT_INTERNAL_SOURCE\n    where DBT_INTERNAL_SOURCE.dbt_change_type::text = 'insert'::text;\n\n{% endmacro %}",
+          "depends_on": {
+            "macros": []
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240825.98368
+        },
+        "macro.dbt_duckdb.duckdb__get_catalog": {
+          "name": "duckdb__get_catalog",
+          "resource_type": "macro",
+          "package_name": "dbt_duckdb",
+          "path": "macros/catalog.sql",
+          "original_file_path": "macros/catalog.sql",
+          "unique_id": "macro.dbt_duckdb.duckdb__get_catalog",
+          "macro_sql": "{% macro duckdb__get_catalog(information_schema, schemas) -%}\n  {%- call statement('catalog', fetch_result=True) -%}\n    select\n        '{{ database }}' as table_database,\n        t.table_schema,\n        t.table_name,\n        t.table_type,\n        '' as table_comment,\n        c.column_name,\n        c.ordinal_position as column_index,\n        c.data_type column_type,\n        '' as column_comment,\n        '' as table_owner\n    FROM information_schema.tables t JOIN information_schema.columns c ON t.table_schema = c.table_schema AND t.table_name = c.table_name\n    WHERE (\n        {%- for schema in schemas -%}\n          upper(t.table_schema) = upper('{{ schema }}'){%- if not loop.last %} or {% endif -%}\n        {%- endfor -%}\n    )\n    AND t.table_type IN ('BASE TABLE', 'VIEW')\n    ORDER BY\n        t.table_schema,\n        t.table_name,\n        c.ordinal_position\n  {%- endcall -%}\n  {{ return(load_result('catalog').table) }}\n{%- endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.statement"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240825.984376
+        },
+        "macro.dbt_duckdb.duckdb__create_schema": {
+          "name": "duckdb__create_schema",
+          "resource_type": "macro",
+          "package_name": "dbt_duckdb",
+          "path": "macros/adapters.sql",
+          "original_file_path": "macros/adapters.sql",
+          "unique_id": "macro.dbt_duckdb.duckdb__create_schema",
+          "macro_sql": "{% macro duckdb__create_schema(relation) -%}\n  {%- call statement('create_schema') -%}\n    create schema if not exists {{ relation.without_identifier().include(database=adapter.use_database()) }}\n  {%- endcall -%}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.statement"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240825.993748
+        },
+        "macro.dbt_duckdb.duckdb__drop_schema": {
+          "name": "duckdb__drop_schema",
+          "resource_type": "macro",
+          "package_name": "dbt_duckdb",
+          "path": "macros/adapters.sql",
+          "original_file_path": "macros/adapters.sql",
+          "unique_id": "macro.dbt_duckdb.duckdb__drop_schema",
+          "macro_sql": "{% macro duckdb__drop_schema(relation) -%}\n  {%- call statement('drop_schema') -%}\n    drop schema if exists {{ relation.without_identifier().include(database=adapter.use_database()) }} cascade\n  {%- endcall -%}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.statement"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240825.99399
+        },
+        "macro.dbt_duckdb.duckdb__list_schemas": {
+          "name": "duckdb__list_schemas",
+          "resource_type": "macro",
+          "package_name": "dbt_duckdb",
+          "path": "macros/adapters.sql",
+          "original_file_path": "macros/adapters.sql",
+          "unique_id": "macro.dbt_duckdb.duckdb__list_schemas",
+          "macro_sql": "{% macro duckdb__list_schemas(database) -%}\n  {% set sql %}\n    select schema_name\n    from information_schema.schemata\n  {% endset %}\n  {{ return(run_query(sql)) }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.run_query"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240825.994179
+        },
+        "macro.dbt_duckdb.duckdb__check_schema_exists": {
+          "name": "duckdb__check_schema_exists",
+          "resource_type": "macro",
+          "package_name": "dbt_duckdb",
+          "path": "macros/adapters.sql",
+          "original_file_path": "macros/adapters.sql",
+          "unique_id": "macro.dbt_duckdb.duckdb__check_schema_exists",
+          "macro_sql": "{% macro duckdb__check_schema_exists(information_schema, schema) -%}\n  {% set sql -%}\n        select count(*)\n        from information_schema.schemata\n        where schema_name='{{ schema }}'\n  {%- endset %}\n  {{ return(run_query(sql)) }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.run_query"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240825.994391
+        },
+        "macro.dbt_duckdb.get_column_names": {
+          "name": "get_column_names",
+          "resource_type": "macro",
+          "package_name": "dbt_duckdb",
+          "path": "macros/adapters.sql",
+          "original_file_path": "macros/adapters.sql",
+          "unique_id": "macro.dbt_duckdb.get_column_names",
+          "macro_sql": "{% macro get_column_names() %}\n  {# loop through user_provided_columns to get column names #}\n    {%- set user_provided_columns = model['columns'] -%}\n    (\n    {% for i in user_provided_columns %}\n      {% set col = user_provided_columns[i] %}\n      {{ col['name'] }} {{ \",\" if not loop.last }}\n    {% endfor %}\n  )\n{% endmacro %}",
+          "depends_on": {
+            "macros": []
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240825.994747
+        },
+        "macro.dbt_duckdb.duckdb__create_table_as": {
+          "name": "duckdb__create_table_as",
+          "resource_type": "macro",
+          "package_name": "dbt_duckdb",
+          "path": "macros/adapters.sql",
+          "original_file_path": "macros/adapters.sql",
+          "unique_id": "macro.dbt_duckdb.duckdb__create_table_as",
+          "macro_sql": "{% macro duckdb__create_table_as(temporary, relation, compiled_code, language='sql') -%}\n  {%- if language == 'sql' -%}\n    {% set contract_config = config.get('contract') %}\n    {% if contract_config.enforced %}\n      {{ get_assert_columns_equivalent(compiled_code) }}\n    {% endif %}\n    {%- set sql_header = config.get('sql_header', none) -%}\n\n    {{ sql_header if sql_header is not none }}\n\n    create {% if temporary: -%}temporary{%- endif %} table\n      {{ relation.include(database=(not temporary and adapter.use_database()), schema=(not temporary)) }}\n  {% if contract_config.enforced and not temporary %}\n    {#-- DuckDB doesnt support constraints on temp tables --#}\n    {{ get_table_columns_and_constraints() }} ;\n    insert into {{ relation }} {{ get_column_names() }} (\n      {{ get_select_subquery(compiled_code) }}\n    );\n  {% else %}\n    as (\n      {{ compiled_code }}\n    );\n  {% endif %}\n  {%- elif language == 'python' -%}\n    {{ py_write_table(temporary=temporary, relation=relation, compiled_code=compiled_code) }}\n  {%- else -%}\n      {% do exceptions.raise_compiler_error(\"duckdb__create_table_as macro didn't get supported language, it got %s\" % language) %}\n  {%- endif -%}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.get_assert_columns_equivalent",
+              "macro.dbt.get_table_columns_and_constraints",
+              "macro.dbt_duckdb.get_column_names",
+              "macro.dbt.get_select_subquery",
+              "macro.dbt_duckdb.py_write_table"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240825.9958432
+        },
+        "macro.dbt_duckdb.py_write_table": {
+          "name": "py_write_table",
+          "resource_type": "macro",
+          "package_name": "dbt_duckdb",
+          "path": "macros/adapters.sql",
+          "original_file_path": "macros/adapters.sql",
+          "unique_id": "macro.dbt_duckdb.py_write_table",
+          "macro_sql": "{% macro py_write_table(temporary, relation, compiled_code) -%}\n{{ compiled_code }}\n\ndef materialize(df, con):\n    try:\n        import pyarrow\n        pyarrow_available = True\n    except ImportError:\n        pyarrow_available = False\n    finally:\n        if pyarrow_available and isinstance(df, pyarrow.Table):\n            # https://github.com/duckdb/duckdb/issues/6584\n            import pyarrow.dataset\n    con.execute('create table {{ relation.include(database=adapter.use_database()) }} as select * from df')\n{% endmacro %}",
+          "depends_on": {
+            "macros": []
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240825.996063
+        },
+        "macro.dbt_duckdb.duckdb__create_view_as": {
+          "name": "duckdb__create_view_as",
+          "resource_type": "macro",
+          "package_name": "dbt_duckdb",
+          "path": "macros/adapters.sql",
+          "original_file_path": "macros/adapters.sql",
+          "unique_id": "macro.dbt_duckdb.duckdb__create_view_as",
+          "macro_sql": "{% macro duckdb__create_view_as(relation, sql) -%}\n  {% set contract_config = config.get('contract') %}\n  {% if contract_config.enforced %}\n    {{ get_assert_columns_equivalent(sql) }}\n  {%- endif %}\n  {%- set sql_header = config.get('sql_header', none) -%}\n\n  {{ sql_header if sql_header is not none }}\n  create view {{ relation.include(database=adapter.use_database()) }} as (\n    {{ sql }}\n  );\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.get_assert_columns_equivalent"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240825.9965599
+        },
+        "macro.dbt_duckdb.duckdb__get_columns_in_relation": {
+          "name": "duckdb__get_columns_in_relation",
+          "resource_type": "macro",
+          "package_name": "dbt_duckdb",
+          "path": "macros/adapters.sql",
+          "original_file_path": "macros/adapters.sql",
+          "unique_id": "macro.dbt_duckdb.duckdb__get_columns_in_relation",
+          "macro_sql": "{% macro duckdb__get_columns_in_relation(relation) -%}\n  {% call statement('get_columns_in_relation', fetch_result=True) %}\n      select\n          column_name,\n          data_type,\n          character_maximum_length,\n          numeric_precision,\n          numeric_scale\n\n      from information_schema.columns\n      where table_name = '{{ relation.identifier }}'\n        {% if relation.schema %}\n        and table_schema = '{{ relation.schema }}'\n        {% endif %}\n      order by ordinal_position\n\n  {% endcall %}\n  {% set table = load_result('get_columns_in_relation').table %}\n  {{ return(sql_convert_columns_in_relation(table)) }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.statement",
+              "macro.dbt.sql_convert_columns_in_relation"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240825.996989
+        },
+        "macro.dbt_duckdb.duckdb__list_relations_without_caching": {
+          "name": "duckdb__list_relations_without_caching",
+          "resource_type": "macro",
+          "package_name": "dbt_duckdb",
+          "path": "macros/adapters.sql",
+          "original_file_path": "macros/adapters.sql",
+          "unique_id": "macro.dbt_duckdb.duckdb__list_relations_without_caching",
+          "macro_sql": "{% macro duckdb__list_relations_without_caching(schema_relation) %}\n  {% call statement('list_relations_without_caching', fetch_result=True) -%}\n    select\n      '{{ schema_relation.database }}' as database,\n      table_name as name,\n      table_schema as schema,\n      CASE table_type\n        WHEN 'BASE TABLE' THEN 'table'\n        WHEN 'VIEW' THEN 'view'\n        WHEN 'LOCAL TEMPORARY' THEN 'table'\n        END as type\n    from information_schema.tables\n    where table_schema = '{{ schema_relation.schema }}'\n  {% endcall %}\n  {{ return(load_result('list_relations_without_caching').table) }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.statement"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240825.997302
+        },
+        "macro.dbt_duckdb.duckdb__drop_relation": {
+          "name": "duckdb__drop_relation",
+          "resource_type": "macro",
+          "package_name": "dbt_duckdb",
+          "path": "macros/adapters.sql",
+          "original_file_path": "macros/adapters.sql",
+          "unique_id": "macro.dbt_duckdb.duckdb__drop_relation",
+          "macro_sql": "{% macro duckdb__drop_relation(relation) -%}\n  {% call statement('drop_relation', auto_begin=False) -%}\n    drop {{ relation.type }} if exists {{ relation.include(database=adapter.use_database()) }} cascade\n  {%- endcall %}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.statement"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240825.9975638
+        },
+        "macro.dbt_duckdb.duckdb__truncate_relation": {
+          "name": "duckdb__truncate_relation",
+          "resource_type": "macro",
+          "package_name": "dbt_duckdb",
+          "path": "macros/adapters.sql",
+          "original_file_path": "macros/adapters.sql",
+          "unique_id": "macro.dbt_duckdb.duckdb__truncate_relation",
+          "macro_sql": "{% macro duckdb__truncate_relation(relation) -%}\n  {% call statement('truncate_relation') -%}\n    DELETE FROM {{ relation.include(database=adapter.use_database()) }} WHERE 1=1\n  {%- endcall %}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.statement"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240825.997778
+        },
+        "macro.dbt_duckdb.duckdb__rename_relation": {
+          "name": "duckdb__rename_relation",
+          "resource_type": "macro",
+          "package_name": "dbt_duckdb",
+          "path": "macros/adapters.sql",
+          "original_file_path": "macros/adapters.sql",
+          "unique_id": "macro.dbt_duckdb.duckdb__rename_relation",
+          "macro_sql": "{% macro duckdb__rename_relation(from_relation, to_relation) -%}\n  {% set target_name = adapter.quote_as_configured(to_relation.identifier, 'identifier') %}\n  {% call statement('rename_relation') -%}\n    alter {{ to_relation.type }} {{ from_relation }} rename to {{ target_name }}\n  {%- endcall %}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.statement"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240825.998143
+        },
+        "macro.dbt_duckdb.duckdb__make_temp_relation": {
+          "name": "duckdb__make_temp_relation",
+          "resource_type": "macro",
+          "package_name": "dbt_duckdb",
+          "path": "macros/adapters.sql",
+          "original_file_path": "macros/adapters.sql",
+          "unique_id": "macro.dbt_duckdb.duckdb__make_temp_relation",
+          "macro_sql": "{% macro duckdb__make_temp_relation(base_relation, suffix) %}\n    {% set tmp_identifier = base_relation.identifier ~ suffix ~ py_current_timestring() %}\n    {% do return(base_relation.incorporate(\n                                  path={\n                                    \"identifier\": tmp_identifier,\n                                    \"schema\": none,\n                                    \"database\": none\n                                  })) -%}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.py_current_timestring"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240825.9984908
+        },
+        "macro.dbt_duckdb.duckdb__current_timestamp": {
+          "name": "duckdb__current_timestamp",
+          "resource_type": "macro",
+          "package_name": "dbt_duckdb",
+          "path": "macros/adapters.sql",
+          "original_file_path": "macros/adapters.sql",
+          "unique_id": "macro.dbt_duckdb.duckdb__current_timestamp",
+          "macro_sql": "{% macro duckdb__current_timestamp() -%}\n  now()\n{%- endmacro %}",
+          "depends_on": {
+            "macros": []
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240825.9985678
+        },
+        "macro.dbt_duckdb.duckdb__snapshot_string_as_time": {
+          "name": "duckdb__snapshot_string_as_time",
+          "resource_type": "macro",
+          "package_name": "dbt_duckdb",
+          "path": "macros/adapters.sql",
+          "original_file_path": "macros/adapters.sql",
+          "unique_id": "macro.dbt_duckdb.duckdb__snapshot_string_as_time",
+          "macro_sql": "{% macro duckdb__snapshot_string_as_time(timestamp) -%}\n    {%- set result = \"'\" ~ timestamp ~ \"'::timestamp\" -%}\n    {{ return(result) }}\n{%- endmacro %}",
+          "depends_on": {
+            "macros": []
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240825.9987369
+        },
+        "macro.dbt_duckdb.duckdb__snapshot_get_time": {
+          "name": "duckdb__snapshot_get_time",
+          "resource_type": "macro",
+          "package_name": "dbt_duckdb",
+          "path": "macros/adapters.sql",
+          "original_file_path": "macros/adapters.sql",
+          "unique_id": "macro.dbt_duckdb.duckdb__snapshot_get_time",
+          "macro_sql": "{% macro duckdb__snapshot_get_time() -%}\n  {{ current_timestamp() }}::timestamp\n{%- endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.current_timestamp"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240825.998833
+        },
+        "macro.dbt_duckdb.duckdb__get_incremental_default_sql": {
+          "name": "duckdb__get_incremental_default_sql",
+          "resource_type": "macro",
+          "package_name": "dbt_duckdb",
+          "path": "macros/adapters.sql",
+          "original_file_path": "macros/adapters.sql",
+          "unique_id": "macro.dbt_duckdb.duckdb__get_incremental_default_sql",
+          "macro_sql": "{% macro duckdb__get_incremental_default_sql(arg_dict) %}\n  {% do return(get_incremental_delete_insert_sql(arg_dict)) %}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.get_incremental_delete_insert_sql"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240825.998973
+        },
+        "macro.dbt_duckdb.duckdb__get_incremental_delete_insert_sql": {
+          "name": "duckdb__get_incremental_delete_insert_sql",
+          "resource_type": "macro",
+          "package_name": "dbt_duckdb",
+          "path": "macros/adapters.sql",
+          "original_file_path": "macros/adapters.sql",
+          "unique_id": "macro.dbt_duckdb.duckdb__get_incremental_delete_insert_sql",
+          "macro_sql": "{% macro duckdb__get_incremental_delete_insert_sql(arg_dict) %}\n  {% do return(get_delete_insert_merge_sql(arg_dict[\"target_relation\"].include(database=adapter.use_database()), arg_dict[\"temp_relation\"], arg_dict[\"unique_key\"], arg_dict[\"dest_columns\"])) %}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.get_delete_insert_merge_sql"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240825.9993129
+        },
+        "macro.dbt_duckdb.duckdb__get_incremental_append_sql": {
+          "name": "duckdb__get_incremental_append_sql",
+          "resource_type": "macro",
+          "package_name": "dbt_duckdb",
+          "path": "macros/adapters.sql",
+          "original_file_path": "macros/adapters.sql",
+          "unique_id": "macro.dbt_duckdb.duckdb__get_incremental_append_sql",
+          "macro_sql": "{% macro duckdb__get_incremental_append_sql(arg_dict) %}\n  {% do return(get_insert_into_sql(arg_dict[\"target_relation\"].include(database=adapter.use_database()), arg_dict[\"temp_relation\"], arg_dict[\"dest_columns\"])) %}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.get_insert_into_sql"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240825.999593
+        },
+        "macro.dbt_duckdb.location_exists": {
+          "name": "location_exists",
+          "resource_type": "macro",
+          "package_name": "dbt_duckdb",
+          "path": "macros/adapters.sql",
+          "original_file_path": "macros/adapters.sql",
+          "unique_id": "macro.dbt_duckdb.location_exists",
+          "macro_sql": "{% macro location_exists(location) -%}\n  {% do return(adapter.location_exists(location)) %}\n{% endmacro %}",
+          "depends_on": {
+            "macros": []
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240825.999747
+        },
+        "macro.dbt_duckdb.write_to_file": {
+          "name": "write_to_file",
+          "resource_type": "macro",
+          "package_name": "dbt_duckdb",
+          "path": "macros/adapters.sql",
+          "original_file_path": "macros/adapters.sql",
+          "unique_id": "macro.dbt_duckdb.write_to_file",
+          "macro_sql": "{% macro write_to_file(relation, location, options) -%}\n  {% call statement('write_to_file') -%}\n    copy {{ relation }} to '{{ location }}' ({{ options }})\n  {%- endcall %}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.statement"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240825.999957
+        },
+        "macro.dbt_duckdb.register_glue_table": {
+          "name": "register_glue_table",
+          "resource_type": "macro",
+          "package_name": "dbt_duckdb",
+          "path": "macros/adapters.sql",
+          "original_file_path": "macros/adapters.sql",
+          "unique_id": "macro.dbt_duckdb.register_glue_table",
+          "macro_sql": "{% macro register_glue_table(register, glue_database, relation, location, format) -%}\n  {% if location.startswith(\"s3://\") and register == true %}\n    {%- set column_list = adapter.get_columns_in_relation(relation) -%}\n    {% do adapter.register_glue_table(glue_database, relation.identifier, column_list, location, format) %}\n  {% endif %}\n{% endmacro %}",
+          "depends_on": {
+            "macros": []
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.000336
+        },
+        "macro.dbt_duckdb.render_write_options": {
+          "name": "render_write_options",
+          "resource_type": "macro",
+          "package_name": "dbt_duckdb",
+          "path": "macros/adapters.sql",
+          "original_file_path": "macros/adapters.sql",
+          "unique_id": "macro.dbt_duckdb.render_write_options",
+          "macro_sql": "{% macro render_write_options(config) -%}\n  {% set options = config.get('options', {}) %}\n  {% for k in options %}\n    {% if options[k] is string %}\n      {% set _ = options.update({k: render(options[k])}) %}\n    {% else %}\n      {% set _ = options.update({k: render(options[k])}) %}\n    {% endif %}\n  {% endfor %}\n\n  {# legacy top-level write options #}\n  {% if config.get('format') %}\n    {% set _ = options.update({'format': render(config.get('format'))}) %}\n  {% endif %}\n  {% if config.get('delimiter') %}\n    {% set _ = options.update({'delimiter': render(config.get('delimiter'))}) %}\n  {% endif %}\n\n  {% do return(options) %}\n{%- endmacro %}",
+          "depends_on": {
+            "macros": []
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.0013702
+        },
+        "macro.dbt_duckdb.materialization_table_duckdb": {
+          "name": "materialization_table_duckdb",
+          "resource_type": "macro",
+          "package_name": "dbt_duckdb",
+          "path": "macros/materializations/table.sql",
+          "original_file_path": "macros/materializations/table.sql",
+          "unique_id": "macro.dbt_duckdb.materialization_table_duckdb",
+          "macro_sql": "{% materialization table, adapter=\"duckdb\", supported_languages=['sql', 'python'] %}\n\n  {%- set language = model['language'] -%}\n\n  {%- set existing_relation = load_cached_relation(this) -%}\n  {%- set target_relation = this.incorporate(type='table') %}\n  {%- set intermediate_relation =  make_intermediate_relation(target_relation) -%}\n  -- the intermediate_relation should not already exist in the database; get_relation\n  -- will return None in that case. Otherwise, we get a relation that we can drop\n  -- later, before we try to use this name for the current operation\n  {%- set preexisting_intermediate_relation = load_cached_relation(intermediate_relation) -%}\n  /*\n      See ../view/view.sql for more information about this relation.\n  */\n  {%- set backup_relation_type = 'table' if existing_relation is none else existing_relation.type -%}\n  {%- set backup_relation = make_backup_relation(target_relation, backup_relation_type) -%}\n  -- as above, the backup_relation should not already exist\n  {%- set preexisting_backup_relation = load_cached_relation(backup_relation) -%}\n  -- grab current tables grants config for comparision later on\n  {% set grant_config = config.get('grants') %}\n\n  -- drop the temp relations if they exist already in the database\n  {{ drop_relation_if_exists(preexisting_intermediate_relation) }}\n  {{ drop_relation_if_exists(preexisting_backup_relation) }}\n\n  {{ run_hooks(pre_hooks, inside_transaction=False) }}\n\n  -- `BEGIN` happens here:\n  {{ run_hooks(pre_hooks, inside_transaction=True) }}\n\n  -- build model\n  {% call statement('main', language=language) -%}\n    {{- create_table_as(False, intermediate_relation, compiled_code, language) }}\n  {%- endcall %}\n\n  -- cleanup\n  {% if existing_relation is not none %}\n      {{ adapter.rename_relation(existing_relation, backup_relation) }}\n  {% endif %}\n\n  {{ adapter.rename_relation(intermediate_relation, target_relation) }}\n\n  {% do create_indexes(target_relation) %}\n\n  {{ run_hooks(post_hooks, inside_transaction=True) }}\n\n  {% set should_revoke = should_revoke(existing_relation, full_refresh_mode=True) %}\n  {% do apply_grants(target_relation, grant_config, should_revoke=should_revoke) %}\n\n  {% do persist_docs(target_relation, model) %}\n\n  -- `COMMIT` happens here\n  {{ adapter.commit() }}\n\n  -- finally, drop the existing/backup relation after the commit\n  {{ drop_relation_if_exists(backup_relation) }}\n\n  {{ run_hooks(post_hooks, inside_transaction=False) }}\n\n  {{ return({'relations': [target_relation]}) }}\n{% endmaterialization %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.load_cached_relation",
+              "macro.dbt.make_intermediate_relation",
+              "macro.dbt.make_backup_relation",
+              "macro.dbt.drop_relation_if_exists",
+              "macro.dbt.run_hooks",
+              "macro.dbt.statement",
+              "macro.dbt.create_table_as",
+              "macro.dbt.create_indexes",
+              "macro.dbt.should_revoke",
+              "macro.dbt.apply_grants",
+              "macro.dbt.persist_docs"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.004147,
+          "supported_languages": [
+            "sql",
+            "python"
+          ]
+        },
+        "macro.dbt_duckdb.materialization_external_duckdb": {
+          "name": "materialization_external_duckdb",
+          "resource_type": "macro",
+          "package_name": "dbt_duckdb",
+          "path": "macros/materializations/external.sql",
+          "original_file_path": "macros/materializations/external.sql",
+          "unique_id": "macro.dbt_duckdb.materialization_external_duckdb",
+          "macro_sql": "{% materialization external, adapter=\"duckdb\", supported_languages=['sql', 'python'] %}\n\n  {%- set location = render(config.get('location', default=external_location(this, config))) -%})\n  {%- set rendered_options = render_write_options(config) -%}\n  {%- set format = config.get('format', 'parquet') -%}\n  {%- set write_options = adapter.external_write_options(location, rendered_options) -%}\n  {%- set read_location = adapter.external_read_location(location, rendered_options) -%}\n\n  -- set language - python or sql\n  {%- set language = model['language'] -%}\n\n  {%- set target_relation = this.incorporate(type='view') %}\n\n  -- Continue as normal materialization\n  {%- set existing_relation = load_cached_relation(this) -%}\n  {%- set temp_relation =  make_intermediate_relation(this.incorporate(type='table'), suffix='__dbt_tmp') -%}\n  {%- set intermediate_relation =  make_intermediate_relation(target_relation, suffix='__dbt_int') -%}\n  -- the intermediate_relation should not already exist in the database; get_relation\n  -- will return None in that case. Otherwise, we get a relation that we can drop\n  -- later, before we try to use this name for the current operation\n  {%- set preexisting_temp_relation = load_cached_relation(temp_relation) -%}\n  {%- set preexisting_intermediate_relation = load_cached_relation(intermediate_relation) -%}\n  /*\n      See ../view/view.sql for more information about this relation.\n  */\n  {%- set backup_relation_type = 'table' if existing_relation is none else existing_relation.type -%}\n  {%- set backup_relation = make_backup_relation(target_relation, backup_relation_type) -%}\n  -- as above, the backup_relation should not already exist\n  {%- set preexisting_backup_relation = load_cached_relation(backup_relation) -%}\n  -- grab current tables grants config for comparision later on\n  {% set grant_config = config.get('grants') %}\n\n  -- drop the temp relations if they exist already in the database\n  {{ drop_relation_if_exists(preexisting_intermediate_relation) }}\n  {{ drop_relation_if_exists(preexisting_temp_relation) }}\n  {{ drop_relation_if_exists(preexisting_backup_relation) }}\n\n  {{ run_hooks(pre_hooks, inside_transaction=False) }}\n\n  -- `BEGIN` happens here:\n  {{ run_hooks(pre_hooks, inside_transaction=True) }}\n\n  -- build model\n  {% call statement('create_table', language=language) -%}\n    {{- create_table_as(False, temp_relation, compiled_code, language) }}\n  {%- endcall %}\n\n  -- write an temp relation into file\n  {{ write_to_file(temp_relation, location, write_options) }}\n  -- create a view on top of the location\n  {% call statement('main', language='sql') -%}\n    create or replace view {{ intermediate_relation.include(database=adapter.use_database()) }} as (\n        select * from '{{ read_location }}'\n    );\n  {%- endcall %}\n\n  -- cleanup\n  {% if existing_relation is not none %}\n      {{ adapter.rename_relation(existing_relation, backup_relation) }}\n  {% endif %}\n\n  {{ adapter.rename_relation(intermediate_relation, target_relation) }}\n\n  {{ run_hooks(post_hooks, inside_transaction=True) }}\n\n  {% set should_revoke = should_revoke(existing_relation, full_refresh_mode=True) %}\n  {% do apply_grants(target_relation, grant_config, should_revoke=should_revoke) %}\n\n  {% do persist_docs(target_relation, model) %}\n\n  -- `COMMIT` happens here\n  {{ adapter.commit() }}\n\n  -- finally, drop the existing/backup relation after the commit\n  {{ drop_relation_if_exists(backup_relation) }}\n  {{ drop_relation_if_exists(temp_relation) }}\n\n  -- register table into glue\n  {%- set glue_register = config.get('glue_register', default=false) -%}\n  {%- set glue_database = render(config.get('glue_database', default='default')) -%}\n  {% do register_glue_table(glue_register, glue_database, target_relation, location, format) %}\n\n  {{ run_hooks(post_hooks, inside_transaction=False) }}\n\n  {{ return({'relations': [target_relation]}) }}\n\n{% endmaterialization %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt_duckdb.external_location",
+              "macro.dbt_duckdb.render_write_options",
+              "macro.dbt.load_cached_relation",
+              "macro.dbt.make_intermediate_relation",
+              "macro.dbt.make_backup_relation",
+              "macro.dbt.drop_relation_if_exists",
+              "macro.dbt.run_hooks",
+              "macro.dbt.statement",
+              "macro.dbt.create_table_as",
+              "macro.dbt_duckdb.write_to_file",
+              "macro.dbt.should_revoke",
+              "macro.dbt.apply_grants",
+              "macro.dbt.persist_docs",
+              "macro.dbt_duckdb.register_glue_table"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.009253,
+          "supported_languages": [
+            "sql",
+            "python"
+          ]
+        },
+        "macro.dbt_duckdb.materialization_incremental_duckdb": {
+          "name": "materialization_incremental_duckdb",
+          "resource_type": "macro",
+          "package_name": "dbt_duckdb",
+          "path": "macros/materializations/incremental.sql",
+          "original_file_path": "macros/materializations/incremental.sql",
+          "unique_id": "macro.dbt_duckdb.materialization_incremental_duckdb",
+          "macro_sql": "{% materialization incremental, adapter=\"duckdb\", supported_languages=['sql', 'python'] -%}\n\n  {%- set language = model['language'] -%}\n\n  -- relations\n  {%- set existing_relation = load_cached_relation(this) -%}\n  {%- set target_relation = this.incorporate(type='table') -%}\n  {%- set temp_relation = make_temp_relation(target_relation)-%}\n  {%- set intermediate_relation = make_intermediate_relation(target_relation)-%}\n  {%- set backup_relation_type = 'table' if existing_relation is none else existing_relation.type -%}\n  {%- set backup_relation = make_backup_relation(target_relation, backup_relation_type) -%}\n\n  -- configs\n  {%- set unique_key = config.get('unique_key') -%}\n  {%- set full_refresh_mode = (should_full_refresh()  or existing_relation.is_view) -%}\n  {%- set on_schema_change = incremental_validate_on_schema_change(config.get('on_schema_change'), default='ignore') -%}\n\n  -- the temp_ and backup_ relations should not already exist in the database; get_relation\n  -- will return None in that case. Otherwise, we get a relation that we can drop\n  -- later, before we try to use this name for the current operation. This has to happen before\n  -- BEGIN, in a separate transaction\n  {%- set preexisting_intermediate_relation = load_cached_relation(intermediate_relation)-%}\n  {%- set preexisting_backup_relation = load_cached_relation(backup_relation) -%}\n   -- grab current tables grants config for comparision later on\n  {% set grant_config = config.get('grants') %}\n  {{ drop_relation_if_exists(preexisting_intermediate_relation) }}\n  {{ drop_relation_if_exists(preexisting_backup_relation) }}\n\n  {{ run_hooks(pre_hooks, inside_transaction=False) }}\n\n  -- `BEGIN` happens here:\n  {{ run_hooks(pre_hooks, inside_transaction=True) }}\n\n  {% set to_drop = [] %}\n\n  {% if existing_relation is none %}\n    {% set build_sql = create_table_as(False, target_relation, compiled_code, language) %}\n  {% elif full_refresh_mode %}\n    {% set build_sql = create_table_as(False, intermediate_relation, compiled_code, language) %}\n    {% set need_swap = true %}\n  {% else %}\n    {% if language == 'python' %}\n      {% set build_python = create_table_as(False, temp_relation, compiled_code, language) %}\n      {% call statement(\"pre\", language=language) %}\n        {{- build_python }}\n      {% endcall %}\n    {% else %} {# SQL #}\n      {% do run_query(create_table_as(True, temp_relation, compiled_code, language)) %}\n    {% endif %}\n    {% do adapter.expand_target_column_types(\n             from_relation=temp_relation,\n             to_relation=target_relation) %}\n    {#-- Process schema changes. Returns dict of changes if successful. Use source columns for upserting/merging --#}\n    {% set dest_columns = process_schema_changes(on_schema_change, temp_relation, existing_relation) %}\n    {% if not dest_columns %}\n      {% set dest_columns = adapter.get_columns_in_relation(existing_relation) %}\n    {% endif %}\n\n    {#-- Get the incremental_strategy, the macro to use for the strategy, and build the sql --#}\n    {% set incremental_strategy = config.get('incremental_strategy') or 'default' %}\n    {% set incremental_predicates = config.get('incremental_predicates', none) %}\n    {% set strategy_sql_macro_func = adapter.get_incremental_strategy_macro(context, incremental_strategy) %}\n    {% set strategy_arg_dict = ({'target_relation': target_relation, 'temp_relation': temp_relation, 'unique_key': unique_key, 'dest_columns': dest_columns, 'predicates': incremental_predicates }) %}\n    {% set build_sql = strategy_sql_macro_func(strategy_arg_dict) %}\n    {% set language = \"sql\" %}\n\n  {% endif %}\n\n  {% call statement(\"main\", language=language) %}\n      {{- build_sql }}\n  {% endcall %}\n\n  {% if need_swap %}\n      {% do adapter.rename_relation(target_relation, backup_relation) %}\n      {% do adapter.rename_relation(intermediate_relation, target_relation) %}\n      {% do to_drop.append(backup_relation) %}\n  {% endif %}\n\n  {% set should_revoke = should_revoke(existing_relation, full_refresh_mode) %}\n  {% do apply_grants(target_relation, grant_config, should_revoke=should_revoke) %}\n\n  {% do persist_docs(target_relation, model) %}\n\n  {% if existing_relation is none or existing_relation.is_view or should_full_refresh() %}\n    {% do create_indexes(target_relation) %}\n  {% endif %}\n\n  {{ run_hooks(post_hooks, inside_transaction=True) }}\n\n  -- `COMMIT` happens here\n  {% do adapter.commit() %}\n\n  {% for rel in to_drop %}\n      {% do adapter.drop_relation(rel) %}\n  {% endfor %}\n\n  {{ run_hooks(post_hooks, inside_transaction=False) }}\n\n  {{ return({'relations': [target_relation]}) }}\n\n{%- endmaterialization %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.load_cached_relation",
+              "macro.dbt.make_temp_relation",
+              "macro.dbt.make_intermediate_relation",
+              "macro.dbt.make_backup_relation",
+              "macro.dbt.should_full_refresh",
+              "macro.dbt.incremental_validate_on_schema_change",
+              "macro.dbt.drop_relation_if_exists",
+              "macro.dbt.run_hooks",
+              "macro.dbt.create_table_as",
+              "macro.dbt.statement",
+              "macro.dbt.run_query",
+              "macro.dbt.process_schema_changes",
+              "macro.dbt.should_revoke",
+              "macro.dbt.apply_grants",
+              "macro.dbt.persist_docs",
+              "macro.dbt.create_indexes"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.015245,
+          "supported_languages": [
+            "sql",
+            "python"
+          ]
+        },
+        "macro.dbt_duckdb.duckdb__dateadd": {
+          "name": "duckdb__dateadd",
+          "resource_type": "macro",
+          "package_name": "dbt_duckdb",
+          "path": "macros/utils/dateadd.sql",
+          "original_file_path": "macros/utils/dateadd.sql",
+          "unique_id": "macro.dbt_duckdb.duckdb__dateadd",
+          "macro_sql": "{% macro duckdb__dateadd(datepart, interval, from_date_or_timestamp) %}\n\n    {{ from_date_or_timestamp }} + ((interval '1 {{ datepart }}') * ({{ interval }}))\n\n{% endmacro %}",
+          "depends_on": {
+            "macros": []
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.0155258
+        },
+        "macro.dbt_duckdb.duckdb__listagg": {
+          "name": "duckdb__listagg",
+          "resource_type": "macro",
+          "package_name": "dbt_duckdb",
+          "path": "macros/utils/listagg.sql",
+          "original_file_path": "macros/utils/listagg.sql",
+          "unique_id": "macro.dbt_duckdb.duckdb__listagg",
+          "macro_sql": "{% macro duckdb__listagg(measure, delimiter_text, order_by_clause, limit_num) -%}\n    {% if limit_num -%}\n    list_aggr(\n        (array_agg(\n            {{ measure }}\n            {% if order_by_clause -%}\n            {{ order_by_clause }}\n            {%- endif %}\n        ))[1:{{ limit_num }}],\n        'string_agg',\n        {{ delimiter_text }}\n        )\n    {%- else %}\n    string_agg(\n        {{ measure }},\n        {{ delimiter_text }}\n        {% if order_by_clause -%}\n        {{ order_by_clause }}\n        {%- endif %}\n        )\n    {%- endif %}\n{%- endmacro %}",
+          "depends_on": {
+            "macros": []
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.01616
+        },
+        "macro.dbt_duckdb.duckdb__datediff": {
+          "name": "duckdb__datediff",
+          "resource_type": "macro",
+          "package_name": "dbt_duckdb",
+          "path": "macros/utils/datediff.sql",
+          "original_file_path": "macros/utils/datediff.sql",
+          "unique_id": "macro.dbt_duckdb.duckdb__datediff",
+          "macro_sql": "{% macro duckdb__datediff(first_date, second_date, datepart) -%}\n\n    {% if datepart == 'year' %}\n        (date_part('year', ({{second_date}})::date) - date_part('year', ({{first_date}})::date))\n    {% elif datepart == 'quarter' %}\n        ({{ datediff(first_date, second_date, 'year') }} * 4 + date_part('quarter', ({{second_date}})::date) - date_part('quarter', ({{first_date}})::date))\n    {% elif datepart == 'month' %}\n        ({{ datediff(first_date, second_date, 'year') }} * 12 + date_part('month', ({{second_date}})::date) - date_part('month', ({{first_date}})::date))\n    {% elif datepart == 'day' %}\n        (({{second_date}})::date - ({{first_date}})::date)\n    {% elif datepart == 'week' %}\n        ({{ datediff(first_date, second_date, 'day') }} / 7 + case\n            when date_part('dow', ({{first_date}})::timestamp) <= date_part('dow', ({{second_date}})::timestamp) then\n                case when {{first_date}} <= {{second_date}} then 0 else -1 end\n            else\n                case when {{first_date}} <= {{second_date}} then 1 else 0 end\n        end)\n    {% elif datepart == 'hour' %}\n        ({{ datediff(first_date, second_date, 'day') }} * 24 + date_part('hour', ({{second_date}})::timestamp) - date_part('hour', ({{first_date}})::timestamp))\n    {% elif datepart == 'minute' %}\n        ({{ datediff(first_date, second_date, 'hour') }} * 60 + date_part('minute', ({{second_date}})::timestamp) - date_part('minute', ({{first_date}})::timestamp))\n    {% elif datepart == 'second' %}\n        ({{ datediff(first_date, second_date, 'minute') }} * 60 + floor(date_part('second', ({{second_date}})::timestamp)) - floor(date_part('second', ({{first_date}})::timestamp)))\n    {% elif datepart == 'millisecond' %}\n        ({{ datediff(first_date, second_date, 'minute') }} * 60000 + floor(date_part('millisecond', ({{second_date}})::timestamp)) - floor(date_part('millisecond', ({{first_date}})::timestamp)))\n    {% elif datepart == 'microsecond' %}\n        ({{ datediff(first_date, second_date, 'minute') }} * 60000000 + floor(date_part('microsecond', ({{second_date}})::timestamp)) - floor(date_part('microsecond', ({{first_date}})::timestamp)))\n    {% else %}\n        {{ exceptions.raise_compiler_error(\"Unsupported datepart for macro datediff in postgres: {!r}\".format(datepart)) }}\n    {% endif %}\n\n{%- endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.datediff"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.019397
+        },
+        "macro.dbt_duckdb.duckdb__any_value": {
+          "name": "duckdb__any_value",
+          "resource_type": "macro",
+          "package_name": "dbt_duckdb",
+          "path": "macros/utils/any_value.sql",
+          "original_file_path": "macros/utils/any_value.sql",
+          "unique_id": "macro.dbt_duckdb.duckdb__any_value",
+          "macro_sql": "{% macro duckdb__any_value(expression) -%}\n\n    arbitrary({{ expression }})\n\n{%- endmacro %}",
+          "depends_on": {
+            "macros": []
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.019542
+        },
+        "macro.dbt_duckdb.register_upstream_external_models": {
+          "name": "register_upstream_external_models",
+          "resource_type": "macro",
+          "package_name": "dbt_duckdb",
+          "path": "macros/utils/upstream.sql",
+          "original_file_path": "macros/utils/upstream.sql",
+          "unique_id": "macro.dbt_duckdb.register_upstream_external_models",
+          "macro_sql": "{%- macro register_upstream_external_models() -%}\n{% if execute %}\n{% set upstream_nodes = {} %}\n{% set upstream_schemas = {} %}\n{% for node in selected_resources %}\n  {% for upstream_node in graph['nodes'][node]['depends_on']['nodes'] %}\n    {% if upstream_node not in upstream_nodes and upstream_node not in selected_resources %}\n      {% do upstream_nodes.update({upstream_node: None}) %}\n      {% set upstream = graph['nodes'].get(upstream_node) %}\n      {% if upstream\n         and upstream.resource_type in ('model', 'seed')\n         and upstream.config.materialized=='external'\n      %}\n        {%- set upstream_rel = api.Relation.create(\n          database=upstream['database'],\n          schema=upstream['schema'],\n          identifier=upstream['alias']\n        ) -%}\n        {%- set location = upstream.config.get('location', external_location(upstream_rel, upstream.config)) -%}\n        {%- set rendered_options = render_write_options(upstream.config) -%}\n        {%- set upstream_location = adapter.external_read_location(location, rendered_options) -%}\n        {% if upstream_rel.schema not in upstream_schemas %}\n          {% call statement('main', language='sql') -%}\n            create schema if not exists {{ upstream_rel.schema }}\n          {%- endcall %}\n          {% do upstream_schemas.update({upstream_rel.schema: None}) %}\n        {% endif %}\n        {% call statement('main', language='sql') -%}\n          create or replace view {{ upstream_rel.include(database=adapter.use_database()) }} as (\n            select * from '{{ upstream_location }}'\n          );\n        {%- endcall %}\n      {%- endif %}\n    {% endif %}\n  {% endfor %}\n{% endfor %}\n{% do adapter.commit() %}\n{% endif %}\n{%- endmacro -%}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt_duckdb.external_location",
+              "macro.dbt_duckdb.render_write_options",
+              "macro.dbt.statement"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.022062
+        },
+        "macro.dbt_duckdb.duckdb__split_part": {
+          "name": "duckdb__split_part",
+          "resource_type": "macro",
+          "package_name": "dbt_duckdb",
+          "path": "macros/utils/splitpart.sql",
+          "original_file_path": "macros/utils/splitpart.sql",
+          "unique_id": "macro.dbt_duckdb.duckdb__split_part",
+          "macro_sql": "{% macro duckdb__split_part(string_text, delimiter_text, part_number) %}\n\n  {% if part_number >= 0 %}\n    coalesce(string_split({{ string_text }}, {{ delimiter_text }})[ {{ part_number }} ], '')\n  {% else %}\n    {{ dbt._split_part_negative(string_text, delimiter_text, part_number) }}\n  {% endif %}\n\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt._split_part_negative"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.022478
+        },
+        "macro.dbt_duckdb.duckdb__last_day": {
+          "name": "duckdb__last_day",
+          "resource_type": "macro",
+          "package_name": "dbt_duckdb",
+          "path": "macros/utils/lastday.sql",
+          "original_file_path": "macros/utils/lastday.sql",
+          "unique_id": "macro.dbt_duckdb.duckdb__last_day",
+          "macro_sql": "{% macro duckdb__last_day(date, datepart) -%}\n\n    {%- if datepart == 'quarter' -%}\n    -- duckdb dateadd does not support quarter interval.\n    cast(\n        {{dbt.dateadd('day', '-1',\n        dbt.dateadd('month', '3', dbt.date_trunc(datepart, date))\n        )}}\n        as date)\n    {%- else -%}\n    {{dbt.default_last_day(date, datepart)}}\n    {%- endif -%}\n\n{%- endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.dateadd",
+              "macro.dbt.date_trunc",
+              "macro.dbt.default_last_day"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.022978
+        },
+        "macro.dbt_duckdb.external_location": {
+          "name": "external_location",
+          "resource_type": "macro",
+          "package_name": "dbt_duckdb",
+          "path": "macros/utils/external_location.sql",
+          "original_file_path": "macros/utils/external_location.sql",
+          "unique_id": "macro.dbt_duckdb.external_location",
+          "macro_sql": "{%- macro external_location(relation, config) -%}\n  {%- if config.get('options', {}).get('partition_by') is none -%}\n    {%- set format = config.get('format', 'parquet') -%}\n    {{- adapter.external_root() }}/{{ relation.identifier }}.{{ format }}\n  {%- else -%}\n    {{- adapter.external_root() }}/{{ relation.identifier }}\n  {%- endif -%}\n{%- endmacro -%}",
+          "depends_on": {
+            "macros": []
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.02352
+        },
+        "macro.dbt.run_hooks": {
+          "name": "run_hooks",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/materializations/hooks.sql",
+          "original_file_path": "macros/materializations/hooks.sql",
+          "unique_id": "macro.dbt.run_hooks",
+          "macro_sql": "{% macro run_hooks(hooks, inside_transaction=True) %}\n  {% for hook in hooks | selectattr('transaction', 'equalto', inside_transaction)  %}\n    {% if not inside_transaction and loop.first %}\n      {% call statement(auto_begin=inside_transaction) %}\n        commit;\n      {% endcall %}\n    {% endif %}\n    {% set rendered = render(hook.get('sql')) | trim %}\n    {% if (rendered | length) > 0 %}\n      {% call statement(auto_begin=inside_transaction) %}\n        {{ rendered }}\n      {% endcall %}\n    {% endif %}\n  {% endfor %}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.statement"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.024571
+        },
+        "macro.dbt.make_hook_config": {
+          "name": "make_hook_config",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/materializations/hooks.sql",
+          "original_file_path": "macros/materializations/hooks.sql",
+          "unique_id": "macro.dbt.make_hook_config",
+          "macro_sql": "{% macro make_hook_config(sql, inside_transaction) %}\n    {{ tojson({\"sql\": sql, \"transaction\": inside_transaction}) }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": []
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.024758
+        },
+        "macro.dbt.before_begin": {
+          "name": "before_begin",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/materializations/hooks.sql",
+          "original_file_path": "macros/materializations/hooks.sql",
+          "unique_id": "macro.dbt.before_begin",
+          "macro_sql": "{% macro before_begin(sql) %}\n    {{ make_hook_config(sql, inside_transaction=False) }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.make_hook_config"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.024904
+        },
+        "macro.dbt.in_transaction": {
+          "name": "in_transaction",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/materializations/hooks.sql",
+          "original_file_path": "macros/materializations/hooks.sql",
+          "unique_id": "macro.dbt.in_transaction",
+          "macro_sql": "{% macro in_transaction(sql) %}\n    {{ make_hook_config(sql, inside_transaction=True) }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.make_hook_config"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.025045
+        },
+        "macro.dbt.after_commit": {
+          "name": "after_commit",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/materializations/hooks.sql",
+          "original_file_path": "macros/materializations/hooks.sql",
+          "unique_id": "macro.dbt.after_commit",
+          "macro_sql": "{% macro after_commit(sql) %}\n    {{ make_hook_config(sql, inside_transaction=False) }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.make_hook_config"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.025182
+        },
+        "macro.dbt.set_sql_header": {
+          "name": "set_sql_header",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/materializations/configs.sql",
+          "original_file_path": "macros/materializations/configs.sql",
+          "unique_id": "macro.dbt.set_sql_header",
+          "macro_sql": "{% macro set_sql_header(config) -%}\n  {{ config.set('sql_header', caller()) }}\n{%- endmacro %}",
+          "depends_on": {
+            "macros": []
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.025554
+        },
+        "macro.dbt.should_full_refresh": {
+          "name": "should_full_refresh",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/materializations/configs.sql",
+          "original_file_path": "macros/materializations/configs.sql",
+          "unique_id": "macro.dbt.should_full_refresh",
+          "macro_sql": "{% macro should_full_refresh() %}\n  {% set config_full_refresh = config.get('full_refresh') %}\n  {% if config_full_refresh is none %}\n    {% set config_full_refresh = flags.FULL_REFRESH %}\n  {% endif %}\n  {% do return(config_full_refresh) %}\n{% endmacro %}",
+          "depends_on": {
+            "macros": []
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.025847
+        },
+        "macro.dbt.should_store_failures": {
+          "name": "should_store_failures",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/materializations/configs.sql",
+          "original_file_path": "macros/materializations/configs.sql",
+          "unique_id": "macro.dbt.should_store_failures",
+          "macro_sql": "{% macro should_store_failures() %}\n  {% set config_store_failures = config.get('store_failures') %}\n  {% if config_store_failures is none %}\n    {% set config_store_failures = flags.STORE_FAILURES %}\n  {% endif %}\n  {% do return(config_store_failures) %}\n{% endmacro %}",
+          "depends_on": {
+            "macros": []
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.0261362
+        },
+        "macro.dbt.snapshot_merge_sql": {
+          "name": "snapshot_merge_sql",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/materializations/snapshots/snapshot_merge.sql",
+          "original_file_path": "macros/materializations/snapshots/snapshot_merge.sql",
+          "unique_id": "macro.dbt.snapshot_merge_sql",
+          "macro_sql": "{% macro snapshot_merge_sql(target, source, insert_cols) -%}\n  {{ adapter.dispatch('snapshot_merge_sql', 'dbt')(target, source, insert_cols) }}\n{%- endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt_duckdb.duckdb__snapshot_merge_sql"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.026568
+        },
+        "macro.dbt.default__snapshot_merge_sql": {
+          "name": "default__snapshot_merge_sql",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/materializations/snapshots/snapshot_merge.sql",
+          "original_file_path": "macros/materializations/snapshots/snapshot_merge.sql",
+          "unique_id": "macro.dbt.default__snapshot_merge_sql",
+          "macro_sql": "{% macro default__snapshot_merge_sql(target, source, insert_cols) -%}\n    {%- set insert_cols_csv = insert_cols | join(', ') -%}\n\n    merge into {{ target }} as DBT_INTERNAL_DEST\n    using {{ source }} as DBT_INTERNAL_SOURCE\n    on DBT_INTERNAL_SOURCE.dbt_scd_id = DBT_INTERNAL_DEST.dbt_scd_id\n\n    when matched\n     and DBT_INTERNAL_DEST.dbt_valid_to is null\n     and DBT_INTERNAL_SOURCE.dbt_change_type in ('update', 'delete')\n        then update\n        set dbt_valid_to = DBT_INTERNAL_SOURCE.dbt_valid_to\n\n    when not matched\n     and DBT_INTERNAL_SOURCE.dbt_change_type = 'insert'\n        then insert ({{ insert_cols_csv }})\n        values ({{ insert_cols_csv }})\n\n{% endmacro %}",
+          "depends_on": {
+            "macros": []
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.0268302
+        },
+        "macro.dbt.strategy_dispatch": {
+          "name": "strategy_dispatch",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/materializations/snapshots/strategies.sql",
+          "original_file_path": "macros/materializations/snapshots/strategies.sql",
+          "unique_id": "macro.dbt.strategy_dispatch",
+          "macro_sql": "{% macro strategy_dispatch(name) -%}\n{% set original_name = name %}\n  {% if '.' in name %}\n    {% set package_name, name = name.split(\".\", 1) %}\n  {% else %}\n    {% set package_name = none %}\n  {% endif %}\n\n  {% if package_name is none %}\n    {% set package_context = context %}\n  {% elif package_name in context %}\n    {% set package_context = context[package_name] %}\n  {% else %}\n    {% set error_msg %}\n        Could not find package '{{package_name}}', called with '{{original_name}}'\n    {% endset %}\n    {{ exceptions.raise_compiler_error(error_msg | trim) }}\n  {% endif %}\n\n  {%- set search_name = 'snapshot_' ~ name ~ '_strategy' -%}\n\n  {% if search_name not in package_context %}\n    {% set error_msg %}\n        The specified strategy macro '{{name}}' was not found in package '{{ package_name }}'\n    {% endset %}\n    {{ exceptions.raise_compiler_error(error_msg | trim) }}\n  {% endif %}\n  {{ return(package_context[search_name]) }}\n{%- endmacro %}",
+          "depends_on": {
+            "macros": []
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.030553
+        },
+        "macro.dbt.snapshot_hash_arguments": {
+          "name": "snapshot_hash_arguments",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/materializations/snapshots/strategies.sql",
+          "original_file_path": "macros/materializations/snapshots/strategies.sql",
+          "unique_id": "macro.dbt.snapshot_hash_arguments",
+          "macro_sql": "{% macro snapshot_hash_arguments(args) -%}\n  {{ adapter.dispatch('snapshot_hash_arguments', 'dbt')(args) }}\n{%- endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.default__snapshot_hash_arguments"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.030717
+        },
+        "macro.dbt.default__snapshot_hash_arguments": {
+          "name": "default__snapshot_hash_arguments",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/materializations/snapshots/strategies.sql",
+          "original_file_path": "macros/materializations/snapshots/strategies.sql",
+          "unique_id": "macro.dbt.default__snapshot_hash_arguments",
+          "macro_sql": "{% macro default__snapshot_hash_arguments(args) -%}\n    md5({%- for arg in args -%}\n        coalesce(cast({{ arg }} as varchar ), '')\n        {% if not loop.last %} || '|' || {% endif %}\n    {%- endfor -%})\n{%- endmacro %}",
+          "depends_on": {
+            "macros": []
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.0309289
+        },
+        "macro.dbt.snapshot_timestamp_strategy": {
+          "name": "snapshot_timestamp_strategy",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/materializations/snapshots/strategies.sql",
+          "original_file_path": "macros/materializations/snapshots/strategies.sql",
+          "unique_id": "macro.dbt.snapshot_timestamp_strategy",
+          "macro_sql": "{% macro snapshot_timestamp_strategy(node, snapshotted_rel, current_rel, config, target_exists) %}\n    {% set primary_key = config['unique_key'] %}\n    {% set updated_at = config['updated_at'] %}\n    {% set invalidate_hard_deletes = config.get('invalidate_hard_deletes', false) %}\n\n    {#/*\n        The snapshot relation might not have an {{ updated_at }} value if the\n        snapshot strategy is changed from `check` to `timestamp`. We\n        should use a dbt-created column for the comparison in the snapshot\n        table instead of assuming that the user-supplied {{ updated_at }}\n        will be present in the historical data.\n\n        See https://github.com/dbt-labs/dbt-core/issues/2350\n    */ #}\n    {% set row_changed_expr -%}\n        ({{ snapshotted_rel }}.dbt_valid_from < {{ current_rel }}.{{ updated_at }})\n    {%- endset %}\n\n    {% set scd_id_expr = snapshot_hash_arguments([primary_key, updated_at]) %}\n\n    {% do return({\n        \"unique_key\": primary_key,\n        \"updated_at\": updated_at,\n        \"row_changed\": row_changed_expr,\n        \"scd_id\": scd_id_expr,\n        \"invalidate_hard_deletes\": invalidate_hard_deletes\n    }) %}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.snapshot_hash_arguments"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.031641
+        },
+        "macro.dbt.snapshot_string_as_time": {
+          "name": "snapshot_string_as_time",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/materializations/snapshots/strategies.sql",
+          "original_file_path": "macros/materializations/snapshots/strategies.sql",
+          "unique_id": "macro.dbt.snapshot_string_as_time",
+          "macro_sql": "{% macro snapshot_string_as_time(timestamp) -%}\n    {{ adapter.dispatch('snapshot_string_as_time', 'dbt')(timestamp) }}\n{%- endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt_duckdb.duckdb__snapshot_string_as_time"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.0318
+        },
+        "macro.dbt.default__snapshot_string_as_time": {
+          "name": "default__snapshot_string_as_time",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/materializations/snapshots/strategies.sql",
+          "original_file_path": "macros/materializations/snapshots/strategies.sql",
+          "unique_id": "macro.dbt.default__snapshot_string_as_time",
+          "macro_sql": "{% macro default__snapshot_string_as_time(timestamp) %}\n    {% do exceptions.raise_not_implemented(\n        'snapshot_string_as_time macro not implemented for adapter '+adapter.type()\n    ) %}\n{% endmacro %}",
+          "depends_on": {
+            "macros": []
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.0319722
+        },
+        "macro.dbt.snapshot_check_all_get_existing_columns": {
+          "name": "snapshot_check_all_get_existing_columns",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/materializations/snapshots/strategies.sql",
+          "original_file_path": "macros/materializations/snapshots/strategies.sql",
+          "unique_id": "macro.dbt.snapshot_check_all_get_existing_columns",
+          "macro_sql": "{% macro snapshot_check_all_get_existing_columns(node, target_exists, check_cols_config) -%}\n    {%- if not target_exists -%}\n        {#-- no table yet -> return whatever the query does --#}\n        {{ return((false, query_columns)) }}\n    {%- endif -%}\n\n    {#-- handle any schema changes --#}\n    {%- set target_relation = adapter.get_relation(database=node.database, schema=node.schema, identifier=node.alias) -%}\n\n    {% if check_cols_config == 'all' %}\n        {%- set query_columns = get_columns_in_query(node['compiled_code']) -%}\n\n    {% elif check_cols_config is iterable and (check_cols_config | length) > 0 %}\n        {#-- query for proper casing/quoting, to support comparison below --#}\n        {%- set select_check_cols_from_target -%}\n            {#-- N.B. The whitespace below is necessary to avoid edge case issue with comments --#}\n            {#-- See: https://github.com/dbt-labs/dbt-core/issues/6781 --#}\n            select {{ check_cols_config | join(', ') }} from (\n                {{ node['compiled_code'] }}\n            ) subq\n        {%- endset -%}\n        {% set query_columns = get_columns_in_query(select_check_cols_from_target) %}\n\n    {% else %}\n        {% do exceptions.raise_compiler_error(\"Invalid value for 'check_cols': \" ~ check_cols_config) %}\n    {% endif %}\n\n    {%- set existing_cols = adapter.get_columns_in_relation(target_relation) | map(attribute = 'name') | list -%}\n    {%- set ns = namespace() -%} {#-- handle for-loop scoping with a namespace --#}\n    {%- set ns.column_added = false -%}\n\n    {%- set intersection = [] -%}\n    {%- for col in query_columns -%}\n        {%- if col in existing_cols -%}\n            {%- do intersection.append(adapter.quote(col)) -%}\n        {%- else -%}\n            {% set ns.column_added = true %}\n        {%- endif -%}\n    {%- endfor -%}\n    {{ return((ns.column_added, intersection)) }}\n{%- endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.get_columns_in_query"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.033322
+        },
+        "macro.dbt.snapshot_check_strategy": {
+          "name": "snapshot_check_strategy",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/materializations/snapshots/strategies.sql",
+          "original_file_path": "macros/materializations/snapshots/strategies.sql",
+          "unique_id": "macro.dbt.snapshot_check_strategy",
+          "macro_sql": "{% macro snapshot_check_strategy(node, snapshotted_rel, current_rel, config, target_exists) %}\n    {% set check_cols_config = config['check_cols'] %}\n    {% set primary_key = config['unique_key'] %}\n    {% set invalidate_hard_deletes = config.get('invalidate_hard_deletes', false) %}\n    {% set updated_at = config.get('updated_at', snapshot_get_time()) %}\n\n    {% set column_added = false %}\n\n    {% set column_added, check_cols = snapshot_check_all_get_existing_columns(node, target_exists, check_cols_config) %}\n\n    {%- set row_changed_expr -%}\n    (\n    {%- if column_added -%}\n        {{ get_true_sql() }}\n    {%- else -%}\n    {%- for col in check_cols -%}\n        {{ snapshotted_rel }}.{{ col }} != {{ current_rel }}.{{ col }}\n        or\n        (\n            (({{ snapshotted_rel }}.{{ col }} is null) and not ({{ current_rel }}.{{ col }} is null))\n            or\n            ((not {{ snapshotted_rel }}.{{ col }} is null) and ({{ current_rel }}.{{ col }} is null))\n        )\n        {%- if not loop.last %} or {% endif -%}\n    {%- endfor -%}\n    {%- endif -%}\n    )\n    {%- endset %}\n\n    {% set scd_id_expr = snapshot_hash_arguments([primary_key, updated_at]) %}\n\n    {% do return({\n        \"unique_key\": primary_key,\n        \"updated_at\": updated_at,\n        \"row_changed\": row_changed_expr,\n        \"scd_id\": scd_id_expr,\n        \"invalidate_hard_deletes\": invalidate_hard_deletes\n    }) %}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.snapshot_get_time",
+              "macro.dbt.snapshot_check_all_get_existing_columns",
+              "macro.dbt.get_true_sql",
+              "macro.dbt.snapshot_hash_arguments"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.034653
+        },
+        "macro.dbt.create_columns": {
+          "name": "create_columns",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/materializations/snapshots/helpers.sql",
+          "original_file_path": "macros/materializations/snapshots/helpers.sql",
+          "unique_id": "macro.dbt.create_columns",
+          "macro_sql": "{% macro create_columns(relation, columns) %}\n  {{ adapter.dispatch('create_columns', 'dbt')(relation, columns) }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.default__create_columns"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.038982
+        },
+        "macro.dbt.default__create_columns": {
+          "name": "default__create_columns",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/materializations/snapshots/helpers.sql",
+          "original_file_path": "macros/materializations/snapshots/helpers.sql",
+          "unique_id": "macro.dbt.default__create_columns",
+          "macro_sql": "{% macro default__create_columns(relation, columns) %}\n  {% for column in columns %}\n    {% call statement() %}\n      alter table {{ relation }} add column \"{{ column.name }}\" {{ column.data_type }};\n    {% endcall %}\n  {% endfor %}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.statement"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.039258
+        },
+        "macro.dbt.post_snapshot": {
+          "name": "post_snapshot",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/materializations/snapshots/helpers.sql",
+          "original_file_path": "macros/materializations/snapshots/helpers.sql",
+          "unique_id": "macro.dbt.post_snapshot",
+          "macro_sql": "{% macro post_snapshot(staging_relation) %}\n  {{ adapter.dispatch('post_snapshot', 'dbt')(staging_relation) }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.default__post_snapshot"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.0394182
+        },
+        "macro.dbt.default__post_snapshot": {
+          "name": "default__post_snapshot",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/materializations/snapshots/helpers.sql",
+          "original_file_path": "macros/materializations/snapshots/helpers.sql",
+          "unique_id": "macro.dbt.default__post_snapshot",
+          "macro_sql": "{% macro default__post_snapshot(staging_relation) %}\n    {# no-op #}\n{% endmacro %}",
+          "depends_on": {
+            "macros": []
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.0395021
+        },
+        "macro.dbt.get_true_sql": {
+          "name": "get_true_sql",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/materializations/snapshots/helpers.sql",
+          "original_file_path": "macros/materializations/snapshots/helpers.sql",
+          "unique_id": "macro.dbt.get_true_sql",
+          "macro_sql": "{% macro get_true_sql() %}\n  {{ adapter.dispatch('get_true_sql', 'dbt')() }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.default__get_true_sql"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.039642
+        },
+        "macro.dbt.default__get_true_sql": {
+          "name": "default__get_true_sql",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/materializations/snapshots/helpers.sql",
+          "original_file_path": "macros/materializations/snapshots/helpers.sql",
+          "unique_id": "macro.dbt.default__get_true_sql",
+          "macro_sql": "{% macro default__get_true_sql() %}\n    {{ return('TRUE') }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": []
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.039753
+        },
+        "macro.dbt.snapshot_staging_table": {
+          "name": "snapshot_staging_table",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/materializations/snapshots/helpers.sql",
+          "original_file_path": "macros/materializations/snapshots/helpers.sql",
+          "unique_id": "macro.dbt.snapshot_staging_table",
+          "macro_sql": "{% macro snapshot_staging_table(strategy, source_sql, target_relation) -%}\n  {{ adapter.dispatch('snapshot_staging_table', 'dbt')(strategy, source_sql, target_relation) }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.default__snapshot_staging_table"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.039972
+        },
+        "macro.dbt.default__snapshot_staging_table": {
+          "name": "default__snapshot_staging_table",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/materializations/snapshots/helpers.sql",
+          "original_file_path": "macros/materializations/snapshots/helpers.sql",
+          "unique_id": "macro.dbt.default__snapshot_staging_table",
+          "macro_sql": "{% macro default__snapshot_staging_table(strategy, source_sql, target_relation) -%}\n\n    with snapshot_query as (\n\n        {{ source_sql }}\n\n    ),\n\n    snapshotted_data as (\n\n        select *,\n            {{ strategy.unique_key }} as dbt_unique_key\n\n        from {{ target_relation }}\n        where dbt_valid_to is null\n\n    ),\n\n    insertions_source_data as (\n\n        select\n            *,\n            {{ strategy.unique_key }} as dbt_unique_key,\n            {{ strategy.updated_at }} as dbt_updated_at,\n            {{ strategy.updated_at }} as dbt_valid_from,\n            nullif({{ strategy.updated_at }}, {{ strategy.updated_at }}) as dbt_valid_to,\n            {{ strategy.scd_id }} as dbt_scd_id\n\n        from snapshot_query\n    ),\n\n    updates_source_data as (\n\n        select\n            *,\n            {{ strategy.unique_key }} as dbt_unique_key,\n            {{ strategy.updated_at }} as dbt_updated_at,\n            {{ strategy.updated_at }} as dbt_valid_from,\n            {{ strategy.updated_at }} as dbt_valid_to\n\n        from snapshot_query\n    ),\n\n    {%- if strategy.invalidate_hard_deletes %}\n\n    deletes_source_data as (\n\n        select\n            *,\n            {{ strategy.unique_key }} as dbt_unique_key\n        from snapshot_query\n    ),\n    {% endif %}\n\n    insertions as (\n\n        select\n            'insert' as dbt_change_type,\n            source_data.*\n\n        from insertions_source_data as source_data\n        left outer join snapshotted_data on snapshotted_data.dbt_unique_key = source_data.dbt_unique_key\n        where snapshotted_data.dbt_unique_key is null\n           or (\n                snapshotted_data.dbt_unique_key is not null\n            and (\n                {{ strategy.row_changed }}\n            )\n        )\n\n    ),\n\n    updates as (\n\n        select\n            'update' as dbt_change_type,\n            source_data.*,\n            snapshotted_data.dbt_scd_id\n\n        from updates_source_data as source_data\n        join snapshotted_data on snapshotted_data.dbt_unique_key = source_data.dbt_unique_key\n        where (\n            {{ strategy.row_changed }}\n        )\n    )\n\n    {%- if strategy.invalidate_hard_deletes -%}\n    ,\n\n    deletes as (\n\n        select\n            'delete' as dbt_change_type,\n            source_data.*,\n            {{ snapshot_get_time() }} as dbt_valid_from,\n            {{ snapshot_get_time() }} as dbt_updated_at,\n            {{ snapshot_get_time() }} as dbt_valid_to,\n            snapshotted_data.dbt_scd_id\n\n        from snapshotted_data\n        left join deletes_source_data as source_data on snapshotted_data.dbt_unique_key = source_data.dbt_unique_key\n        where source_data.dbt_unique_key is null\n    )\n    {%- endif %}\n\n    select * from insertions\n    union all\n    select * from updates\n    {%- if strategy.invalidate_hard_deletes %}\n    union all\n    select * from deletes\n    {%- endif %}\n\n{%- endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.snapshot_get_time"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.0408268
+        },
+        "macro.dbt.build_snapshot_table": {
+          "name": "build_snapshot_table",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/materializations/snapshots/helpers.sql",
+          "original_file_path": "macros/materializations/snapshots/helpers.sql",
+          "unique_id": "macro.dbt.build_snapshot_table",
+          "macro_sql": "{% macro build_snapshot_table(strategy, sql) -%}\n  {{ adapter.dispatch('build_snapshot_table', 'dbt')(strategy, sql) }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.default__build_snapshot_table"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.041007
+        },
+        "macro.dbt.default__build_snapshot_table": {
+          "name": "default__build_snapshot_table",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/materializations/snapshots/helpers.sql",
+          "original_file_path": "macros/materializations/snapshots/helpers.sql",
+          "unique_id": "macro.dbt.default__build_snapshot_table",
+          "macro_sql": "{% macro default__build_snapshot_table(strategy, sql) %}\n\n    select *,\n        {{ strategy.scd_id }} as dbt_scd_id,\n        {{ strategy.updated_at }} as dbt_updated_at,\n        {{ strategy.updated_at }} as dbt_valid_from,\n        nullif({{ strategy.updated_at }}, {{ strategy.updated_at }}) as dbt_valid_to\n    from (\n        {{ sql }}\n    ) sbq\n\n{% endmacro %}",
+          "depends_on": {
+            "macros": []
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.0412538
+        },
+        "macro.dbt.build_snapshot_staging_table": {
+          "name": "build_snapshot_staging_table",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/materializations/snapshots/helpers.sql",
+          "original_file_path": "macros/materializations/snapshots/helpers.sql",
+          "unique_id": "macro.dbt.build_snapshot_staging_table",
+          "macro_sql": "{% macro build_snapshot_staging_table(strategy, sql, target_relation) %}\n    {% set temp_relation = make_temp_relation(target_relation) %}\n\n    {% set select = snapshot_staging_table(strategy, sql, target_relation) %}\n\n    {% call statement('build_snapshot_staging_relation') %}\n        {{ create_table_as(True, temp_relation, select) }}\n    {% endcall %}\n\n    {% do return(temp_relation) %}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.make_temp_relation",
+              "macro.dbt.snapshot_staging_table",
+              "macro.dbt.statement",
+              "macro.dbt.create_table_as"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.0416598
+        },
+        "macro.dbt.materialization_snapshot_default": {
+          "name": "materialization_snapshot_default",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/materializations/snapshots/snapshot.sql",
+          "original_file_path": "macros/materializations/snapshots/snapshot.sql",
+          "unique_id": "macro.dbt.materialization_snapshot_default",
+          "macro_sql": "{% materialization snapshot, default %}\n  {%- set config = model['config'] -%}\n\n  {%- set target_table = model.get('alias', model.get('name')) -%}\n\n  {%- set strategy_name = config.get('strategy') -%}\n  {%- set unique_key = config.get('unique_key') %}\n  -- grab current tables grants config for comparision later on\n  {%- set grant_config = config.get('grants') -%}\n\n  {% set target_relation_exists, target_relation = get_or_create_relation(\n          database=model.database,\n          schema=model.schema,\n          identifier=target_table,\n          type='table') -%}\n\n  {%- if not target_relation.is_table -%}\n    {% do exceptions.relation_wrong_type(target_relation, 'table') %}\n  {%- endif -%}\n\n\n  {{ run_hooks(pre_hooks, inside_transaction=False) }}\n\n  {{ run_hooks(pre_hooks, inside_transaction=True) }}\n\n  {% set strategy_macro = strategy_dispatch(strategy_name) %}\n  {% set strategy = strategy_macro(model, \"snapshotted_data\", \"source_data\", config, target_relation_exists) %}\n\n  {% if not target_relation_exists %}\n\n      {% set build_sql = build_snapshot_table(strategy, model['compiled_code']) %}\n      {% set final_sql = create_table_as(False, target_relation, build_sql) %}\n\n  {% else %}\n\n      {{ adapter.valid_snapshot_target(target_relation) }}\n\n      {% set staging_table = build_snapshot_staging_table(strategy, sql, target_relation) %}\n\n      -- this may no-op if the database does not require column expansion\n      {% do adapter.expand_target_column_types(from_relation=staging_table,\n                                               to_relation=target_relation) %}\n\n      {% set missing_columns = adapter.get_missing_columns(staging_table, target_relation)\n                                   | rejectattr('name', 'equalto', 'dbt_change_type')\n                                   | rejectattr('name', 'equalto', 'DBT_CHANGE_TYPE')\n                                   | rejectattr('name', 'equalto', 'dbt_unique_key')\n                                   | rejectattr('name', 'equalto', 'DBT_UNIQUE_KEY')\n                                   | list %}\n\n      {% do create_columns(target_relation, missing_columns) %}\n\n      {% set source_columns = adapter.get_columns_in_relation(staging_table)\n                                   | rejectattr('name', 'equalto', 'dbt_change_type')\n                                   | rejectattr('name', 'equalto', 'DBT_CHANGE_TYPE')\n                                   | rejectattr('name', 'equalto', 'dbt_unique_key')\n                                   | rejectattr('name', 'equalto', 'DBT_UNIQUE_KEY')\n                                   | list %}\n\n      {% set quoted_source_columns = [] %}\n      {% for column in source_columns %}\n        {% do quoted_source_columns.append(adapter.quote(column.name)) %}\n      {% endfor %}\n\n      {% set final_sql = snapshot_merge_sql(\n            target = target_relation,\n            source = staging_table,\n            insert_cols = quoted_source_columns\n         )\n      %}\n\n  {% endif %}\n\n  {% call statement('main') %}\n      {{ final_sql }}\n  {% endcall %}\n\n  {% set should_revoke = should_revoke(target_relation_exists, full_refresh_mode=False) %}\n  {% do apply_grants(target_relation, grant_config, should_revoke=should_revoke) %}\n\n  {% do persist_docs(target_relation, model) %}\n\n  {% if not target_relation_exists %}\n    {% do create_indexes(target_relation) %}\n  {% endif %}\n\n  {{ run_hooks(post_hooks, inside_transaction=True) }}\n\n  {{ adapter.commit() }}\n\n  {% if staging_table is defined %}\n      {% do post_snapshot(staging_table) %}\n  {% endif %}\n\n  {{ run_hooks(post_hooks, inside_transaction=False) }}\n\n  {{ return({'relations': [target_relation]}) }}\n\n{% endmaterialization %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.get_or_create_relation",
+              "macro.dbt.run_hooks",
+              "macro.dbt.strategy_dispatch",
+              "macro.dbt.build_snapshot_table",
+              "macro.dbt.create_table_as",
+              "macro.dbt.build_snapshot_staging_table",
+              "macro.dbt.create_columns",
+              "macro.dbt.snapshot_merge_sql",
+              "macro.dbt.statement",
+              "macro.dbt.should_revoke",
+              "macro.dbt.apply_grants",
+              "macro.dbt.persist_docs",
+              "macro.dbt.create_indexes",
+              "macro.dbt.post_snapshot"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.047958,
+          "supported_languages": [
+            "sql"
+          ]
+        },
+        "macro.dbt.materialization_test_default": {
+          "name": "materialization_test_default",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/materializations/tests/test.sql",
+          "original_file_path": "macros/materializations/tests/test.sql",
+          "unique_id": "macro.dbt.materialization_test_default",
+          "macro_sql": "{%- materialization test, default -%}\n\n  {% set relations = [] %}\n\n  {% if should_store_failures() %}\n\n    {% set identifier = model['alias'] %}\n    {% set old_relation = adapter.get_relation(database=database, schema=schema, identifier=identifier) %}\n    {% set target_relation = api.Relation.create(\n        identifier=identifier, schema=schema, database=database, type='table') -%} %}\n\n    {% if old_relation %}\n        {% do adapter.drop_relation(old_relation) %}\n    {% endif %}\n\n    {% call statement(auto_begin=True) %}\n        {{ create_table_as(False, target_relation, sql) }}\n    {% endcall %}\n\n    {% do relations.append(target_relation) %}\n\n    {% set main_sql %}\n        select *\n        from {{ target_relation }}\n    {% endset %}\n\n    {{ adapter.commit() }}\n\n  {% else %}\n\n      {% set main_sql = sql %}\n\n  {% endif %}\n\n  {% set limit = config.get('limit') %}\n  {% set fail_calc = config.get('fail_calc') %}\n  {% set warn_if = config.get('warn_if') %}\n  {% set error_if = config.get('error_if') %}\n\n  {% call statement('main', fetch_result=True) -%}\n\n    {{ get_test_sql(main_sql, fail_calc, warn_if, error_if, limit)}}\n\n  {%- endcall %}\n\n  {{ return({'relations': relations}) }}\n\n{%- endmaterialization -%}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.should_store_failures",
+              "macro.dbt.statement",
+              "macro.dbt.create_table_as",
+              "macro.dbt.get_test_sql"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.050019,
+          "supported_languages": [
+            "sql"
+          ]
+        },
+        "macro.dbt.get_test_sql": {
+          "name": "get_test_sql",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/materializations/tests/helpers.sql",
+          "original_file_path": "macros/materializations/tests/helpers.sql",
+          "unique_id": "macro.dbt.get_test_sql",
+          "macro_sql": "{% macro get_test_sql(main_sql, fail_calc, warn_if, error_if, limit) -%}\n  {{ adapter.dispatch('get_test_sql', 'dbt')(main_sql, fail_calc, warn_if, error_if, limit) }}\n{%- endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.default__get_test_sql"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.050474
+        },
+        "macro.dbt.default__get_test_sql": {
+          "name": "default__get_test_sql",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/materializations/tests/helpers.sql",
+          "original_file_path": "macros/materializations/tests/helpers.sql",
+          "unique_id": "macro.dbt.default__get_test_sql",
+          "macro_sql": "{% macro default__get_test_sql(main_sql, fail_calc, warn_if, error_if, limit) -%}\n    select\n      {{ fail_calc }} as failures,\n      {{ fail_calc }} {{ warn_if }} as should_warn,\n      {{ fail_calc }} {{ error_if }} as should_error\n    from (\n      {{ main_sql }}\n      {{ \"limit \" ~ limit if limit != none }}\n    ) dbt_internal_test\n{%- endmacro %}",
+          "depends_on": {
+            "macros": []
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.0507782
+        },
+        "macro.dbt.get_where_subquery": {
+          "name": "get_where_subquery",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/materializations/tests/where_subquery.sql",
+          "original_file_path": "macros/materializations/tests/where_subquery.sql",
+          "unique_id": "macro.dbt.get_where_subquery",
+          "macro_sql": "{% macro get_where_subquery(relation) -%}\n    {% do return(adapter.dispatch('get_where_subquery', 'dbt')(relation)) %}\n{%- endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.default__get_where_subquery"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.051147
+        },
+        "macro.dbt.default__get_where_subquery": {
+          "name": "default__get_where_subquery",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/materializations/tests/where_subquery.sql",
+          "original_file_path": "macros/materializations/tests/where_subquery.sql",
+          "unique_id": "macro.dbt.default__get_where_subquery",
+          "macro_sql": "{% macro default__get_where_subquery(relation) -%}\n    {% set where = config.get('where', '') %}\n    {% if where %}\n        {%- set filtered -%}\n            (select * from {{ relation }} where {{ where }}) dbt_subquery\n        {%- endset -%}\n        {% do return(filtered) %}\n    {%- else -%}\n        {% do return(relation) %}\n    {%- endif -%}\n{%- endmacro %}",
+          "depends_on": {
+            "macros": []
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.05156
+        },
+        "macro.dbt.get_quoted_csv": {
+          "name": "get_quoted_csv",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/materializations/models/incremental/column_helpers.sql",
+          "original_file_path": "macros/materializations/models/incremental/column_helpers.sql",
+          "unique_id": "macro.dbt.get_quoted_csv",
+          "macro_sql": "{% macro get_quoted_csv(column_names) %}\n\n    {% set quoted = [] %}\n    {% for col in column_names -%}\n        {%- do quoted.append(adapter.quote(col)) -%}\n    {%- endfor %}\n\n    {%- set dest_cols_csv = quoted | join(', ') -%}\n    {{ return(dest_cols_csv) }}\n\n{% endmacro %}",
+          "depends_on": {
+            "macros": []
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.053173
+        },
+        "macro.dbt.diff_columns": {
+          "name": "diff_columns",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/materializations/models/incremental/column_helpers.sql",
+          "original_file_path": "macros/materializations/models/incremental/column_helpers.sql",
+          "unique_id": "macro.dbt.diff_columns",
+          "macro_sql": "{% macro diff_columns(source_columns, target_columns) %}\n\n  {% set result = [] %}\n  {% set source_names = source_columns | map(attribute = 'column') | list %}\n  {% set target_names = target_columns | map(attribute = 'column') | list %}\n\n   {# --check whether the name attribute exists in the target - this does not perform a data type check #}\n   {% for sc in source_columns %}\n     {% if sc.name not in target_names %}\n        {{ result.append(sc) }}\n     {% endif %}\n   {% endfor %}\n\n  {{ return(result) }}\n\n{% endmacro %}",
+          "depends_on": {
+            "macros": []
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.0537028
+        },
+        "macro.dbt.diff_column_data_types": {
+          "name": "diff_column_data_types",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/materializations/models/incremental/column_helpers.sql",
+          "original_file_path": "macros/materializations/models/incremental/column_helpers.sql",
+          "unique_id": "macro.dbt.diff_column_data_types",
+          "macro_sql": "{% macro diff_column_data_types(source_columns, target_columns) %}\n\n  {% set result = [] %}\n  {% for sc in source_columns %}\n    {% set tc = target_columns | selectattr(\"name\", \"equalto\", sc.name) | list | first %}\n    {% if tc %}\n      {% if sc.data_type != tc.data_type and not sc.can_expand_to(other_column=tc) %}\n        {{ result.append( { 'column_name': tc.name, 'new_type': sc.data_type } ) }}\n      {% endif %}\n    {% endif %}\n  {% endfor %}\n\n  {{ return(result) }}\n\n{% endmacro %}",
+          "depends_on": {
+            "macros": []
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.0543401
+        },
+        "macro.dbt.get_merge_update_columns": {
+          "name": "get_merge_update_columns",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/materializations/models/incremental/column_helpers.sql",
+          "original_file_path": "macros/materializations/models/incremental/column_helpers.sql",
+          "unique_id": "macro.dbt.get_merge_update_columns",
+          "macro_sql": "{% macro get_merge_update_columns(merge_update_columns, merge_exclude_columns, dest_columns) %}\n  {{ return(adapter.dispatch('get_merge_update_columns', 'dbt')(merge_update_columns, merge_exclude_columns, dest_columns)) }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.default__get_merge_update_columns"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.0545762
+        },
+        "macro.dbt.default__get_merge_update_columns": {
+          "name": "default__get_merge_update_columns",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/materializations/models/incremental/column_helpers.sql",
+          "original_file_path": "macros/materializations/models/incremental/column_helpers.sql",
+          "unique_id": "macro.dbt.default__get_merge_update_columns",
+          "macro_sql": "{% macro default__get_merge_update_columns(merge_update_columns, merge_exclude_columns, dest_columns) %}\n  {%- set default_cols = dest_columns | map(attribute=\"quoted\") | list -%}\n\n  {%- if merge_update_columns and merge_exclude_columns -%}\n    {{ exceptions.raise_compiler_error(\n        'Model cannot specify merge_update_columns and merge_exclude_columns. Please update model to use only one config'\n    )}}\n  {%- elif merge_update_columns -%}\n    {%- set update_columns = merge_update_columns -%}\n  {%- elif merge_exclude_columns -%}\n    {%- set update_columns = [] -%}\n    {%- for column in dest_columns -%}\n      {% if column.column | lower not in merge_exclude_columns | map(\"lower\") | list %}\n        {%- do update_columns.append(column.quoted) -%}\n      {% endif %}\n    {%- endfor -%}\n  {%- else -%}\n    {%- set update_columns = default_cols -%}\n  {%- endif -%}\n\n  {{ return(update_columns) }}\n\n{% endmacro %}",
+          "depends_on": {
+            "macros": []
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.0552619
+        },
+        "macro.dbt.get_merge_sql": {
+          "name": "get_merge_sql",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/materializations/models/incremental/merge.sql",
+          "original_file_path": "macros/materializations/models/incremental/merge.sql",
+          "unique_id": "macro.dbt.get_merge_sql",
+          "macro_sql": "{% macro get_merge_sql(target, source, unique_key, dest_columns, incremental_predicates=none) -%}\n   -- back compat for old kwarg name\n  {% set incremental_predicates = kwargs.get('predicates', incremental_predicates) %}\n  {{ adapter.dispatch('get_merge_sql', 'dbt')(target, source, unique_key, dest_columns, incremental_predicates) }}\n{%- endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.default__get_merge_sql"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.062042
+        },
+        "macro.dbt.default__get_merge_sql": {
+          "name": "default__get_merge_sql",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/materializations/models/incremental/merge.sql",
+          "original_file_path": "macros/materializations/models/incremental/merge.sql",
+          "unique_id": "macro.dbt.default__get_merge_sql",
+          "macro_sql": "{% macro default__get_merge_sql(target, source, unique_key, dest_columns, incremental_predicates=none) -%}\n    {%- set predicates = [] if incremental_predicates is none else [] + incremental_predicates -%}\n    {%- set dest_cols_csv = get_quoted_csv(dest_columns | map(attribute=\"name\")) -%}\n    {%- set merge_update_columns = config.get('merge_update_columns') -%}\n    {%- set merge_exclude_columns = config.get('merge_exclude_columns') -%}\n    {%- set update_columns = get_merge_update_columns(merge_update_columns, merge_exclude_columns, dest_columns) -%}\n    {%- set sql_header = config.get('sql_header', none) -%}\n\n    {% if unique_key %}\n        {% if unique_key is sequence and unique_key is not mapping and unique_key is not string %}\n            {% for key in unique_key %}\n                {% set this_key_match %}\n                    DBT_INTERNAL_SOURCE.{{ key }} = DBT_INTERNAL_DEST.{{ key }}\n                {% endset %}\n                {% do predicates.append(this_key_match) %}\n            {% endfor %}\n        {% else %}\n            {% set unique_key_match %}\n                DBT_INTERNAL_SOURCE.{{ unique_key }} = DBT_INTERNAL_DEST.{{ unique_key }}\n            {% endset %}\n            {% do predicates.append(unique_key_match) %}\n        {% endif %}\n    {% else %}\n        {% do predicates.append('FALSE') %}\n    {% endif %}\n\n    {{ sql_header if sql_header is not none }}\n\n    merge into {{ target }} as DBT_INTERNAL_DEST\n        using {{ source }} as DBT_INTERNAL_SOURCE\n        on {{\"(\" ~ predicates | join(\") and (\") ~ \")\"}}\n\n    {% if unique_key %}\n    when matched then update set\n        {% for column_name in update_columns -%}\n            {{ column_name }} = DBT_INTERNAL_SOURCE.{{ column_name }}\n            {%- if not loop.last %}, {%- endif %}\n        {%- endfor %}\n    {% endif %}\n\n    when not matched then insert\n        ({{ dest_cols_csv }})\n    values\n        ({{ dest_cols_csv }})\n\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.get_quoted_csv",
+              "macro.dbt.get_merge_update_columns"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.0636811
+        },
+        "macro.dbt.get_delete_insert_merge_sql": {
+          "name": "get_delete_insert_merge_sql",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/materializations/models/incremental/merge.sql",
+          "original_file_path": "macros/materializations/models/incremental/merge.sql",
+          "unique_id": "macro.dbt.get_delete_insert_merge_sql",
+          "macro_sql": "{% macro get_delete_insert_merge_sql(target, source, unique_key, dest_columns, incremental_predicates) -%}\n  {{ adapter.dispatch('get_delete_insert_merge_sql', 'dbt')(target, source, unique_key, dest_columns, incremental_predicates) }}\n{%- endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.default__get_delete_insert_merge_sql"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.0639338
+        },
+        "macro.dbt.default__get_delete_insert_merge_sql": {
+          "name": "default__get_delete_insert_merge_sql",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/materializations/models/incremental/merge.sql",
+          "original_file_path": "macros/materializations/models/incremental/merge.sql",
+          "unique_id": "macro.dbt.default__get_delete_insert_merge_sql",
+          "macro_sql": "{% macro default__get_delete_insert_merge_sql(target, source, unique_key, dest_columns, incremental_predicates) -%}\n\n    {%- set dest_cols_csv = get_quoted_csv(dest_columns | map(attribute=\"name\")) -%}\n\n    {% if unique_key %}\n        {% if unique_key is sequence and unique_key is not string %}\n            delete from {{target }}\n            using {{ source }}\n            where (\n                {% for key in unique_key %}\n                    {{ source }}.{{ key }} = {{ target }}.{{ key }}\n                    {{ \"and \" if not loop.last}}\n                {% endfor %}\n                {% if incremental_predicates %}\n                    {% for predicate in incremental_predicates %}\n                        and {{ predicate }}\n                    {% endfor %}\n                {% endif %}\n            );\n        {% else %}\n            delete from {{ target }}\n            where (\n                {{ unique_key }}) in (\n                select ({{ unique_key }})\n                from {{ source }}\n            )\n            {%- if incremental_predicates %}\n                {% for predicate in incremental_predicates %}\n                    and {{ predicate }}\n                {% endfor %}\n            {%- endif -%};\n\n        {% endif %}\n    {% endif %}\n\n    insert into {{ target }} ({{ dest_cols_csv }})\n    (\n        select {{ dest_cols_csv }}\n        from {{ source }}\n    )\n\n{%- endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.get_quoted_csv"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.0649018
+        },
+        "macro.dbt.get_insert_overwrite_merge_sql": {
+          "name": "get_insert_overwrite_merge_sql",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/materializations/models/incremental/merge.sql",
+          "original_file_path": "macros/materializations/models/incremental/merge.sql",
+          "unique_id": "macro.dbt.get_insert_overwrite_merge_sql",
+          "macro_sql": "{% macro get_insert_overwrite_merge_sql(target, source, dest_columns, predicates, include_sql_header=false) -%}\n  {{ adapter.dispatch('get_insert_overwrite_merge_sql', 'dbt')(target, source, dest_columns, predicates, include_sql_header) }}\n{%- endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.default__get_insert_overwrite_merge_sql"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.0651588
+        },
+        "macro.dbt.default__get_insert_overwrite_merge_sql": {
+          "name": "default__get_insert_overwrite_merge_sql",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/materializations/models/incremental/merge.sql",
+          "original_file_path": "macros/materializations/models/incremental/merge.sql",
+          "unique_id": "macro.dbt.default__get_insert_overwrite_merge_sql",
+          "macro_sql": "{% macro default__get_insert_overwrite_merge_sql(target, source, dest_columns, predicates, include_sql_header) -%}\n    {#-- The only time include_sql_header is True: --#}\n    {#-- BigQuery + insert_overwrite strategy + \"static\" partitions config --#}\n    {#-- We should consider including the sql header at the materialization level instead --#}\n\n    {%- set predicates = [] if predicates is none else [] + predicates -%}\n    {%- set dest_cols_csv = get_quoted_csv(dest_columns | map(attribute=\"name\")) -%}\n    {%- set sql_header = config.get('sql_header', none) -%}\n\n    {{ sql_header if sql_header is not none and include_sql_header }}\n\n    merge into {{ target }} as DBT_INTERNAL_DEST\n        using {{ source }} as DBT_INTERNAL_SOURCE\n        on FALSE\n\n    when not matched by source\n        {% if predicates %} and {{ predicates | join(' and ') }} {% endif %}\n        then delete\n\n    when not matched then insert\n        ({{ dest_cols_csv }})\n    values\n        ({{ dest_cols_csv }})\n\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.get_quoted_csv"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.065779
+        },
+        "macro.dbt.is_incremental": {
+          "name": "is_incremental",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/materializations/models/incremental/is_incremental.sql",
+          "original_file_path": "macros/materializations/models/incremental/is_incremental.sql",
+          "unique_id": "macro.dbt.is_incremental",
+          "macro_sql": "{% macro is_incremental() %}\n    {#-- do not run introspective queries in parsing #}\n    {% if not execute %}\n        {{ return(False) }}\n    {% else %}\n        {% set relation = adapter.get_relation(this.database, this.schema, this.table) %}\n        {{ return(relation is not none\n                  and relation.type == 'table'\n                  and model.config.materialized == 'incremental'\n                  and not should_full_refresh()) }}\n    {% endif %}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.should_full_refresh"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.066398
+        },
+        "macro.dbt.get_incremental_append_sql": {
+          "name": "get_incremental_append_sql",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/materializations/models/incremental/strategies.sql",
+          "original_file_path": "macros/materializations/models/incremental/strategies.sql",
+          "unique_id": "macro.dbt.get_incremental_append_sql",
+          "macro_sql": "{% macro get_incremental_append_sql(arg_dict) %}\n\n  {{ return(adapter.dispatch('get_incremental_append_sql', 'dbt')(arg_dict)) }}\n\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt_duckdb.duckdb__get_incremental_append_sql"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.067273
+        },
+        "macro.dbt.default__get_incremental_append_sql": {
+          "name": "default__get_incremental_append_sql",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/materializations/models/incremental/strategies.sql",
+          "original_file_path": "macros/materializations/models/incremental/strategies.sql",
+          "unique_id": "macro.dbt.default__get_incremental_append_sql",
+          "macro_sql": "{% macro default__get_incremental_append_sql(arg_dict) %}\n\n  {% do return(get_insert_into_sql(arg_dict[\"target_relation\"], arg_dict[\"temp_relation\"], arg_dict[\"dest_columns\"])) %}\n\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.get_insert_into_sql"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.067502
+        },
+        "macro.dbt.get_incremental_delete_insert_sql": {
+          "name": "get_incremental_delete_insert_sql",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/materializations/models/incremental/strategies.sql",
+          "original_file_path": "macros/materializations/models/incremental/strategies.sql",
+          "unique_id": "macro.dbt.get_incremental_delete_insert_sql",
+          "macro_sql": "{% macro get_incremental_delete_insert_sql(arg_dict) %}\n\n  {{ return(adapter.dispatch('get_incremental_delete_insert_sql', 'dbt')(arg_dict)) }}\n\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt_duckdb.duckdb__get_incremental_delete_insert_sql"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.06768
+        },
+        "macro.dbt.default__get_incremental_delete_insert_sql": {
+          "name": "default__get_incremental_delete_insert_sql",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/materializations/models/incremental/strategies.sql",
+          "original_file_path": "macros/materializations/models/incremental/strategies.sql",
+          "unique_id": "macro.dbt.default__get_incremental_delete_insert_sql",
+          "macro_sql": "{% macro default__get_incremental_delete_insert_sql(arg_dict) %}\n\n  {% do return(get_delete_insert_merge_sql(arg_dict[\"target_relation\"], arg_dict[\"temp_relation\"], arg_dict[\"unique_key\"], arg_dict[\"dest_columns\"], arg_dict[\"incremental_predicates\"])) %}\n\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.get_delete_insert_merge_sql"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.067963
+        },
+        "macro.dbt.get_incremental_merge_sql": {
+          "name": "get_incremental_merge_sql",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/materializations/models/incremental/strategies.sql",
+          "original_file_path": "macros/materializations/models/incremental/strategies.sql",
+          "unique_id": "macro.dbt.get_incremental_merge_sql",
+          "macro_sql": "{% macro get_incremental_merge_sql(arg_dict) %}\n\n  {{ return(adapter.dispatch('get_incremental_merge_sql', 'dbt')(arg_dict)) }}\n\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.default__get_incremental_merge_sql"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.068138
+        },
+        "macro.dbt.default__get_incremental_merge_sql": {
+          "name": "default__get_incremental_merge_sql",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/materializations/models/incremental/strategies.sql",
+          "original_file_path": "macros/materializations/models/incremental/strategies.sql",
+          "unique_id": "macro.dbt.default__get_incremental_merge_sql",
+          "macro_sql": "{% macro default__get_incremental_merge_sql(arg_dict) %}\n\n  {% do return(get_merge_sql(arg_dict[\"target_relation\"], arg_dict[\"temp_relation\"], arg_dict[\"unique_key\"], arg_dict[\"dest_columns\"], arg_dict[\"incremental_predicates\"])) %}\n\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.get_merge_sql"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.0684211
+        },
+        "macro.dbt.get_incremental_insert_overwrite_sql": {
+          "name": "get_incremental_insert_overwrite_sql",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/materializations/models/incremental/strategies.sql",
+          "original_file_path": "macros/materializations/models/incremental/strategies.sql",
+          "unique_id": "macro.dbt.get_incremental_insert_overwrite_sql",
+          "macro_sql": "{% macro get_incremental_insert_overwrite_sql(arg_dict) %}\n\n  {{ return(adapter.dispatch('get_incremental_insert_overwrite_sql', 'dbt')(arg_dict)) }}\n\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.default__get_incremental_insert_overwrite_sql"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.068596
+        },
+        "macro.dbt.default__get_incremental_insert_overwrite_sql": {
+          "name": "default__get_incremental_insert_overwrite_sql",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/materializations/models/incremental/strategies.sql",
+          "original_file_path": "macros/materializations/models/incremental/strategies.sql",
+          "unique_id": "macro.dbt.default__get_incremental_insert_overwrite_sql",
+          "macro_sql": "{% macro default__get_incremental_insert_overwrite_sql(arg_dict) %}\n\n  {% do return(get_insert_overwrite_merge_sql(arg_dict[\"target_relation\"], arg_dict[\"temp_relation\"], arg_dict[\"dest_columns\"], arg_dict[\"incremental_predicates\"])) %}\n\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.get_insert_overwrite_merge_sql"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.068861
+        },
+        "macro.dbt.get_incremental_default_sql": {
+          "name": "get_incremental_default_sql",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/materializations/models/incremental/strategies.sql",
+          "original_file_path": "macros/materializations/models/incremental/strategies.sql",
+          "unique_id": "macro.dbt.get_incremental_default_sql",
+          "macro_sql": "{% macro get_incremental_default_sql(arg_dict) %}\n\n  {{ return(adapter.dispatch('get_incremental_default_sql', 'dbt')(arg_dict)) }}\n\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt_duckdb.duckdb__get_incremental_default_sql"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.069057
+        },
+        "macro.dbt.default__get_incremental_default_sql": {
+          "name": "default__get_incremental_default_sql",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/materializations/models/incremental/strategies.sql",
+          "original_file_path": "macros/materializations/models/incremental/strategies.sql",
+          "unique_id": "macro.dbt.default__get_incremental_default_sql",
+          "macro_sql": "{% macro default__get_incremental_default_sql(arg_dict) %}\n\n  {% do return(get_incremental_append_sql(arg_dict)) %}\n\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.get_incremental_append_sql"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.0692039
+        },
+        "macro.dbt.get_insert_into_sql": {
+          "name": "get_insert_into_sql",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/materializations/models/incremental/strategies.sql",
+          "original_file_path": "macros/materializations/models/incremental/strategies.sql",
+          "unique_id": "macro.dbt.get_insert_into_sql",
+          "macro_sql": "{% macro get_insert_into_sql(target_relation, temp_relation, dest_columns) %}\n\n    {%- set dest_cols_csv = get_quoted_csv(dest_columns | map(attribute=\"name\")) -%}\n\n    insert into {{ target_relation }} ({{ dest_cols_csv }})\n    (\n        select {{ dest_cols_csv }}\n        from {{ temp_relation }}\n    )\n\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.get_quoted_csv"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.069469
+        },
+        "macro.dbt.materialization_incremental_default": {
+          "name": "materialization_incremental_default",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/materializations/models/incremental/incremental.sql",
+          "original_file_path": "macros/materializations/models/incremental/incremental.sql",
+          "unique_id": "macro.dbt.materialization_incremental_default",
+          "macro_sql": "{% materialization incremental, default -%}\n\n  -- relations\n  {%- set existing_relation = load_cached_relation(this) -%}\n  {%- set target_relation = this.incorporate(type='table') -%}\n  {%- set temp_relation = make_temp_relation(target_relation)-%}\n  {%- set intermediate_relation = make_intermediate_relation(target_relation)-%}\n  {%- set backup_relation_type = 'table' if existing_relation is none else existing_relation.type -%}\n  {%- set backup_relation = make_backup_relation(target_relation, backup_relation_type) -%}\n\n  -- configs\n  {%- set unique_key = config.get('unique_key') -%}\n  {%- set full_refresh_mode = (should_full_refresh()  or existing_relation.is_view) -%}\n  {%- set on_schema_change = incremental_validate_on_schema_change(config.get('on_schema_change'), default='ignore') -%}\n\n  -- the temp_ and backup_ relations should not already exist in the database; get_relation\n  -- will return None in that case. Otherwise, we get a relation that we can drop\n  -- later, before we try to use this name for the current operation. This has to happen before\n  -- BEGIN, in a separate transaction\n  {%- set preexisting_intermediate_relation = load_cached_relation(intermediate_relation)-%}\n  {%- set preexisting_backup_relation = load_cached_relation(backup_relation) -%}\n   -- grab current tables grants config for comparision later on\n  {% set grant_config = config.get('grants') %}\n  {{ drop_relation_if_exists(preexisting_intermediate_relation) }}\n  {{ drop_relation_if_exists(preexisting_backup_relation) }}\n\n  {{ run_hooks(pre_hooks, inside_transaction=False) }}\n\n  -- `BEGIN` happens here:\n  {{ run_hooks(pre_hooks, inside_transaction=True) }}\n\n  {% set to_drop = [] %}\n\n  {% if existing_relation is none %}\n      {% set build_sql = get_create_table_as_sql(False, target_relation, sql) %}\n  {% elif full_refresh_mode %}\n      {% set build_sql = get_create_table_as_sql(False, intermediate_relation, sql) %}\n      {% set need_swap = true %}\n  {% else %}\n    {% do run_query(get_create_table_as_sql(True, temp_relation, sql)) %}\n    {% do adapter.expand_target_column_types(\n             from_relation=temp_relation,\n             to_relation=target_relation) %}\n    {#-- Process schema changes. Returns dict of changes if successful. Use source columns for upserting/merging --#}\n    {% set dest_columns = process_schema_changes(on_schema_change, temp_relation, existing_relation) %}\n    {% if not dest_columns %}\n      {% set dest_columns = adapter.get_columns_in_relation(existing_relation) %}\n    {% endif %}\n\n    {#-- Get the incremental_strategy, the macro to use for the strategy, and build the sql --#}\n    {% set incremental_strategy = config.get('incremental_strategy') or 'default' %}\n    {% set incremental_predicates = config.get('predicates', none) or config.get('incremental_predicates', none) %}\n    {% set strategy_sql_macro_func = adapter.get_incremental_strategy_macro(context, incremental_strategy) %}\n    {% set strategy_arg_dict = ({'target_relation': target_relation, 'temp_relation': temp_relation, 'unique_key': unique_key, 'dest_columns': dest_columns, 'incremental_predicates': incremental_predicates }) %}\n    {% set build_sql = strategy_sql_macro_func(strategy_arg_dict) %}\n\n  {% endif %}\n\n  {% call statement(\"main\") %}\n      {{ build_sql }}\n  {% endcall %}\n\n  {% if need_swap %}\n      {% do adapter.rename_relation(target_relation, backup_relation) %}\n      {% do adapter.rename_relation(intermediate_relation, target_relation) %}\n      {% do to_drop.append(backup_relation) %}\n  {% endif %}\n\n  {% set should_revoke = should_revoke(existing_relation, full_refresh_mode) %}\n  {% do apply_grants(target_relation, grant_config, should_revoke=should_revoke) %}\n\n  {% do persist_docs(target_relation, model) %}\n\n  {% if existing_relation is none or existing_relation.is_view or should_full_refresh() %}\n    {% do create_indexes(target_relation) %}\n  {% endif %}\n\n  {{ run_hooks(post_hooks, inside_transaction=True) }}\n\n  -- `COMMIT` happens here\n  {% do adapter.commit() %}\n\n  {% for rel in to_drop %}\n      {% do adapter.drop_relation(rel) %}\n  {% endfor %}\n\n  {{ run_hooks(post_hooks, inside_transaction=False) }}\n\n  {{ return({'relations': [target_relation]}) }}\n\n{%- endmaterialization %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.load_cached_relation",
+              "macro.dbt.make_temp_relation",
+              "macro.dbt.make_intermediate_relation",
+              "macro.dbt.make_backup_relation",
+              "macro.dbt.should_full_refresh",
+              "macro.dbt.incremental_validate_on_schema_change",
+              "macro.dbt.drop_relation_if_exists",
+              "macro.dbt.run_hooks",
+              "macro.dbt.get_create_table_as_sql",
+              "macro.dbt.run_query",
+              "macro.dbt.process_schema_changes",
+              "macro.dbt.statement",
+              "macro.dbt.should_revoke",
+              "macro.dbt.apply_grants",
+              "macro.dbt.persist_docs",
+              "macro.dbt.create_indexes"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.074357,
+          "supported_languages": [
+            "sql"
+          ]
+        },
+        "macro.dbt.incremental_validate_on_schema_change": {
+          "name": "incremental_validate_on_schema_change",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/materializations/models/incremental/on_schema_change.sql",
+          "original_file_path": "macros/materializations/models/incremental/on_schema_change.sql",
+          "unique_id": "macro.dbt.incremental_validate_on_schema_change",
+          "macro_sql": "{% macro incremental_validate_on_schema_change(on_schema_change, default='ignore') %}\n\n   {% if on_schema_change not in ['sync_all_columns', 'append_new_columns', 'fail', 'ignore'] %}\n\n     {% set log_message = 'Invalid value for on_schema_change (%s) specified. Setting default value of %s.' % (on_schema_change, default) %}\n     {% do log(log_message) %}\n\n     {{ return(default) }}\n\n   {% else %}\n\n     {{ return(on_schema_change) }}\n\n   {% endif %}\n\n{% endmacro %}",
+          "depends_on": {
+            "macros": []
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.0802088
+        },
+        "macro.dbt.check_for_schema_changes": {
+          "name": "check_for_schema_changes",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/materializations/models/incremental/on_schema_change.sql",
+          "original_file_path": "macros/materializations/models/incremental/on_schema_change.sql",
+          "unique_id": "macro.dbt.check_for_schema_changes",
+          "macro_sql": "{% macro check_for_schema_changes(source_relation, target_relation) %}\n\n  {% set schema_changed = False %}\n\n  {%- set source_columns = adapter.get_columns_in_relation(source_relation) -%}\n  {%- set target_columns = adapter.get_columns_in_relation(target_relation) -%}\n  {%- set source_not_in_target = diff_columns(source_columns, target_columns) -%}\n  {%- set target_not_in_source = diff_columns(target_columns, source_columns) -%}\n\n  {% set new_target_types = diff_column_data_types(source_columns, target_columns) %}\n\n  {% if source_not_in_target != [] %}\n    {% set schema_changed = True %}\n  {% elif target_not_in_source != [] or new_target_types != [] %}\n    {% set schema_changed = True %}\n  {% elif new_target_types != [] %}\n    {% set schema_changed = True %}\n  {% endif %}\n\n  {% set changes_dict = {\n    'schema_changed': schema_changed,\n    'source_not_in_target': source_not_in_target,\n    'target_not_in_source': target_not_in_source,\n    'source_columns': source_columns,\n    'target_columns': target_columns,\n    'new_target_types': new_target_types\n  } %}\n\n  {% set msg %}\n    In {{ target_relation }}:\n        Schema changed: {{ schema_changed }}\n        Source columns not in target: {{ source_not_in_target }}\n        Target columns not in source: {{ target_not_in_source }}\n        New column types: {{ new_target_types }}\n  {% endset %}\n\n  {% do log(msg) %}\n\n  {{ return(changes_dict) }}\n\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.diff_columns",
+              "macro.dbt.diff_column_data_types"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.081416
+        },
+        "macro.dbt.sync_column_schemas": {
+          "name": "sync_column_schemas",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/materializations/models/incremental/on_schema_change.sql",
+          "original_file_path": "macros/materializations/models/incremental/on_schema_change.sql",
+          "unique_id": "macro.dbt.sync_column_schemas",
+          "macro_sql": "{% macro sync_column_schemas(on_schema_change, target_relation, schema_changes_dict) %}\n\n  {%- set add_to_target_arr = schema_changes_dict['source_not_in_target'] -%}\n\n  {%- if on_schema_change == 'append_new_columns'-%}\n     {%- if add_to_target_arr | length > 0 -%}\n       {%- do alter_relation_add_remove_columns(target_relation, add_to_target_arr, none) -%}\n     {%- endif -%}\n\n  {% elif on_schema_change == 'sync_all_columns' %}\n     {%- set remove_from_target_arr = schema_changes_dict['target_not_in_source'] -%}\n     {%- set new_target_types = schema_changes_dict['new_target_types'] -%}\n\n     {% if add_to_target_arr | length > 0 or remove_from_target_arr | length > 0 %}\n       {%- do alter_relation_add_remove_columns(target_relation, add_to_target_arr, remove_from_target_arr) -%}\n     {% endif %}\n\n     {% if new_target_types != [] %}\n       {% for ntt in new_target_types %}\n         {% set column_name = ntt['column_name'] %}\n         {% set new_type = ntt['new_type'] %}\n         {% do alter_column_type(target_relation, column_name, new_type) %}\n       {% endfor %}\n     {% endif %}\n\n  {% endif %}\n\n  {% set schema_change_message %}\n    In {{ target_relation }}:\n        Schema change approach: {{ on_schema_change }}\n        Columns added: {{ add_to_target_arr }}\n        Columns removed: {{ remove_from_target_arr }}\n        Data types changed: {{ new_target_types }}\n  {% endset %}\n\n  {% do log(schema_change_message) %}\n\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.alter_relation_add_remove_columns",
+              "macro.dbt.alter_column_type"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.082561
+        },
+        "macro.dbt.process_schema_changes": {
+          "name": "process_schema_changes",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/materializations/models/incremental/on_schema_change.sql",
+          "original_file_path": "macros/materializations/models/incremental/on_schema_change.sql",
+          "unique_id": "macro.dbt.process_schema_changes",
+          "macro_sql": "{% macro process_schema_changes(on_schema_change, source_relation, target_relation) %}\n\n    {% if on_schema_change == 'ignore' %}\n\n     {{ return({}) }}\n\n    {% else %}\n\n      {% set schema_changes_dict = check_for_schema_changes(source_relation, target_relation) %}\n\n      {% if schema_changes_dict['schema_changed'] %}\n\n        {% if on_schema_change == 'fail' %}\n\n          {% set fail_msg %}\n              The source and target schemas on this incremental model are out of sync!\n              They can be reconciled in several ways:\n                - set the `on_schema_change` config to either append_new_columns or sync_all_columns, depending on your situation.\n                - Re-run the incremental model with `full_refresh: True` to update the target schema.\n                - update the schema manually and re-run the process.\n\n              Additional troubleshooting context:\n                 Source columns not in target: {{ schema_changes_dict['source_not_in_target'] }}\n                 Target columns not in source: {{ schema_changes_dict['target_not_in_source'] }}\n                 New column types: {{ schema_changes_dict['new_target_types'] }}\n          {% endset %}\n\n          {% do exceptions.raise_compiler_error(fail_msg) %}\n\n        {# -- unless we ignore, run the sync operation per the config #}\n        {% else %}\n\n          {% do sync_column_schemas(on_schema_change, target_relation, schema_changes_dict) %}\n\n        {% endif %}\n\n      {% endif %}\n\n      {{ return(schema_changes_dict['source_columns']) }}\n\n    {% endif %}\n\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.check_for_schema_changes",
+              "macro.dbt.sync_column_schemas"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.0833821
+        },
+        "macro.dbt.get_table_columns_and_constraints": {
+          "name": "get_table_columns_and_constraints",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/materializations/models/table/columns_spec_ddl.sql",
+          "original_file_path": "macros/materializations/models/table/columns_spec_ddl.sql",
+          "unique_id": "macro.dbt.get_table_columns_and_constraints",
+          "macro_sql": "{%- macro get_table_columns_and_constraints() -%}\n  {{ adapter.dispatch('get_table_columns_and_constraints', 'dbt')() }}\n{%- endmacro -%}\n\n",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.default__get_table_columns_and_constraints"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.084374
+        },
+        "macro.dbt.default__get_table_columns_and_constraints": {
+          "name": "default__get_table_columns_and_constraints",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/materializations/models/table/columns_spec_ddl.sql",
+          "original_file_path": "macros/materializations/models/table/columns_spec_ddl.sql",
+          "unique_id": "macro.dbt.default__get_table_columns_and_constraints",
+          "macro_sql": "{% macro default__get_table_columns_and_constraints() -%}\n  {{ return(table_columns_and_constraints()) }}\n{%- endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.table_columns_and_constraints"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.084491
+        },
+        "macro.dbt.table_columns_and_constraints": {
+          "name": "table_columns_and_constraints",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/materializations/models/table/columns_spec_ddl.sql",
+          "original_file_path": "macros/materializations/models/table/columns_spec_ddl.sql",
+          "unique_id": "macro.dbt.table_columns_and_constraints",
+          "macro_sql": "{% macro table_columns_and_constraints() %}\n  {# loop through user_provided_columns to create DDL with data types and constraints #}\n    {%- set raw_column_constraints = adapter.render_raw_columns_constraints(raw_columns=model['columns']) -%}\n    {%- set raw_model_constraints = adapter.render_raw_model_constraints(raw_constraints=model['constraints']) -%}\n    (\n    {% for c in raw_column_constraints -%}\n      {{ c }}{{ \",\" if not loop.last or raw_model_constraints }}\n    {% endfor %}\n    {% for c in raw_model_constraints -%}\n        {{ c }}{{ \",\" if not loop.last }}\n    {% endfor -%}\n    )\n{% endmacro %}",
+          "depends_on": {
+            "macros": []
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.085
+        },
+        "macro.dbt.get_assert_columns_equivalent": {
+          "name": "get_assert_columns_equivalent",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/materializations/models/table/columns_spec_ddl.sql",
+          "original_file_path": "macros/materializations/models/table/columns_spec_ddl.sql",
+          "unique_id": "macro.dbt.get_assert_columns_equivalent",
+          "macro_sql": "\n\n{%- macro get_assert_columns_equivalent(sql) -%}\n  {{ adapter.dispatch('get_assert_columns_equivalent', 'dbt')(sql) }}\n{%- endmacro -%}\n\n",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.default__get_assert_columns_equivalent"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.085166
+        },
+        "macro.dbt.default__get_assert_columns_equivalent": {
+          "name": "default__get_assert_columns_equivalent",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/materializations/models/table/columns_spec_ddl.sql",
+          "original_file_path": "macros/materializations/models/table/columns_spec_ddl.sql",
+          "unique_id": "macro.dbt.default__get_assert_columns_equivalent",
+          "macro_sql": "{% macro default__get_assert_columns_equivalent(sql) -%}\n  {{ return(assert_columns_equivalent(sql)) }}\n{%- endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.assert_columns_equivalent"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.085294
+        },
+        "macro.dbt.assert_columns_equivalent": {
+          "name": "assert_columns_equivalent",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/materializations/models/table/columns_spec_ddl.sql",
+          "original_file_path": "macros/materializations/models/table/columns_spec_ddl.sql",
+          "unique_id": "macro.dbt.assert_columns_equivalent",
+          "macro_sql": "{% macro assert_columns_equivalent(sql) %}\n  {#-- Obtain the column schema provided by sql file. #}\n  {%- set sql_file_provided_columns = get_column_schema_from_query(sql) -%}\n  {#--Obtain the column schema provided by the schema file by generating an 'empty schema' query from the model's columns. #}\n  {%- set schema_file_provided_columns = get_column_schema_from_query(get_empty_schema_sql(model['columns'])) -%}\n\n  {#-- create dictionaries with name and formatted data type and strings for exception #}\n  {%- set sql_columns = format_columns(sql_file_provided_columns) -%}\n  {%- set yaml_columns = format_columns(schema_file_provided_columns)  -%}\n\n  {%- if sql_columns|length != yaml_columns|length -%}\n    {%- do exceptions.raise_contract_error(yaml_columns, sql_columns) -%}\n  {%- endif -%}\n\n  {%- for sql_col in sql_columns -%}\n    {%- set yaml_col = [] -%}\n    {%- for this_col in yaml_columns -%}\n      {%- if this_col['name'] == sql_col['name'] -%}\n        {%- do yaml_col.append(this_col) -%}\n        {%- break -%}\n      {%- endif -%}\n    {%- endfor -%}\n    {%- if not yaml_col -%}\n      {#-- Column with name not found in yaml #}\n      {%- do exceptions.raise_contract_error(yaml_columns, sql_columns) -%}\n    {%- endif -%}\n    {%- if sql_col['formatted'] != yaml_col[0]['formatted'] -%}\n      {#-- Column data types don't match #}\n      {%- do exceptions.raise_contract_error(yaml_columns, sql_columns) -%}\n    {%- endif -%}\n  {%- endfor -%}\n\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.get_column_schema_from_query",
+              "macro.dbt.get_empty_schema_sql",
+              "macro.dbt.format_columns"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.0863411
+        },
+        "macro.dbt.format_columns": {
+          "name": "format_columns",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/materializations/models/table/columns_spec_ddl.sql",
+          "original_file_path": "macros/materializations/models/table/columns_spec_ddl.sql",
+          "unique_id": "macro.dbt.format_columns",
+          "macro_sql": "{% macro format_columns(columns) %}\n  {% set formatted_columns = [] %}\n  {% for column in columns %}\n    {%- set formatted_column = adapter.dispatch('format_column', 'dbt')(column) -%}\n    {%- do formatted_columns.append(formatted_column) -%}\n  {% endfor %}\n  {{ return(formatted_columns) }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.default__format_column"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.086726
+        },
+        "macro.dbt.default__format_column": {
+          "name": "default__format_column",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/materializations/models/table/columns_spec_ddl.sql",
+          "original_file_path": "macros/materializations/models/table/columns_spec_ddl.sql",
+          "unique_id": "macro.dbt.default__format_column",
+          "macro_sql": "{% macro default__format_column(column) -%}\n  {% set data_type = column.dtype %}\n  {% set formatted = column.column.lower() ~ \" \" ~ data_type %}\n  {{ return({'name': column.name, 'data_type': data_type, 'formatted': formatted}) }}\n{%- endmacro -%}",
+          "depends_on": {
+            "macros": []
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.087061
+        },
+        "macro.dbt.materialization_table_default": {
+          "name": "materialization_table_default",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/materializations/models/table/table.sql",
+          "original_file_path": "macros/materializations/models/table/table.sql",
+          "unique_id": "macro.dbt.materialization_table_default",
+          "macro_sql": "{% materialization table, default %}\n\n  {%- set existing_relation = load_cached_relation(this) -%}\n  {%- set target_relation = this.incorporate(type='table') %}\n  {%- set intermediate_relation =  make_intermediate_relation(target_relation) -%}\n  -- the intermediate_relation should not already exist in the database; get_relation\n  -- will return None in that case. Otherwise, we get a relation that we can drop\n  -- later, before we try to use this name for the current operation\n  {%- set preexisting_intermediate_relation = load_cached_relation(intermediate_relation) -%}\n  /*\n      See ../view/view.sql for more information about this relation.\n  */\n  {%- set backup_relation_type = 'table' if existing_relation is none else existing_relation.type -%}\n  {%- set backup_relation = make_backup_relation(target_relation, backup_relation_type) -%}\n  -- as above, the backup_relation should not already exist\n  {%- set preexisting_backup_relation = load_cached_relation(backup_relation) -%}\n  -- grab current tables grants config for comparision later on\n  {% set grant_config = config.get('grants') %}\n\n  -- drop the temp relations if they exist already in the database\n  {{ drop_relation_if_exists(preexisting_intermediate_relation) }}\n  {{ drop_relation_if_exists(preexisting_backup_relation) }}\n\n  {{ run_hooks(pre_hooks, inside_transaction=False) }}\n\n  -- `BEGIN` happens here:\n  {{ run_hooks(pre_hooks, inside_transaction=True) }}\n\n  -- build model\n  {% call statement('main') -%}\n    {{ get_create_table_as_sql(False, intermediate_relation, sql) }}\n  {%- endcall %}\n\n  -- cleanup\n  {% if existing_relation is not none %}\n      {{ adapter.rename_relation(existing_relation, backup_relation) }}\n  {% endif %}\n\n  {{ adapter.rename_relation(intermediate_relation, target_relation) }}\n\n  {% do create_indexes(target_relation) %}\n\n  {{ run_hooks(post_hooks, inside_transaction=True) }}\n\n  {% set should_revoke = should_revoke(existing_relation, full_refresh_mode=True) %}\n  {% do apply_grants(target_relation, grant_config, should_revoke=should_revoke) %}\n\n  {% do persist_docs(target_relation, model) %}\n\n  -- `COMMIT` happens here\n  {{ adapter.commit() }}\n\n  -- finally, drop the existing/backup relation after the commit\n  {{ drop_relation_if_exists(backup_relation) }}\n\n  {{ run_hooks(post_hooks, inside_transaction=False) }}\n\n  {{ return({'relations': [target_relation]}) }}\n{% endmaterialization %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.load_cached_relation",
+              "macro.dbt.make_intermediate_relation",
+              "macro.dbt.make_backup_relation",
+              "macro.dbt.drop_relation_if_exists",
+              "macro.dbt.run_hooks",
+              "macro.dbt.statement",
+              "macro.dbt.get_create_table_as_sql",
+              "macro.dbt.create_indexes",
+              "macro.dbt.should_revoke",
+              "macro.dbt.apply_grants",
+              "macro.dbt.persist_docs"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.089637,
+          "supported_languages": [
+            "sql"
+          ]
+        },
+        "macro.dbt.get_create_table_as_sql": {
+          "name": "get_create_table_as_sql",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/materializations/models/table/create_table_as.sql",
+          "original_file_path": "macros/materializations/models/table/create_table_as.sql",
+          "unique_id": "macro.dbt.get_create_table_as_sql",
+          "macro_sql": "{% macro get_create_table_as_sql(temporary, relation, sql) -%}\n  {{ adapter.dispatch('get_create_table_as_sql', 'dbt')(temporary, relation, sql) }}\n{%- endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.default__get_create_table_as_sql"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.0905101
+        },
+        "macro.dbt.default__get_create_table_as_sql": {
+          "name": "default__get_create_table_as_sql",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/materializations/models/table/create_table_as.sql",
+          "original_file_path": "macros/materializations/models/table/create_table_as.sql",
+          "unique_id": "macro.dbt.default__get_create_table_as_sql",
+          "macro_sql": "{% macro default__get_create_table_as_sql(temporary, relation, sql) -%}\n  {{ return(create_table_as(temporary, relation, sql)) }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.create_table_as"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.090688
+        },
+        "macro.dbt.create_table_as": {
+          "name": "create_table_as",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/materializations/models/table/create_table_as.sql",
+          "original_file_path": "macros/materializations/models/table/create_table_as.sql",
+          "unique_id": "macro.dbt.create_table_as",
+          "macro_sql": "{% macro create_table_as(temporary, relation, compiled_code, language='sql') -%}\n  {# backward compatibility for create_table_as that does not support language #}\n  {% if language == \"sql\" %}\n    {{ adapter.dispatch('create_table_as', 'dbt')(temporary, relation, compiled_code)}}\n  {% else %}\n    {{ adapter.dispatch('create_table_as', 'dbt')(temporary, relation, compiled_code, language) }}\n  {% endif %}\n\n{%- endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt_duckdb.duckdb__create_table_as"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.091104
+        },
+        "macro.dbt.default__create_table_as": {
+          "name": "default__create_table_as",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/materializations/models/table/create_table_as.sql",
+          "original_file_path": "macros/materializations/models/table/create_table_as.sql",
+          "unique_id": "macro.dbt.default__create_table_as",
+          "macro_sql": "{% macro default__create_table_as(temporary, relation, sql) -%}\n  {%- set sql_header = config.get('sql_header', none) -%}\n\n  {{ sql_header if sql_header is not none }}\n\n  create {% if temporary: -%}temporary{%- endif %} table\n    {{ relation.include(database=(not temporary), schema=(not temporary)) }}\n  {% set contract_config = config.get('contract') %}\n  {% if contract_config.enforced %}\n    {{ get_assert_columns_equivalent(sql) }}\n    {{ get_table_columns_and_constraints() }}\n    {%- set sql = get_select_subquery(sql) %}\n  {% endif %}\n  as (\n    {{ sql }}\n  );\n{%- endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.get_assert_columns_equivalent",
+              "macro.dbt.get_table_columns_and_constraints",
+              "macro.dbt.get_select_subquery"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.091739
+        },
+        "macro.dbt.get_select_subquery": {
+          "name": "get_select_subquery",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/materializations/models/table/create_table_as.sql",
+          "original_file_path": "macros/materializations/models/table/create_table_as.sql",
+          "unique_id": "macro.dbt.get_select_subquery",
+          "macro_sql": "{% macro get_select_subquery(sql) %}\n  {{ return(adapter.dispatch('get_select_subquery', 'dbt')(sql)) }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.default__get_select_subquery"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.09192
+        },
+        "macro.dbt.default__get_select_subquery": {
+          "name": "default__get_select_subquery",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/materializations/models/table/create_table_as.sql",
+          "original_file_path": "macros/materializations/models/table/create_table_as.sql",
+          "unique_id": "macro.dbt.default__get_select_subquery",
+          "macro_sql": "{% macro default__get_select_subquery(sql) %}\n    select\n    {% for column in model['columns'] %}\n      {{ column }}{{ \", \" if not loop.last }}\n    {% endfor %}\n    from (\n        {{ sql }}\n    ) as model_subq\n{%- endmacro %}",
+          "depends_on": {
+            "macros": []
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.09217
+        },
+        "macro.dbt.materialization_view_default": {
+          "name": "materialization_view_default",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/materializations/models/view/view.sql",
+          "original_file_path": "macros/materializations/models/view/view.sql",
+          "unique_id": "macro.dbt.materialization_view_default",
+          "macro_sql": "{%- materialization view, default -%}\n\n  {%- set existing_relation = load_cached_relation(this) -%}\n  {%- set target_relation = this.incorporate(type='view') -%}\n  {%- set intermediate_relation =  make_intermediate_relation(target_relation) -%}\n\n  -- the intermediate_relation should not already exist in the database; get_relation\n  -- will return None in that case. Otherwise, we get a relation that we can drop\n  -- later, before we try to use this name for the current operation\n  {%- set preexisting_intermediate_relation = load_cached_relation(intermediate_relation) -%}\n  /*\n     This relation (probably) doesn't exist yet. If it does exist, it's a leftover from\n     a previous run, and we're going to try to drop it immediately. At the end of this\n     materialization, we're going to rename the \"existing_relation\" to this identifier,\n     and then we're going to drop it. In order to make sure we run the correct one of:\n       - drop view ...\n       - drop table ...\n\n     We need to set the type of this relation to be the type of the existing_relation, if it exists,\n     or else \"view\" as a sane default if it does not. Note that if the existing_relation does not\n     exist, then there is nothing to move out of the way and subsequentally drop. In that case,\n     this relation will be effectively unused.\n  */\n  {%- set backup_relation_type = 'view' if existing_relation is none else existing_relation.type -%}\n  {%- set backup_relation = make_backup_relation(target_relation, backup_relation_type) -%}\n  -- as above, the backup_relation should not already exist\n  {%- set preexisting_backup_relation = load_cached_relation(backup_relation) -%}\n  -- grab current tables grants config for comparision later on\n  {% set grant_config = config.get('grants') %}\n\n  {{ run_hooks(pre_hooks, inside_transaction=False) }}\n\n  -- drop the temp relations if they exist already in the database\n  {{ drop_relation_if_exists(preexisting_intermediate_relation) }}\n  {{ drop_relation_if_exists(preexisting_backup_relation) }}\n\n  -- `BEGIN` happens here:\n  {{ run_hooks(pre_hooks, inside_transaction=True) }}\n\n  -- build model\n  {% call statement('main') -%}\n    {{ get_create_view_as_sql(intermediate_relation, sql) }}\n  {%- endcall %}\n\n  -- cleanup\n  -- move the existing view out of the way\n  {% if existing_relation is not none %}\n    {{ adapter.rename_relation(existing_relation, backup_relation) }}\n  {% endif %}\n  {{ adapter.rename_relation(intermediate_relation, target_relation) }}\n\n  {% set should_revoke = should_revoke(existing_relation, full_refresh_mode=True) %}\n  {% do apply_grants(target_relation, grant_config, should_revoke=should_revoke) %}\n\n  {% do persist_docs(target_relation, model) %}\n\n  {{ run_hooks(post_hooks, inside_transaction=True) }}\n\n  {{ adapter.commit() }}\n\n  {{ drop_relation_if_exists(backup_relation) }}\n\n  {{ run_hooks(post_hooks, inside_transaction=False) }}\n\n  {{ return({'relations': [target_relation]}) }}\n\n{%- endmaterialization -%}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.load_cached_relation",
+              "macro.dbt.make_intermediate_relation",
+              "macro.dbt.make_backup_relation",
+              "macro.dbt.run_hooks",
+              "macro.dbt.drop_relation_if_exists",
+              "macro.dbt.statement",
+              "macro.dbt.get_create_view_as_sql",
+              "macro.dbt.should_revoke",
+              "macro.dbt.apply_grants",
+              "macro.dbt.persist_docs"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.094712,
+          "supported_languages": [
+            "sql"
+          ]
+        },
+        "macro.dbt.handle_existing_table": {
+          "name": "handle_existing_table",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/materializations/models/view/helpers.sql",
+          "original_file_path": "macros/materializations/models/view/helpers.sql",
+          "unique_id": "macro.dbt.handle_existing_table",
+          "macro_sql": "{% macro handle_existing_table(full_refresh, old_relation) %}\n    {{ adapter.dispatch('handle_existing_table', 'dbt')(full_refresh, old_relation) }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.default__handle_existing_table"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.095003
+        },
+        "macro.dbt.default__handle_existing_table": {
+          "name": "default__handle_existing_table",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/materializations/models/view/helpers.sql",
+          "original_file_path": "macros/materializations/models/view/helpers.sql",
+          "unique_id": "macro.dbt.default__handle_existing_table",
+          "macro_sql": "{% macro default__handle_existing_table(full_refresh, old_relation) %}\n    {{ log(\"Dropping relation \" ~ old_relation ~ \" because it is of type \" ~ old_relation.type) }}\n    {{ adapter.drop_relation(old_relation) }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": []
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.095253
+        },
+        "macro.dbt.create_or_replace_view": {
+          "name": "create_or_replace_view",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/materializations/models/view/create_or_replace_view.sql",
+          "original_file_path": "macros/materializations/models/view/create_or_replace_view.sql",
+          "unique_id": "macro.dbt.create_or_replace_view",
+          "macro_sql": "{% macro create_or_replace_view() %}\n  {%- set identifier = model['alias'] -%}\n\n  {%- set old_relation = adapter.get_relation(database=database, schema=schema, identifier=identifier) -%}\n  {%- set exists_as_view = (old_relation is not none and old_relation.is_view) -%}\n\n  {%- set target_relation = api.Relation.create(\n      identifier=identifier, schema=schema, database=database,\n      type='view') -%}\n  {% set grant_config = config.get('grants') %}\n\n  {{ run_hooks(pre_hooks) }}\n\n  -- If there's a table with the same name and we weren't told to full refresh,\n  -- that's an error. If we were told to full refresh, drop it. This behavior differs\n  -- for Snowflake and BigQuery, so multiple dispatch is used.\n  {%- if old_relation is not none and old_relation.is_table -%}\n    {{ handle_existing_table(should_full_refresh(), old_relation) }}\n  {%- endif -%}\n\n  -- build model\n  {% call statement('main') -%}\n    {{ get_create_view_as_sql(target_relation, sql) }}\n  {%- endcall %}\n\n  {% set should_revoke = should_revoke(exists_as_view, full_refresh_mode=True) %}\n  {% do apply_grants(target_relation, grant_config, should_revoke=should_revoke) %}\n\n  {{ run_hooks(post_hooks) }}\n\n  {{ return({'relations': [target_relation]}) }}\n\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.run_hooks",
+              "macro.dbt.handle_existing_table",
+              "macro.dbt.should_full_refresh",
+              "macro.dbt.statement",
+              "macro.dbt.get_create_view_as_sql",
+              "macro.dbt.should_revoke",
+              "macro.dbt.apply_grants"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.096705
+        },
+        "macro.dbt.get_create_view_as_sql": {
+          "name": "get_create_view_as_sql",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/materializations/models/view/create_view_as.sql",
+          "original_file_path": "macros/materializations/models/view/create_view_as.sql",
+          "unique_id": "macro.dbt.get_create_view_as_sql",
+          "macro_sql": "{% macro get_create_view_as_sql(relation, sql) -%}\n  {{ adapter.dispatch('get_create_view_as_sql', 'dbt')(relation, sql) }}\n{%- endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.default__get_create_view_as_sql"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.09711
+        },
+        "macro.dbt.default__get_create_view_as_sql": {
+          "name": "default__get_create_view_as_sql",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/materializations/models/view/create_view_as.sql",
+          "original_file_path": "macros/materializations/models/view/create_view_as.sql",
+          "unique_id": "macro.dbt.default__get_create_view_as_sql",
+          "macro_sql": "{% macro default__get_create_view_as_sql(relation, sql) -%}\n  {{ return(create_view_as(relation, sql)) }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.create_view_as"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.097264
+        },
+        "macro.dbt.create_view_as": {
+          "name": "create_view_as",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/materializations/models/view/create_view_as.sql",
+          "original_file_path": "macros/materializations/models/view/create_view_as.sql",
+          "unique_id": "macro.dbt.create_view_as",
+          "macro_sql": "{% macro create_view_as(relation, sql) -%}\n  {{ adapter.dispatch('create_view_as', 'dbt')(relation, sql) }}\n{%- endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt_duckdb.duckdb__create_view_as"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.097434
+        },
+        "macro.dbt.default__create_view_as": {
+          "name": "default__create_view_as",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/materializations/models/view/create_view_as.sql",
+          "original_file_path": "macros/materializations/models/view/create_view_as.sql",
+          "unique_id": "macro.dbt.default__create_view_as",
+          "macro_sql": "{% macro default__create_view_as(relation, sql) -%}\n  {%- set sql_header = config.get('sql_header', none) -%}\n\n  {{ sql_header if sql_header is not none }}\n  create view {{ relation }}\n    {% set contract_config = config.get('contract') %}\n    {% if contract_config.enforced %}\n      {{ get_assert_columns_equivalent(sql) }}\n    {%- endif %}\n  as (\n    {{ sql }}\n  );\n{%- endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.get_assert_columns_equivalent"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.097839
+        },
+        "macro.dbt.materialization_seed_default": {
+          "name": "materialization_seed_default",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/materializations/seeds/seed.sql",
+          "original_file_path": "macros/materializations/seeds/seed.sql",
+          "unique_id": "macro.dbt.materialization_seed_default",
+          "macro_sql": "{% materialization seed, default %}\n\n  {%- set identifier = model['alias'] -%}\n  {%- set full_refresh_mode = (should_full_refresh()) -%}\n\n  {%- set old_relation = adapter.get_relation(database=database, schema=schema, identifier=identifier) -%}\n\n  {%- set exists_as_table = (old_relation is not none and old_relation.is_table) -%}\n  {%- set exists_as_view = (old_relation is not none and old_relation.is_view) -%}\n\n  {%- set grant_config = config.get('grants') -%}\n  {%- set agate_table = load_agate_table() -%}\n  -- grab current tables grants config for comparision later on\n\n  {%- do store_result('agate_table', response='OK', agate_table=agate_table) -%}\n\n  {{ run_hooks(pre_hooks, inside_transaction=False) }}\n\n  -- `BEGIN` happens here:\n  {{ run_hooks(pre_hooks, inside_transaction=True) }}\n\n  -- build model\n  {% set create_table_sql = \"\" %}\n  {% if exists_as_view %}\n    {{ exceptions.raise_compiler_error(\"Cannot seed to '{}', it is a view\".format(old_relation)) }}\n  {% elif exists_as_table %}\n    {% set create_table_sql = reset_csv_table(model, full_refresh_mode, old_relation, agate_table) %}\n  {% else %}\n    {% set create_table_sql = create_csv_table(model, agate_table) %}\n  {% endif %}\n\n  {% set code = 'CREATE' if full_refresh_mode else 'INSERT' %}\n  {% set rows_affected = (agate_table.rows | length) %}\n  {% set sql = load_csv_rows(model, agate_table) %}\n\n  {% call noop_statement('main', code ~ ' ' ~ rows_affected, code, rows_affected) %}\n    {{ get_csv_sql(create_table_sql, sql) }};\n  {% endcall %}\n\n  {% set target_relation = this.incorporate(type='table') %}\n\n  {% set should_revoke = should_revoke(old_relation, full_refresh_mode) %}\n  {% do apply_grants(target_relation, grant_config, should_revoke=should_revoke) %}\n\n  {% do persist_docs(target_relation, model) %}\n\n  {% if full_refresh_mode or not exists_as_table %}\n    {% do create_indexes(target_relation) %}\n  {% endif %}\n\n  {{ run_hooks(post_hooks, inside_transaction=True) }}\n\n  -- `COMMIT` happens here\n  {{ adapter.commit() }}\n\n  {{ run_hooks(post_hooks, inside_transaction=False) }}\n\n  {{ return({'relations': [target_relation]}) }}\n\n{% endmaterialization %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.should_full_refresh",
+              "macro.dbt.run_hooks",
+              "macro.dbt.reset_csv_table",
+              "macro.dbt.create_csv_table",
+              "macro.dbt.load_csv_rows",
+              "macro.dbt.noop_statement",
+              "macro.dbt.get_csv_sql",
+              "macro.dbt.should_revoke",
+              "macro.dbt.apply_grants",
+              "macro.dbt.persist_docs",
+              "macro.dbt.create_indexes"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.101092,
+          "supported_languages": [
+            "sql"
+          ]
+        },
+        "macro.dbt.create_csv_table": {
+          "name": "create_csv_table",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/materializations/seeds/helpers.sql",
+          "original_file_path": "macros/materializations/seeds/helpers.sql",
+          "unique_id": "macro.dbt.create_csv_table",
+          "macro_sql": "{% macro create_csv_table(model, agate_table) -%}\n  {{ adapter.dispatch('create_csv_table', 'dbt')(model, agate_table) }}\n{%- endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.default__create_csv_table"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.1063411
+        },
+        "macro.dbt.default__create_csv_table": {
+          "name": "default__create_csv_table",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/materializations/seeds/helpers.sql",
+          "original_file_path": "macros/materializations/seeds/helpers.sql",
+          "unique_id": "macro.dbt.default__create_csv_table",
+          "macro_sql": "{% macro default__create_csv_table(model, agate_table) %}\n  {%- set column_override = model['config'].get('column_types', {}) -%}\n  {%- set quote_seed_column = model['config'].get('quote_columns', None) -%}\n\n  {% set sql %}\n    create table {{ this.render() }} (\n        {%- for col_name in agate_table.column_names -%}\n            {%- set inferred_type = adapter.convert_type(agate_table, loop.index0) -%}\n            {%- set type = column_override.get(col_name, inferred_type) -%}\n            {%- set column_name = (col_name | string) -%}\n            {{ adapter.quote_seed_column(column_name, quote_seed_column) }} {{ type }} {%- if not loop.last -%}, {%- endif -%}\n        {%- endfor -%}\n    )\n  {% endset %}\n\n  {% call statement('_') -%}\n    {{ sql }}\n  {%- endcall %}\n\n  {{ return(sql) }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.statement"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.107233
+        },
+        "macro.dbt.reset_csv_table": {
+          "name": "reset_csv_table",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/materializations/seeds/helpers.sql",
+          "original_file_path": "macros/materializations/seeds/helpers.sql",
+          "unique_id": "macro.dbt.reset_csv_table",
+          "macro_sql": "{% macro reset_csv_table(model, full_refresh, old_relation, agate_table) -%}\n  {{ adapter.dispatch('reset_csv_table', 'dbt')(model, full_refresh, old_relation, agate_table) }}\n{%- endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.default__reset_csv_table"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.10746
+        },
+        "macro.dbt.default__reset_csv_table": {
+          "name": "default__reset_csv_table",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/materializations/seeds/helpers.sql",
+          "original_file_path": "macros/materializations/seeds/helpers.sql",
+          "unique_id": "macro.dbt.default__reset_csv_table",
+          "macro_sql": "{% macro default__reset_csv_table(model, full_refresh, old_relation, agate_table) %}\n    {% set sql = \"\" %}\n    {% if full_refresh %}\n        {{ adapter.drop_relation(old_relation) }}\n        {% set sql = create_csv_table(model, agate_table) %}\n    {% else %}\n        {{ adapter.truncate_relation(old_relation) }}\n        {% set sql = \"truncate table \" ~ old_relation %}\n    {% endif %}\n\n    {{ return(sql) }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.create_csv_table"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.107913
+        },
+        "macro.dbt.get_csv_sql": {
+          "name": "get_csv_sql",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/materializations/seeds/helpers.sql",
+          "original_file_path": "macros/materializations/seeds/helpers.sql",
+          "unique_id": "macro.dbt.get_csv_sql",
+          "macro_sql": "{% macro get_csv_sql(create_or_truncate_sql, insert_sql) %}\n    {{ adapter.dispatch('get_csv_sql', 'dbt')(create_or_truncate_sql, insert_sql) }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.default__get_csv_sql"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.108096
+        },
+        "macro.dbt.default__get_csv_sql": {
+          "name": "default__get_csv_sql",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/materializations/seeds/helpers.sql",
+          "original_file_path": "macros/materializations/seeds/helpers.sql",
+          "unique_id": "macro.dbt.default__get_csv_sql",
+          "macro_sql": "{% macro default__get_csv_sql(create_or_truncate_sql, insert_sql) %}\n    {{ create_or_truncate_sql }};\n    -- dbt seed --\n    {{ insert_sql }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": []
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.108226
+        },
+        "macro.dbt.get_binding_char": {
+          "name": "get_binding_char",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/materializations/seeds/helpers.sql",
+          "original_file_path": "macros/materializations/seeds/helpers.sql",
+          "unique_id": "macro.dbt.get_binding_char",
+          "macro_sql": "{% macro get_binding_char() -%}\n  {{ adapter.dispatch('get_binding_char', 'dbt')() }}\n{%- endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt_duckdb.duckdb__get_binding_char"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.108361
+        },
+        "macro.dbt.default__get_binding_char": {
+          "name": "default__get_binding_char",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/materializations/seeds/helpers.sql",
+          "original_file_path": "macros/materializations/seeds/helpers.sql",
+          "unique_id": "macro.dbt.default__get_binding_char",
+          "macro_sql": "{% macro default__get_binding_char() %}\n  {{ return('%s') }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": []
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.108472
+        },
+        "macro.dbt.get_batch_size": {
+          "name": "get_batch_size",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/materializations/seeds/helpers.sql",
+          "original_file_path": "macros/materializations/seeds/helpers.sql",
+          "unique_id": "macro.dbt.get_batch_size",
+          "macro_sql": "{% macro get_batch_size() -%}\n  {{ return(adapter.dispatch('get_batch_size', 'dbt')()) }}\n{%- endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt_duckdb.duckdb__get_batch_size"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.1086211
+        },
+        "macro.dbt.default__get_batch_size": {
+          "name": "default__get_batch_size",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/materializations/seeds/helpers.sql",
+          "original_file_path": "macros/materializations/seeds/helpers.sql",
+          "unique_id": "macro.dbt.default__get_batch_size",
+          "macro_sql": "{% macro default__get_batch_size() %}\n  {{ return(10000) }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": []
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.108733
+        },
+        "macro.dbt.get_seed_column_quoted_csv": {
+          "name": "get_seed_column_quoted_csv",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/materializations/seeds/helpers.sql",
+          "original_file_path": "macros/materializations/seeds/helpers.sql",
+          "unique_id": "macro.dbt.get_seed_column_quoted_csv",
+          "macro_sql": "{% macro get_seed_column_quoted_csv(model, column_names) %}\n  {%- set quote_seed_column = model['config'].get('quote_columns', None) -%}\n    {% set quoted = [] %}\n    {% for col in column_names -%}\n        {%- do quoted.append(adapter.quote_seed_column(col, quote_seed_column)) -%}\n    {%- endfor %}\n\n    {%- set dest_cols_csv = quoted | join(', ') -%}\n    {{ return(dest_cols_csv) }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": []
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.109186
+        },
+        "macro.dbt.load_csv_rows": {
+          "name": "load_csv_rows",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/materializations/seeds/helpers.sql",
+          "original_file_path": "macros/materializations/seeds/helpers.sql",
+          "unique_id": "macro.dbt.load_csv_rows",
+          "macro_sql": "{% macro load_csv_rows(model, agate_table) -%}\n  {{ adapter.dispatch('load_csv_rows', 'dbt')(model, agate_table) }}\n{%- endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt_duckdb.duckdb__load_csv_rows"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.109361
+        },
+        "macro.dbt.default__load_csv_rows": {
+          "name": "default__load_csv_rows",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/materializations/seeds/helpers.sql",
+          "original_file_path": "macros/materializations/seeds/helpers.sql",
+          "unique_id": "macro.dbt.default__load_csv_rows",
+          "macro_sql": "{% macro default__load_csv_rows(model, agate_table) %}\n\n  {% set batch_size = get_batch_size() %}\n\n  {% set cols_sql = get_seed_column_quoted_csv(model, agate_table.column_names) %}\n  {% set bindings = [] %}\n\n  {% set statements = [] %}\n\n  {% for chunk in agate_table.rows | batch(batch_size) %}\n      {% set bindings = [] %}\n\n      {% for row in chunk %}\n          {% do bindings.extend(row) %}\n      {% endfor %}\n\n      {% set sql %}\n          insert into {{ this.render() }} ({{ cols_sql }}) values\n          {% for row in chunk -%}\n              ({%- for column in agate_table.column_names -%}\n                  {{ get_binding_char() }}\n                  {%- if not loop.last%},{%- endif %}\n              {%- endfor -%})\n              {%- if not loop.last%},{%- endif %}\n          {%- endfor %}\n      {% endset %}\n\n      {% do adapter.add_query(sql, bindings=bindings, abridge_sql_log=True) %}\n\n      {% if loop.index0 == 0 %}\n          {% do statements.append(sql) %}\n      {% endif %}\n  {% endfor %}\n\n  {# Return SQL so we can render it out into the compiled files #}\n  {{ return(statements[0]) }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.get_batch_size",
+              "macro.dbt.get_seed_column_quoted_csv",
+              "macro.dbt.get_binding_char"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.1106381
+        },
+        "macro.dbt.generate_alias_name": {
+          "name": "generate_alias_name",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/get_custom_name/get_custom_alias.sql",
+          "original_file_path": "macros/get_custom_name/get_custom_alias.sql",
+          "unique_id": "macro.dbt.generate_alias_name",
+          "macro_sql": "{% macro generate_alias_name(custom_alias_name=none, node=none) -%}\n    {% do return(adapter.dispatch('generate_alias_name', 'dbt')(custom_alias_name, node)) %}\n{%- endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.default__generate_alias_name"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.1110551
+        },
+        "macro.dbt.default__generate_alias_name": {
+          "name": "default__generate_alias_name",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/get_custom_name/get_custom_alias.sql",
+          "original_file_path": "macros/get_custom_name/get_custom_alias.sql",
+          "unique_id": "macro.dbt.default__generate_alias_name",
+          "macro_sql": "{% macro default__generate_alias_name(custom_alias_name=none, node=none) -%}\n\n    {%- if custom_alias_name -%}\n\n        {{ custom_alias_name | trim }}\n\n    {%- elif node.version -%}\n\n        {{ return(node.name ~ \"_v\" ~ (node.version | replace(\".\", \"_\"))) }}\n\n    {%- else -%}\n\n        {{ node.name }}\n\n    {%- endif -%}\n\n{%- endmacro %}",
+          "depends_on": {
+            "macros": []
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.111413
+        },
+        "macro.dbt.generate_schema_name": {
+          "name": "generate_schema_name",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/get_custom_name/get_custom_schema.sql",
+          "original_file_path": "macros/get_custom_name/get_custom_schema.sql",
+          "unique_id": "macro.dbt.generate_schema_name",
+          "macro_sql": "{% macro generate_schema_name(custom_schema_name=none, node=none) -%}\n    {{ return(adapter.dispatch('generate_schema_name', 'dbt')(custom_schema_name, node)) }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.default__generate_schema_name"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.111918
+        },
+        "macro.dbt.default__generate_schema_name": {
+          "name": "default__generate_schema_name",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/get_custom_name/get_custom_schema.sql",
+          "original_file_path": "macros/get_custom_name/get_custom_schema.sql",
+          "unique_id": "macro.dbt.default__generate_schema_name",
+          "macro_sql": "{% macro default__generate_schema_name(custom_schema_name, node) -%}\n\n    {%- set default_schema = target.schema -%}\n    {%- if custom_schema_name is none -%}\n\n        {{ default_schema }}\n\n    {%- else -%}\n\n        {{ default_schema }}_{{ custom_schema_name | trim }}\n\n    {%- endif -%}\n\n{%- endmacro %}",
+          "depends_on": {
+            "macros": []
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.112166
+        },
+        "macro.dbt.generate_schema_name_for_env": {
+          "name": "generate_schema_name_for_env",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/get_custom_name/get_custom_schema.sql",
+          "original_file_path": "macros/get_custom_name/get_custom_schema.sql",
+          "unique_id": "macro.dbt.generate_schema_name_for_env",
+          "macro_sql": "{% macro generate_schema_name_for_env(custom_schema_name, node) -%}\n\n    {%- set default_schema = target.schema -%}\n    {%- if target.name == 'prod' and custom_schema_name is not none -%}\n\n        {{ custom_schema_name | trim }}\n\n    {%- else -%}\n\n        {{ default_schema }}\n\n    {%- endif -%}\n\n{%- endmacro %}",
+          "depends_on": {
+            "macros": []
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.1124392
+        },
+        "macro.dbt.generate_database_name": {
+          "name": "generate_database_name",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/get_custom_name/get_custom_database.sql",
+          "original_file_path": "macros/get_custom_name/get_custom_database.sql",
+          "unique_id": "macro.dbt.generate_database_name",
+          "macro_sql": "{% macro generate_database_name(custom_database_name=none, node=none) -%}\n    {% do return(adapter.dispatch('generate_database_name', 'dbt')(custom_database_name, node)) %}\n{%- endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.default__generate_database_name"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.1128519
+        },
+        "macro.dbt.default__generate_database_name": {
+          "name": "default__generate_database_name",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/get_custom_name/get_custom_database.sql",
+          "original_file_path": "macros/get_custom_name/get_custom_database.sql",
+          "unique_id": "macro.dbt.default__generate_database_name",
+          "macro_sql": "{% macro default__generate_database_name(custom_database_name=none, node=none) -%}\n    {%- set default_database = target.database -%}\n    {%- if custom_database_name is none -%}\n\n        {{ default_database }}\n\n    {%- else -%}\n\n        {{ custom_database_name }}\n\n    {%- endif -%}\n\n{%- endmacro %}",
+          "depends_on": {
+            "macros": []
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.11309
+        },
+        "macro.dbt.default__test_relationships": {
+          "name": "default__test_relationships",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/generic_test_sql/relationships.sql",
+          "original_file_path": "macros/generic_test_sql/relationships.sql",
+          "unique_id": "macro.dbt.default__test_relationships",
+          "macro_sql": "{% macro default__test_relationships(model, column_name, to, field) %}\n\nwith child as (\n    select {{ column_name }} as from_field\n    from {{ model }}\n    where {{ column_name }} is not null\n),\n\nparent as (\n    select {{ field }} as to_field\n    from {{ to }}\n)\n\nselect\n    from_field\n\nfrom child\nleft join parent\n    on child.from_field = parent.to_field\n\nwhere parent.to_field is null\n\n{% endmacro %}",
+          "depends_on": {
+            "macros": []
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.1134279
+        },
+        "macro.dbt.default__test_not_null": {
+          "name": "default__test_not_null",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/generic_test_sql/not_null.sql",
+          "original_file_path": "macros/generic_test_sql/not_null.sql",
+          "unique_id": "macro.dbt.default__test_not_null",
+          "macro_sql": "{% macro default__test_not_null(model, column_name) %}\n\n{% set column_list = '*' if should_store_failures() else column_name %}\n\nselect {{ column_list }}\nfrom {{ model }}\nwhere {{ column_name }} is null\n\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.should_store_failures"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.113709
+        },
+        "macro.dbt.default__test_unique": {
+          "name": "default__test_unique",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/generic_test_sql/unique.sql",
+          "original_file_path": "macros/generic_test_sql/unique.sql",
+          "unique_id": "macro.dbt.default__test_unique",
+          "macro_sql": "{% macro default__test_unique(model, column_name) %}\n\nselect\n    {{ column_name }} as unique_field,\n    count(*) as n_records\n\nfrom {{ model }}\nwhere {{ column_name }} is not null\ngroup by {{ column_name }}\nhaving count(*) > 1\n\n{% endmacro %}",
+          "depends_on": {
+            "macros": []
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.113944
+        },
+        "macro.dbt.default__test_accepted_values": {
+          "name": "default__test_accepted_values",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/generic_test_sql/accepted_values.sql",
+          "original_file_path": "macros/generic_test_sql/accepted_values.sql",
+          "unique_id": "macro.dbt.default__test_accepted_values",
+          "macro_sql": "{% macro default__test_accepted_values(model, column_name, values, quote=True) %}\n\nwith all_values as (\n\n    select\n        {{ column_name }} as value_field,\n        count(*) as n_records\n\n    from {{ model }}\n    group by {{ column_name }}\n\n)\n\nselect *\nfrom all_values\nwhere value_field not in (\n    {% for value in values -%}\n        {% if quote -%}\n        '{{ value }}'\n        {%- else -%}\n        {{ value }}\n        {%- endif -%}\n        {%- if not loop.last -%},{%- endif %}\n    {%- endfor %}\n)\n\n{% endmacro %}",
+          "depends_on": {
+            "macros": []
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.114495
+        },
+        "macro.dbt.statement": {
+          "name": "statement",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/etc/statement.sql",
+          "original_file_path": "macros/etc/statement.sql",
+          "unique_id": "macro.dbt.statement",
+          "macro_sql": "\n{%- macro statement(name=None, fetch_result=False, auto_begin=True, language='sql') -%}\n  {%- if execute: -%}\n    {%- set compiled_code = caller() -%}\n\n    {%- if name == 'main' -%}\n      {{ log('Writing runtime {} for node \"{}\"'.format(language, model['unique_id'])) }}\n      {{ write(compiled_code) }}\n    {%- endif -%}\n    {%- if language == 'sql'-%}\n      {%- set res, table = adapter.execute(compiled_code, auto_begin=auto_begin, fetch=fetch_result) -%}\n    {%- elif language == 'python' -%}\n      {%- set res = submit_python_job(model, compiled_code) -%}\n      {#-- TODO: What should table be for python models? --#}\n      {%- set table = None -%}\n    {%- else -%}\n      {% do exceptions.raise_compiler_error(\"statement macro didn't get supported language\") %}\n    {%- endif -%}\n\n    {%- if name is not none -%}\n      {{ store_result(name, response=res, agate_table=table) }}\n    {%- endif -%}\n\n  {%- endif -%}\n{%- endmacro %}",
+          "depends_on": {
+            "macros": []
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.115948
+        },
+        "macro.dbt.noop_statement": {
+          "name": "noop_statement",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/etc/statement.sql",
+          "original_file_path": "macros/etc/statement.sql",
+          "unique_id": "macro.dbt.noop_statement",
+          "macro_sql": "{% macro noop_statement(name=None, message=None, code=None, rows_affected=None, res=None) -%}\n  {%- set sql = caller() -%}\n\n  {%- if name == 'main' -%}\n    {{ log('Writing runtime SQL for node \"{}\"'.format(model['unique_id'])) }}\n    {{ write(sql) }}\n  {%- endif -%}\n\n  {%- if name is not none -%}\n    {{ store_raw_result(name, message=message, code=code, rows_affected=rows_affected, agate_table=res) }}\n  {%- endif -%}\n\n{%- endmacro %}",
+          "depends_on": {
+            "macros": []
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.116566
+        },
+        "macro.dbt.run_query": {
+          "name": "run_query",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/etc/statement.sql",
+          "original_file_path": "macros/etc/statement.sql",
+          "unique_id": "macro.dbt.run_query",
+          "macro_sql": "{% macro run_query(sql) %}\n  {% call statement(\"run_query_statement\", fetch_result=true, auto_begin=false) %}\n    {{ sql }}\n  {% endcall %}\n\n  {% do return(load_result(\"run_query_statement\").table) %}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.statement"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.116847
+        },
+        "macro.dbt.convert_datetime": {
+          "name": "convert_datetime",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/etc/datetime.sql",
+          "original_file_path": "macros/etc/datetime.sql",
+          "unique_id": "macro.dbt.convert_datetime",
+          "macro_sql": "{% macro convert_datetime(date_str, date_fmt) %}\n\n  {% set error_msg -%}\n      The provided partition date '{{ date_str }}' does not match the expected format '{{ date_fmt }}'\n  {%- endset %}\n\n  {% set res = try_or_compiler_error(error_msg, modules.datetime.datetime.strptime, date_str.strip(), date_fmt) %}\n  {{ return(res) }}\n\n{% endmacro %}",
+          "depends_on": {
+            "macros": []
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.1187131
+        },
+        "macro.dbt.dates_in_range": {
+          "name": "dates_in_range",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/etc/datetime.sql",
+          "original_file_path": "macros/etc/datetime.sql",
+          "unique_id": "macro.dbt.dates_in_range",
+          "macro_sql": "{% macro dates_in_range(start_date_str, end_date_str=none, in_fmt=\"%Y%m%d\", out_fmt=\"%Y%m%d\") %}\n    {% set end_date_str = start_date_str if end_date_str is none else end_date_str %}\n\n    {% set start_date = convert_datetime(start_date_str, in_fmt) %}\n    {% set end_date = convert_datetime(end_date_str, in_fmt) %}\n\n    {% set day_count = (end_date - start_date).days %}\n    {% if day_count < 0 %}\n        {% set msg -%}\n            Partiton start date is after the end date ({{ start_date }}, {{ end_date }})\n        {%- endset %}\n\n        {{ exceptions.raise_compiler_error(msg, model) }}\n    {% endif %}\n\n    {% set date_list = [] %}\n    {% for i in range(0, day_count + 1) %}\n        {% set the_date = (modules.datetime.timedelta(days=i) + start_date) %}\n        {% if not out_fmt %}\n            {% set _ = date_list.append(the_date) %}\n        {% else %}\n            {% set _ = date_list.append(the_date.strftime(out_fmt)) %}\n        {% endif %}\n    {% endfor %}\n\n    {{ return(date_list) }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.convert_datetime"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.119842
+        },
+        "macro.dbt.partition_range": {
+          "name": "partition_range",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/etc/datetime.sql",
+          "original_file_path": "macros/etc/datetime.sql",
+          "unique_id": "macro.dbt.partition_range",
+          "macro_sql": "{% macro partition_range(raw_partition_date, date_fmt='%Y%m%d') %}\n    {% set partition_range = (raw_partition_date | string).split(\",\") %}\n\n    {% if (partition_range | length) == 1 %}\n      {% set start_date = partition_range[0] %}\n      {% set end_date = none %}\n    {% elif (partition_range | length) == 2 %}\n      {% set start_date = partition_range[0] %}\n      {% set end_date = partition_range[1] %}\n    {% else %}\n      {{ exceptions.raise_compiler_error(\"Invalid partition time. Expected format: {Start Date}[,{End Date}]. Got: \" ~ raw_partition_date) }}\n    {% endif %}\n\n    {{ return(dates_in_range(start_date, end_date, in_fmt=date_fmt)) }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.dates_in_range"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.120557
+        },
+        "macro.dbt.py_current_timestring": {
+          "name": "py_current_timestring",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/etc/datetime.sql",
+          "original_file_path": "macros/etc/datetime.sql",
+          "unique_id": "macro.dbt.py_current_timestring",
+          "macro_sql": "{% macro py_current_timestring() %}\n    {% set dt = modules.datetime.datetime.now() %}\n    {% do return(dt.strftime(\"%Y%m%d%H%M%S%f\")) %}\n{% endmacro %}",
+          "depends_on": {
+            "macros": []
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.120778
+        },
+        "macro.dbt.except": {
+          "name": "except",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/utils/except.sql",
+          "original_file_path": "macros/utils/except.sql",
+          "unique_id": "macro.dbt.except",
+          "macro_sql": "{% macro except() %}\n  {{ return(adapter.dispatch('except', 'dbt')()) }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.default__except"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.1209931
+        },
+        "macro.dbt.default__except": {
+          "name": "default__except",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/utils/except.sql",
+          "original_file_path": "macros/utils/except.sql",
+          "unique_id": "macro.dbt.default__except",
+          "macro_sql": "{% macro default__except() %}\n\n    except\n\n{% endmacro %}",
+          "depends_on": {
+            "macros": []
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.121067
+        },
+        "macro.dbt.replace": {
+          "name": "replace",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/utils/replace.sql",
+          "original_file_path": "macros/utils/replace.sql",
+          "unique_id": "macro.dbt.replace",
+          "macro_sql": "{% macro replace(field, old_chars, new_chars) -%}\n    {{ return(adapter.dispatch('replace', 'dbt') (field, old_chars, new_chars)) }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.default__replace"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.1214
+        },
+        "macro.dbt.default__replace": {
+          "name": "default__replace",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/utils/replace.sql",
+          "original_file_path": "macros/utils/replace.sql",
+          "unique_id": "macro.dbt.default__replace",
+          "macro_sql": "{% macro default__replace(field, old_chars, new_chars) %}\n\n    replace(\n        {{ field }},\n        {{ old_chars }},\n        {{ new_chars }}\n    )\n\n\n{% endmacro %}",
+          "depends_on": {
+            "macros": []
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.1215591
+        },
+        "macro.dbt.concat": {
+          "name": "concat",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/utils/concat.sql",
+          "original_file_path": "macros/utils/concat.sql",
+          "unique_id": "macro.dbt.concat",
+          "macro_sql": "{% macro concat(fields) -%}\n  {{ return(adapter.dispatch('concat', 'dbt')(fields)) }}\n{%- endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.default__concat"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.121791
+        },
+        "macro.dbt.default__concat": {
+          "name": "default__concat",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/utils/concat.sql",
+          "original_file_path": "macros/utils/concat.sql",
+          "unique_id": "macro.dbt.default__concat",
+          "macro_sql": "{% macro default__concat(fields) -%}\n    {{ fields|join(' || ') }}\n{%- endmacro %}",
+          "depends_on": {
+            "macros": []
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.121908
+        },
+        "macro.dbt.length": {
+          "name": "length",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/utils/length.sql",
+          "original_file_path": "macros/utils/length.sql",
+          "unique_id": "macro.dbt.length",
+          "macro_sql": "{% macro length(expression) -%}\n    {{ return(adapter.dispatch('length', 'dbt') (expression)) }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.default__length"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.12215
+        },
+        "macro.dbt.default__length": {
+          "name": "default__length",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/utils/length.sql",
+          "original_file_path": "macros/utils/length.sql",
+          "unique_id": "macro.dbt.default__length",
+          "macro_sql": "{% macro default__length(expression) %}\n\n    length(\n        {{ expression }}\n    )\n\n{%- endmacro -%}",
+          "depends_on": {
+            "macros": []
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.122251
+        },
+        "macro.dbt.dateadd": {
+          "name": "dateadd",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/utils/dateadd.sql",
+          "original_file_path": "macros/utils/dateadd.sql",
+          "unique_id": "macro.dbt.dateadd",
+          "macro_sql": "{% macro dateadd(datepart, interval, from_date_or_timestamp) %}\n  {{ return(adapter.dispatch('dateadd', 'dbt')(datepart, interval, from_date_or_timestamp)) }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt_duckdb.duckdb__dateadd"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.122577
+        },
+        "macro.dbt.default__dateadd": {
+          "name": "default__dateadd",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/utils/dateadd.sql",
+          "original_file_path": "macros/utils/dateadd.sql",
+          "unique_id": "macro.dbt.default__dateadd",
+          "macro_sql": "{% macro default__dateadd(datepart, interval, from_date_or_timestamp) %}\n\n    dateadd(\n        {{ datepart }},\n        {{ interval }},\n        {{ from_date_or_timestamp }}\n        )\n\n{% endmacro %}",
+          "depends_on": {
+            "macros": []
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.122734
+        },
+        "macro.dbt.intersect": {
+          "name": "intersect",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/utils/intersect.sql",
+          "original_file_path": "macros/utils/intersect.sql",
+          "unique_id": "macro.dbt.intersect",
+          "macro_sql": "{% macro intersect() %}\n  {{ return(adapter.dispatch('intersect', 'dbt')()) }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.default__intersect"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.122946
+        },
+        "macro.dbt.default__intersect": {
+          "name": "default__intersect",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/utils/intersect.sql",
+          "original_file_path": "macros/utils/intersect.sql",
+          "unique_id": "macro.dbt.default__intersect",
+          "macro_sql": "{% macro default__intersect() %}\n\n    intersect\n\n{% endmacro %}",
+          "depends_on": {
+            "macros": []
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.123017
+        },
+        "macro.dbt.escape_single_quotes": {
+          "name": "escape_single_quotes",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/utils/escape_single_quotes.sql",
+          "original_file_path": "macros/utils/escape_single_quotes.sql",
+          "unique_id": "macro.dbt.escape_single_quotes",
+          "macro_sql": "{% macro escape_single_quotes(expression) %}\n      {{ return(adapter.dispatch('escape_single_quotes', 'dbt') (expression)) }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.default__escape_single_quotes"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.123265
+        },
+        "macro.dbt.default__escape_single_quotes": {
+          "name": "default__escape_single_quotes",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/utils/escape_single_quotes.sql",
+          "original_file_path": "macros/utils/escape_single_quotes.sql",
+          "unique_id": "macro.dbt.default__escape_single_quotes",
+          "macro_sql": "{% macro default__escape_single_quotes(expression) -%}\n{{ expression | replace(\"'\",\"''\") }}\n{%- endmacro %}",
+          "depends_on": {
+            "macros": []
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.123399
+        },
+        "macro.dbt.right": {
+          "name": "right",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/utils/right.sql",
+          "original_file_path": "macros/utils/right.sql",
+          "unique_id": "macro.dbt.right",
+          "macro_sql": "{% macro right(string_text, length_expression) -%}\n    {{ return(adapter.dispatch('right', 'dbt') (string_text, length_expression)) }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.default__right"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.123677
+        },
+        "macro.dbt.default__right": {
+          "name": "default__right",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/utils/right.sql",
+          "original_file_path": "macros/utils/right.sql",
+          "unique_id": "macro.dbt.default__right",
+          "macro_sql": "{% macro default__right(string_text, length_expression) %}\n\n    right(\n        {{ string_text }},\n        {{ length_expression }}\n    )\n\n{%- endmacro -%}",
+          "depends_on": {
+            "macros": []
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.1238668
+        },
+        "macro.dbt.listagg": {
+          "name": "listagg",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/utils/listagg.sql",
+          "original_file_path": "macros/utils/listagg.sql",
+          "unique_id": "macro.dbt.listagg",
+          "macro_sql": "{% macro listagg(measure, delimiter_text=\"','\", order_by_clause=none, limit_num=none) -%}\n    {{ return(adapter.dispatch('listagg', 'dbt') (measure, delimiter_text, order_by_clause, limit_num)) }}\n{%- endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt_duckdb.duckdb__listagg"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.124515
+        },
+        "macro.dbt.default__listagg": {
+          "name": "default__listagg",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/utils/listagg.sql",
+          "original_file_path": "macros/utils/listagg.sql",
+          "unique_id": "macro.dbt.default__listagg",
+          "macro_sql": "{% macro default__listagg(measure, delimiter_text, order_by_clause, limit_num) -%}\n\n    {% if limit_num -%}\n    array_to_string(\n        array_slice(\n            array_agg(\n                {{ measure }}\n            ){% if order_by_clause -%}\n            within group ({{ order_by_clause }})\n            {%- endif %}\n            ,0\n            ,{{ limit_num }}\n        ),\n        {{ delimiter_text }}\n        )\n    {%- else %}\n    listagg(\n        {{ measure }},\n        {{ delimiter_text }}\n        )\n        {% if order_by_clause -%}\n        within group ({{ order_by_clause }})\n        {%- endif %}\n    {%- endif %}\n\n{%- endmacro %}",
+          "depends_on": {
+            "macros": []
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.1248991
+        },
+        "macro.dbt.datediff": {
+          "name": "datediff",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/utils/datediff.sql",
+          "original_file_path": "macros/utils/datediff.sql",
+          "unique_id": "macro.dbt.datediff",
+          "macro_sql": "{% macro datediff(first_date, second_date, datepart) %}\n  {{ return(adapter.dispatch('datediff', 'dbt')(first_date, second_date, datepart)) }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt_duckdb.duckdb__datediff"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.125219
+        },
+        "macro.dbt.default__datediff": {
+          "name": "default__datediff",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/utils/datediff.sql",
+          "original_file_path": "macros/utils/datediff.sql",
+          "unique_id": "macro.dbt.default__datediff",
+          "macro_sql": "{% macro default__datediff(first_date, second_date, datepart) -%}\n\n    datediff(\n        {{ datepart }},\n        {{ first_date }},\n        {{ second_date }}\n        )\n\n{%- endmacro %}",
+          "depends_on": {
+            "macros": []
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.125375
+        },
+        "macro.dbt.safe_cast": {
+          "name": "safe_cast",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/utils/safe_cast.sql",
+          "original_file_path": "macros/utils/safe_cast.sql",
+          "unique_id": "macro.dbt.safe_cast",
+          "macro_sql": "{% macro safe_cast(field, type) %}\n  {{ return(adapter.dispatch('safe_cast', 'dbt') (field, type)) }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.default__safe_cast"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.125644
+        },
+        "macro.dbt.default__safe_cast": {
+          "name": "default__safe_cast",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/utils/safe_cast.sql",
+          "original_file_path": "macros/utils/safe_cast.sql",
+          "unique_id": "macro.dbt.default__safe_cast",
+          "macro_sql": "{% macro default__safe_cast(field, type) %}\n    {# most databases don't support this function yet\n    so we just need to use cast #}\n    cast({{field}} as {{type}})\n{% endmacro %}",
+          "depends_on": {
+            "macros": []
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.125778
+        },
+        "macro.dbt.hash": {
+          "name": "hash",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/utils/hash.sql",
+          "original_file_path": "macros/utils/hash.sql",
+          "unique_id": "macro.dbt.hash",
+          "macro_sql": "{% macro hash(field) -%}\n  {{ return(adapter.dispatch('hash', 'dbt') (field)) }}\n{%- endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.default__hash"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.1260202
+        },
+        "macro.dbt.default__hash": {
+          "name": "default__hash",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/utils/hash.sql",
+          "original_file_path": "macros/utils/hash.sql",
+          "unique_id": "macro.dbt.default__hash",
+          "macro_sql": "{% macro default__hash(field) -%}\n    md5(cast({{ field }} as {{ api.Column.translate_type('string') }}))\n{%- endmacro %}",
+          "depends_on": {
+            "macros": []
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.126179
+        },
+        "macro.dbt.cast_bool_to_text": {
+          "name": "cast_bool_to_text",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/utils/cast_bool_to_text.sql",
+          "original_file_path": "macros/utils/cast_bool_to_text.sql",
+          "unique_id": "macro.dbt.cast_bool_to_text",
+          "macro_sql": "{% macro cast_bool_to_text(field) %}\n  {{ adapter.dispatch('cast_bool_to_text', 'dbt') (field) }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.default__cast_bool_to_text"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.126409
+        },
+        "macro.dbt.default__cast_bool_to_text": {
+          "name": "default__cast_bool_to_text",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/utils/cast_bool_to_text.sql",
+          "original_file_path": "macros/utils/cast_bool_to_text.sql",
+          "unique_id": "macro.dbt.default__cast_bool_to_text",
+          "macro_sql": "{% macro default__cast_bool_to_text(field) %}\n    cast({{ field }} as {{ api.Column.translate_type('string') }})\n{% endmacro %}",
+          "depends_on": {
+            "macros": []
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.126562
+        },
+        "macro.dbt.any_value": {
+          "name": "any_value",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/utils/any_value.sql",
+          "original_file_path": "macros/utils/any_value.sql",
+          "unique_id": "macro.dbt.any_value",
+          "macro_sql": "{% macro any_value(expression) -%}\n    {{ return(adapter.dispatch('any_value', 'dbt') (expression)) }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt_duckdb.duckdb__any_value"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.126794
+        },
+        "macro.dbt.default__any_value": {
+          "name": "default__any_value",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/utils/any_value.sql",
+          "original_file_path": "macros/utils/any_value.sql",
+          "unique_id": "macro.dbt.default__any_value",
+          "macro_sql": "{% macro default__any_value(expression) -%}\n\n    any_value({{ expression }})\n\n{%- endmacro %}",
+          "depends_on": {
+            "macros": []
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.1268978
+        },
+        "macro.dbt.position": {
+          "name": "position",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/utils/position.sql",
+          "original_file_path": "macros/utils/position.sql",
+          "unique_id": "macro.dbt.position",
+          "macro_sql": "{% macro position(substring_text, string_text) -%}\n    {{ return(adapter.dispatch('position', 'dbt') (substring_text, string_text)) }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.default__position"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.127199
+        },
+        "macro.dbt.default__position": {
+          "name": "default__position",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/utils/position.sql",
+          "original_file_path": "macros/utils/position.sql",
+          "unique_id": "macro.dbt.default__position",
+          "macro_sql": "{% macro default__position(substring_text, string_text) %}\n\n    position(\n        {{ substring_text }} in {{ string_text }}\n    )\n\n{%- endmacro -%}",
+          "depends_on": {
+            "macros": []
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.127329
+        },
+        "macro.dbt.string_literal": {
+          "name": "string_literal",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/utils/literal.sql",
+          "original_file_path": "macros/utils/literal.sql",
+          "unique_id": "macro.dbt.string_literal",
+          "macro_sql": "{%- macro string_literal(value) -%}\n  {{ return(adapter.dispatch('string_literal', 'dbt') (value)) }}\n{%- endmacro -%}\n\n",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.default__string_literal"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.127563
+        },
+        "macro.dbt.default__string_literal": {
+          "name": "default__string_literal",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/utils/literal.sql",
+          "original_file_path": "macros/utils/literal.sql",
+          "unique_id": "macro.dbt.default__string_literal",
+          "macro_sql": "{% macro default__string_literal(value) -%}\n    '{{ value }}'\n{%- endmacro %}",
+          "depends_on": {
+            "macros": []
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.1276648
+        },
+        "macro.dbt.type_string": {
+          "name": "type_string",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/utils/data_types.sql",
+          "original_file_path": "macros/utils/data_types.sql",
+          "unique_id": "macro.dbt.type_string",
+          "macro_sql": "\n\n{%- macro type_string() -%}\n  {{ return(adapter.dispatch('type_string', 'dbt')()) }}\n{%- endmacro -%}\n\n",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.default__type_string"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.1285608
+        },
+        "macro.dbt.default__type_string": {
+          "name": "default__type_string",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/utils/data_types.sql",
+          "original_file_path": "macros/utils/data_types.sql",
+          "unique_id": "macro.dbt.default__type_string",
+          "macro_sql": "{% macro default__type_string() %}\n    {{ return(api.Column.translate_type(\"string\")) }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": []
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.128706
+        },
+        "macro.dbt.type_timestamp": {
+          "name": "type_timestamp",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/utils/data_types.sql",
+          "original_file_path": "macros/utils/data_types.sql",
+          "unique_id": "macro.dbt.type_timestamp",
+          "macro_sql": "\n\n{%- macro type_timestamp() -%}\n  {{ return(adapter.dispatch('type_timestamp', 'dbt')()) }}\n{%- endmacro -%}\n\n",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.default__type_timestamp"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.128924
+        },
+        "macro.dbt.default__type_timestamp": {
+          "name": "default__type_timestamp",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/utils/data_types.sql",
+          "original_file_path": "macros/utils/data_types.sql",
+          "unique_id": "macro.dbt.default__type_timestamp",
+          "macro_sql": "{% macro default__type_timestamp() %}\n    {{ return(api.Column.translate_type(\"timestamp\")) }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": []
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.129069
+        },
+        "macro.dbt.type_float": {
+          "name": "type_float",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/utils/data_types.sql",
+          "original_file_path": "macros/utils/data_types.sql",
+          "unique_id": "macro.dbt.type_float",
+          "macro_sql": "\n\n{%- macro type_float() -%}\n  {{ return(adapter.dispatch('type_float', 'dbt')()) }}\n{%- endmacro -%}\n\n",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.default__type_float"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.1292238
+        },
+        "macro.dbt.default__type_float": {
+          "name": "default__type_float",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/utils/data_types.sql",
+          "original_file_path": "macros/utils/data_types.sql",
+          "unique_id": "macro.dbt.default__type_float",
+          "macro_sql": "{% macro default__type_float() %}\n    {{ return(api.Column.translate_type(\"float\")) }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": []
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.129365
+        },
+        "macro.dbt.type_numeric": {
+          "name": "type_numeric",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/utils/data_types.sql",
+          "original_file_path": "macros/utils/data_types.sql",
+          "unique_id": "macro.dbt.type_numeric",
+          "macro_sql": "\n\n{%- macro type_numeric() -%}\n  {{ return(adapter.dispatch('type_numeric', 'dbt')()) }}\n{%- endmacro -%}\n\n",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.default__type_numeric"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.1295161
+        },
+        "macro.dbt.default__type_numeric": {
+          "name": "default__type_numeric",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/utils/data_types.sql",
+          "original_file_path": "macros/utils/data_types.sql",
+          "unique_id": "macro.dbt.default__type_numeric",
+          "macro_sql": "{% macro default__type_numeric() %}\n    {{ return(api.Column.numeric_type(\"numeric\", 28, 6)) }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": []
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.129683
+        },
+        "macro.dbt.type_bigint": {
+          "name": "type_bigint",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/utils/data_types.sql",
+          "original_file_path": "macros/utils/data_types.sql",
+          "unique_id": "macro.dbt.type_bigint",
+          "macro_sql": "\n\n{%- macro type_bigint() -%}\n  {{ return(adapter.dispatch('type_bigint', 'dbt')()) }}\n{%- endmacro -%}\n\n",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.default__type_bigint"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.129836
+        },
+        "macro.dbt.default__type_bigint": {
+          "name": "default__type_bigint",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/utils/data_types.sql",
+          "original_file_path": "macros/utils/data_types.sql",
+          "unique_id": "macro.dbt.default__type_bigint",
+          "macro_sql": "{% macro default__type_bigint() %}\n    {{ return(api.Column.translate_type(\"bigint\")) }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": []
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.130021
+        },
+        "macro.dbt.type_int": {
+          "name": "type_int",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/utils/data_types.sql",
+          "original_file_path": "macros/utils/data_types.sql",
+          "unique_id": "macro.dbt.type_int",
+          "macro_sql": "\n\n{%- macro type_int() -%}\n  {{ return(adapter.dispatch('type_int', 'dbt')()) }}\n{%- endmacro -%}\n\n",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.default__type_int"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.1301792
+        },
+        "macro.dbt.default__type_int": {
+          "name": "default__type_int",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/utils/data_types.sql",
+          "original_file_path": "macros/utils/data_types.sql",
+          "unique_id": "macro.dbt.default__type_int",
+          "macro_sql": "{%- macro default__type_int() -%}\n  {{ return(api.Column.translate_type(\"integer\")) }}\n{%- endmacro -%}\n\n",
+          "depends_on": {
+            "macros": []
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.130319
+        },
+        "macro.dbt.type_boolean": {
+          "name": "type_boolean",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/utils/data_types.sql",
+          "original_file_path": "macros/utils/data_types.sql",
+          "unique_id": "macro.dbt.type_boolean",
+          "macro_sql": "\n\n{%- macro type_boolean() -%}\n  {{ return(adapter.dispatch('type_boolean', 'dbt')()) }}\n{%- endmacro -%}\n\n",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.default__type_boolean"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.130471
+        },
+        "macro.dbt.default__type_boolean": {
+          "name": "default__type_boolean",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/utils/data_types.sql",
+          "original_file_path": "macros/utils/data_types.sql",
+          "unique_id": "macro.dbt.default__type_boolean",
+          "macro_sql": "{%- macro default__type_boolean() -%}\n  {{ return(api.Column.translate_type(\"boolean\")) }}\n{%- endmacro -%}\n\n",
+          "depends_on": {
+            "macros": []
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.1306062
+        },
+        "macro.dbt.array_concat": {
+          "name": "array_concat",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/utils/array_concat.sql",
+          "original_file_path": "macros/utils/array_concat.sql",
+          "unique_id": "macro.dbt.array_concat",
+          "macro_sql": "{% macro array_concat(array_1, array_2) -%}\n  {{ return(adapter.dispatch('array_concat', 'dbt')(array_1, array_2)) }}\n{%- endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.default__array_concat"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.1308658
+        },
+        "macro.dbt.default__array_concat": {
+          "name": "default__array_concat",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/utils/array_concat.sql",
+          "original_file_path": "macros/utils/array_concat.sql",
+          "unique_id": "macro.dbt.default__array_concat",
+          "macro_sql": "{% macro default__array_concat(array_1, array_2) -%}\n    array_cat({{ array_1 }}, {{ array_2 }})\n{%- endmacro %}",
+          "depends_on": {
+            "macros": []
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.130993
+        },
+        "macro.dbt.bool_or": {
+          "name": "bool_or",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/utils/bool_or.sql",
+          "original_file_path": "macros/utils/bool_or.sql",
+          "unique_id": "macro.dbt.bool_or",
+          "macro_sql": "{% macro bool_or(expression) -%}\n    {{ return(adapter.dispatch('bool_or', 'dbt') (expression)) }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.default__bool_or"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.131223
+        },
+        "macro.dbt.default__bool_or": {
+          "name": "default__bool_or",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/utils/bool_or.sql",
+          "original_file_path": "macros/utils/bool_or.sql",
+          "unique_id": "macro.dbt.default__bool_or",
+          "macro_sql": "{% macro default__bool_or(expression) -%}\n\n    bool_or({{ expression }})\n\n{%- endmacro %}",
+          "depends_on": {
+            "macros": []
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.1313221
+        },
+        "macro.dbt.last_day": {
+          "name": "last_day",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/utils/last_day.sql",
+          "original_file_path": "macros/utils/last_day.sql",
+          "unique_id": "macro.dbt.last_day",
+          "macro_sql": "{% macro last_day(date, datepart) %}\n  {{ return(adapter.dispatch('last_day', 'dbt') (date, datepart)) }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt_duckdb.duckdb__last_day"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.1316469
+        },
+        "macro.dbt.default_last_day": {
+          "name": "default_last_day",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/utils/last_day.sql",
+          "original_file_path": "macros/utils/last_day.sql",
+          "unique_id": "macro.dbt.default_last_day",
+          "macro_sql": "\n\n{%- macro default_last_day(date, datepart) -%}\n    cast(\n        {{dbt.dateadd('day', '-1',\n        dbt.dateadd(datepart, '1', dbt.date_trunc(datepart, date))\n        )}}\n        as date)\n{%- endmacro -%}\n\n",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.dateadd",
+              "macro.dbt.date_trunc"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.131901
+        },
+        "macro.dbt.default__last_day": {
+          "name": "default__last_day",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/utils/last_day.sql",
+          "original_file_path": "macros/utils/last_day.sql",
+          "unique_id": "macro.dbt.default__last_day",
+          "macro_sql": "{% macro default__last_day(date, datepart) -%}\n    {{dbt.default_last_day(date, datepart)}}\n{%- endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.default_last_day"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.132041
+        },
+        "macro.dbt.split_part": {
+          "name": "split_part",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/utils/split_part.sql",
+          "original_file_path": "macros/utils/split_part.sql",
+          "unique_id": "macro.dbt.split_part",
+          "macro_sql": "{% macro split_part(string_text, delimiter_text, part_number) %}\n  {{ return(adapter.dispatch('split_part', 'dbt') (string_text, delimiter_text, part_number)) }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt_duckdb.duckdb__split_part"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.1325598
+        },
+        "macro.dbt.default__split_part": {
+          "name": "default__split_part",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/utils/split_part.sql",
+          "original_file_path": "macros/utils/split_part.sql",
+          "unique_id": "macro.dbt.default__split_part",
+          "macro_sql": "{% macro default__split_part(string_text, delimiter_text, part_number) %}\n\n    split_part(\n        {{ string_text }},\n        {{ delimiter_text }},\n        {{ part_number }}\n        )\n\n{% endmacro %}",
+          "depends_on": {
+            "macros": []
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.1329112
+        },
+        "macro.dbt._split_part_negative": {
+          "name": "_split_part_negative",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/utils/split_part.sql",
+          "original_file_path": "macros/utils/split_part.sql",
+          "unique_id": "macro.dbt._split_part_negative",
+          "macro_sql": "{% macro _split_part_negative(string_text, delimiter_text, part_number) %}\n\n    split_part(\n        {{ string_text }},\n        {{ delimiter_text }},\n          length({{ string_text }})\n          - length(\n              replace({{ string_text }},  {{ delimiter_text }}, '')\n          ) + 2 {{ part_number }}\n        )\n\n{% endmacro %}",
+          "depends_on": {
+            "macros": []
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.133125
+        },
+        "macro.dbt.date_trunc": {
+          "name": "date_trunc",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/utils/date_trunc.sql",
+          "original_file_path": "macros/utils/date_trunc.sql",
+          "unique_id": "macro.dbt.date_trunc",
+          "macro_sql": "{% macro date_trunc(datepart, date) -%}\n  {{ return(adapter.dispatch('date_trunc', 'dbt') (datepart, date)) }}\n{%- endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.default__date_trunc"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.133386
+        },
+        "macro.dbt.default__date_trunc": {
+          "name": "default__date_trunc",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/utils/date_trunc.sql",
+          "original_file_path": "macros/utils/date_trunc.sql",
+          "unique_id": "macro.dbt.default__date_trunc",
+          "macro_sql": "{% macro default__date_trunc(datepart, date) -%}\n    date_trunc('{{datepart}}', {{date}})\n{%- endmacro %}",
+          "depends_on": {
+            "macros": []
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.1335092
+        },
+        "macro.dbt.array_construct": {
+          "name": "array_construct",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/utils/array_construct.sql",
+          "original_file_path": "macros/utils/array_construct.sql",
+          "unique_id": "macro.dbt.array_construct",
+          "macro_sql": "{% macro array_construct(inputs=[], data_type=api.Column.translate_type('integer')) -%}\n  {{ return(adapter.dispatch('array_construct', 'dbt')(inputs, data_type)) }}\n{%- endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.default__array_construct"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.13386
+        },
+        "macro.dbt.default__array_construct": {
+          "name": "default__array_construct",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/utils/array_construct.sql",
+          "original_file_path": "macros/utils/array_construct.sql",
+          "unique_id": "macro.dbt.default__array_construct",
+          "macro_sql": "{% macro default__array_construct(inputs, data_type) -%}\n    {% if inputs|length > 0 %}\n    array[ {{ inputs|join(' , ') }} ]\n    {% else %}\n    array[]::{{data_type}}[]\n    {% endif %}\n{%- endmacro %}",
+          "depends_on": {
+            "macros": []
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.134088
+        },
+        "macro.dbt.array_append": {
+          "name": "array_append",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/utils/array_append.sql",
+          "original_file_path": "macros/utils/array_append.sql",
+          "unique_id": "macro.dbt.array_append",
+          "macro_sql": "{% macro array_append(array, new_element) -%}\n  {{ return(adapter.dispatch('array_append', 'dbt')(array, new_element)) }}\n{%- endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.default__array_append"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.1343539
+        },
+        "macro.dbt.default__array_append": {
+          "name": "default__array_append",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/utils/array_append.sql",
+          "original_file_path": "macros/utils/array_append.sql",
+          "unique_id": "macro.dbt.default__array_append",
+          "macro_sql": "{% macro default__array_append(array, new_element) -%}\n    array_append({{ array }}, {{ new_element }})\n{%- endmacro %}",
+          "depends_on": {
+            "macros": []
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.134479
+        },
+        "macro.dbt.create_schema": {
+          "name": "create_schema",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/adapters/schema.sql",
+          "original_file_path": "macros/adapters/schema.sql",
+          "unique_id": "macro.dbt.create_schema",
+          "macro_sql": "{% macro create_schema(relation) -%}\n  {{ adapter.dispatch('create_schema', 'dbt')(relation) }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt_duckdb.duckdb__create_schema"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.1348321
+        },
+        "macro.dbt.default__create_schema": {
+          "name": "default__create_schema",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/adapters/schema.sql",
+          "original_file_path": "macros/adapters/schema.sql",
+          "unique_id": "macro.dbt.default__create_schema",
+          "macro_sql": "{% macro default__create_schema(relation) -%}\n  {%- call statement('create_schema') -%}\n    create schema if not exists {{ relation.without_identifier() }}\n  {% endcall %}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.statement"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.135006
+        },
+        "macro.dbt.drop_schema": {
+          "name": "drop_schema",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/adapters/schema.sql",
+          "original_file_path": "macros/adapters/schema.sql",
+          "unique_id": "macro.dbt.drop_schema",
+          "macro_sql": "{% macro drop_schema(relation) -%}\n  {{ adapter.dispatch('drop_schema', 'dbt')(relation) }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt_duckdb.duckdb__drop_schema"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.135159
+        },
+        "macro.dbt.default__drop_schema": {
+          "name": "default__drop_schema",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/adapters/schema.sql",
+          "original_file_path": "macros/adapters/schema.sql",
+          "unique_id": "macro.dbt.default__drop_schema",
+          "macro_sql": "{% macro default__drop_schema(relation) -%}\n  {%- call statement('drop_schema') -%}\n    drop schema if exists {{ relation.without_identifier() }} cascade\n  {% endcall %}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.statement"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.135329
+        },
+        "macro.dbt.current_timestamp": {
+          "name": "current_timestamp",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/adapters/timestamps.sql",
+          "original_file_path": "macros/adapters/timestamps.sql",
+          "unique_id": "macro.dbt.current_timestamp",
+          "macro_sql": "{%- macro current_timestamp() -%}\n    {{ adapter.dispatch('current_timestamp', 'dbt')() }}\n{%- endmacro -%}\n\n",
+          "depends_on": {
+            "macros": [
+              "macro.dbt_duckdb.duckdb__current_timestamp"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.135814
+        },
+        "macro.dbt.default__current_timestamp": {
+          "name": "default__current_timestamp",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/adapters/timestamps.sql",
+          "original_file_path": "macros/adapters/timestamps.sql",
+          "unique_id": "macro.dbt.default__current_timestamp",
+          "macro_sql": "{% macro default__current_timestamp() -%}\n  {{ exceptions.raise_not_implemented(\n    'current_timestamp macro not implemented for adapter ' + adapter.type()) }}\n{%- endmacro %}",
+          "depends_on": {
+            "macros": []
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.135958
+        },
+        "macro.dbt.snapshot_get_time": {
+          "name": "snapshot_get_time",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/adapters/timestamps.sql",
+          "original_file_path": "macros/adapters/timestamps.sql",
+          "unique_id": "macro.dbt.snapshot_get_time",
+          "macro_sql": "\n\n{%- macro snapshot_get_time() -%}\n    {{ adapter.dispatch('snapshot_get_time', 'dbt')() }}\n{%- endmacro -%}\n\n",
+          "depends_on": {
+            "macros": [
+              "macro.dbt_duckdb.duckdb__snapshot_get_time"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.136096
+        },
+        "macro.dbt.default__snapshot_get_time": {
+          "name": "default__snapshot_get_time",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/adapters/timestamps.sql",
+          "original_file_path": "macros/adapters/timestamps.sql",
+          "unique_id": "macro.dbt.default__snapshot_get_time",
+          "macro_sql": "{% macro default__snapshot_get_time() %}\n    {{ current_timestamp() }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.current_timestamp"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.1361952
+        },
+        "macro.dbt.current_timestamp_backcompat": {
+          "name": "current_timestamp_backcompat",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/adapters/timestamps.sql",
+          "original_file_path": "macros/adapters/timestamps.sql",
+          "unique_id": "macro.dbt.current_timestamp_backcompat",
+          "macro_sql": "{% macro current_timestamp_backcompat() %}\n    {{ return(adapter.dispatch('current_timestamp_backcompat', 'dbt')()) }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.default__current_timestamp_backcompat"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.136353
+        },
+        "macro.dbt.default__current_timestamp_backcompat": {
+          "name": "default__current_timestamp_backcompat",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/adapters/timestamps.sql",
+          "original_file_path": "macros/adapters/timestamps.sql",
+          "unique_id": "macro.dbt.default__current_timestamp_backcompat",
+          "macro_sql": "{% macro default__current_timestamp_backcompat() %}\n    current_timestamp::timestamp\n{% endmacro %}",
+          "depends_on": {
+            "macros": []
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.1364238
+        },
+        "macro.dbt.current_timestamp_in_utc_backcompat": {
+          "name": "current_timestamp_in_utc_backcompat",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/adapters/timestamps.sql",
+          "original_file_path": "macros/adapters/timestamps.sql",
+          "unique_id": "macro.dbt.current_timestamp_in_utc_backcompat",
+          "macro_sql": "{% macro current_timestamp_in_utc_backcompat() %}\n    {{ return(adapter.dispatch('current_timestamp_in_utc_backcompat', 'dbt')()) }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.default__current_timestamp_in_utc_backcompat"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.1365812
+        },
+        "macro.dbt.default__current_timestamp_in_utc_backcompat": {
+          "name": "default__current_timestamp_in_utc_backcompat",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/adapters/timestamps.sql",
+          "original_file_path": "macros/adapters/timestamps.sql",
+          "unique_id": "macro.dbt.default__current_timestamp_in_utc_backcompat",
+          "macro_sql": "{% macro default__current_timestamp_in_utc_backcompat() %}\n    {{ return(adapter.dispatch('current_timestamp_backcompat', 'dbt')()) }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.current_timestamp_backcompat",
+              "macro.dbt.default__current_timestamp_backcompat"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.1368
+        },
+        "macro.dbt.get_create_index_sql": {
+          "name": "get_create_index_sql",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/adapters/indexes.sql",
+          "original_file_path": "macros/adapters/indexes.sql",
+          "unique_id": "macro.dbt.get_create_index_sql",
+          "macro_sql": "{% macro get_create_index_sql(relation, index_dict) -%}\n  {{ return(adapter.dispatch('get_create_index_sql', 'dbt')(relation, index_dict)) }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.default__get_create_index_sql"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.1372411
+        },
+        "macro.dbt.default__get_create_index_sql": {
+          "name": "default__get_create_index_sql",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/adapters/indexes.sql",
+          "original_file_path": "macros/adapters/indexes.sql",
+          "unique_id": "macro.dbt.default__get_create_index_sql",
+          "macro_sql": "{% macro default__get_create_index_sql(relation, index_dict) -%}\n  {% do return(None) %}\n{% endmacro %}",
+          "depends_on": {
+            "macros": []
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.13737
+        },
+        "macro.dbt.create_indexes": {
+          "name": "create_indexes",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/adapters/indexes.sql",
+          "original_file_path": "macros/adapters/indexes.sql",
+          "unique_id": "macro.dbt.create_indexes",
+          "macro_sql": "{% macro create_indexes(relation) -%}\n  {{ adapter.dispatch('create_indexes', 'dbt')(relation) }}\n{%- endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.default__create_indexes"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.137522
+        },
+        "macro.dbt.default__create_indexes": {
+          "name": "default__create_indexes",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/adapters/indexes.sql",
+          "original_file_path": "macros/adapters/indexes.sql",
+          "unique_id": "macro.dbt.default__create_indexes",
+          "macro_sql": "{% macro default__create_indexes(relation) -%}\n  {%- set _indexes = config.get('indexes', default=[]) -%}\n\n  {% for _index_dict in _indexes %}\n    {% set create_index_sql = get_create_index_sql(relation, _index_dict) %}\n    {% if create_index_sql %}\n      {% do run_query(create_index_sql) %}\n    {% endif %}\n  {% endfor %}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.get_create_index_sql",
+              "macro.dbt.run_query"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.1379
+        },
+        "macro.dbt.make_intermediate_relation": {
+          "name": "make_intermediate_relation",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/adapters/relation.sql",
+          "original_file_path": "macros/adapters/relation.sql",
+          "unique_id": "macro.dbt.make_intermediate_relation",
+          "macro_sql": "{% macro make_intermediate_relation(base_relation, suffix='__dbt_tmp') %}\n  {{ return(adapter.dispatch('make_intermediate_relation', 'dbt')(base_relation, suffix)) }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.default__make_intermediate_relation"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.14132
+        },
+        "macro.dbt.default__make_intermediate_relation": {
+          "name": "default__make_intermediate_relation",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/adapters/relation.sql",
+          "original_file_path": "macros/adapters/relation.sql",
+          "unique_id": "macro.dbt.default__make_intermediate_relation",
+          "macro_sql": "{% macro default__make_intermediate_relation(base_relation, suffix) %}\n    {{ return(default__make_temp_relation(base_relation, suffix)) }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.default__make_temp_relation"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.1414778
+        },
+        "macro.dbt.make_temp_relation": {
+          "name": "make_temp_relation",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/adapters/relation.sql",
+          "original_file_path": "macros/adapters/relation.sql",
+          "unique_id": "macro.dbt.make_temp_relation",
+          "macro_sql": "{% macro make_temp_relation(base_relation, suffix='__dbt_tmp') %}\n  {{ return(adapter.dispatch('make_temp_relation', 'dbt')(base_relation, suffix)) }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt_duckdb.duckdb__make_temp_relation"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.1417248
+        },
+        "macro.dbt.default__make_temp_relation": {
+          "name": "default__make_temp_relation",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/adapters/relation.sql",
+          "original_file_path": "macros/adapters/relation.sql",
+          "unique_id": "macro.dbt.default__make_temp_relation",
+          "macro_sql": "{% macro default__make_temp_relation(base_relation, suffix) %}\n    {%- set temp_identifier = base_relation.identifier ~ suffix -%}\n    {%- set temp_relation = base_relation.incorporate(\n                                path={\"identifier\": temp_identifier}) -%}\n\n    {{ return(temp_relation) }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": []
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.142004
+        },
+        "macro.dbt.make_backup_relation": {
+          "name": "make_backup_relation",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/adapters/relation.sql",
+          "original_file_path": "macros/adapters/relation.sql",
+          "unique_id": "macro.dbt.make_backup_relation",
+          "macro_sql": "{% macro make_backup_relation(base_relation, backup_relation_type, suffix='__dbt_backup') %}\n    {{ return(adapter.dispatch('make_backup_relation', 'dbt')(base_relation, backup_relation_type, suffix)) }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.default__make_backup_relation"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.142237
+        },
+        "macro.dbt.default__make_backup_relation": {
+          "name": "default__make_backup_relation",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/adapters/relation.sql",
+          "original_file_path": "macros/adapters/relation.sql",
+          "unique_id": "macro.dbt.default__make_backup_relation",
+          "macro_sql": "{% macro default__make_backup_relation(base_relation, backup_relation_type, suffix) %}\n    {%- set backup_identifier = base_relation.identifier ~ suffix -%}\n    {%- set backup_relation = base_relation.incorporate(\n                                  path={\"identifier\": backup_identifier},\n                                  type=backup_relation_type\n    ) -%}\n    {{ return(backup_relation) }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": []
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.1425438
+        },
+        "macro.dbt.drop_relation": {
+          "name": "drop_relation",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/adapters/relation.sql",
+          "original_file_path": "macros/adapters/relation.sql",
+          "unique_id": "macro.dbt.drop_relation",
+          "macro_sql": "{% macro drop_relation(relation) -%}\n  {{ return(adapter.dispatch('drop_relation', 'dbt')(relation)) }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt_duckdb.duckdb__drop_relation"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.142721
+        },
+        "macro.dbt.default__drop_relation": {
+          "name": "default__drop_relation",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/adapters/relation.sql",
+          "original_file_path": "macros/adapters/relation.sql",
+          "unique_id": "macro.dbt.default__drop_relation",
+          "macro_sql": "{% macro default__drop_relation(relation) -%}\n  {% call statement('drop_relation', auto_begin=False) -%}\n    drop {{ relation.type }} if exists {{ relation }} cascade\n  {%- endcall %}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.statement"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.142924
+        },
+        "macro.dbt.truncate_relation": {
+          "name": "truncate_relation",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/adapters/relation.sql",
+          "original_file_path": "macros/adapters/relation.sql",
+          "unique_id": "macro.dbt.truncate_relation",
+          "macro_sql": "{% macro truncate_relation(relation) -%}\n  {{ return(adapter.dispatch('truncate_relation', 'dbt')(relation)) }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt_duckdb.duckdb__truncate_relation"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.1430972
+        },
+        "macro.dbt.default__truncate_relation": {
+          "name": "default__truncate_relation",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/adapters/relation.sql",
+          "original_file_path": "macros/adapters/relation.sql",
+          "unique_id": "macro.dbt.default__truncate_relation",
+          "macro_sql": "{% macro default__truncate_relation(relation) -%}\n  {% call statement('truncate_relation') -%}\n    truncate table {{ relation }}\n  {%- endcall %}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.statement"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.14325
+        },
+        "macro.dbt.rename_relation": {
+          "name": "rename_relation",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/adapters/relation.sql",
+          "original_file_path": "macros/adapters/relation.sql",
+          "unique_id": "macro.dbt.rename_relation",
+          "macro_sql": "{% macro rename_relation(from_relation, to_relation) -%}\n  {{ return(adapter.dispatch('rename_relation', 'dbt')(from_relation, to_relation)) }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt_duckdb.duckdb__rename_relation"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.143444
+        },
+        "macro.dbt.default__rename_relation": {
+          "name": "default__rename_relation",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/adapters/relation.sql",
+          "original_file_path": "macros/adapters/relation.sql",
+          "unique_id": "macro.dbt.default__rename_relation",
+          "macro_sql": "{% macro default__rename_relation(from_relation, to_relation) -%}\n  {% set target_name = adapter.quote_as_configured(to_relation.identifier, 'identifier') %}\n  {% call statement('rename_relation') -%}\n    alter table {{ from_relation }} rename to {{ target_name }}\n  {%- endcall %}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.statement"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.143709
+        },
+        "macro.dbt.get_or_create_relation": {
+          "name": "get_or_create_relation",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/adapters/relation.sql",
+          "original_file_path": "macros/adapters/relation.sql",
+          "unique_id": "macro.dbt.get_or_create_relation",
+          "macro_sql": "{% macro get_or_create_relation(database, schema, identifier, type) -%}\n  {{ return(adapter.dispatch('get_or_create_relation', 'dbt')(database, schema, identifier, type)) }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.default__get_or_create_relation"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.144015
+        },
+        "macro.dbt.default__get_or_create_relation": {
+          "name": "default__get_or_create_relation",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/adapters/relation.sql",
+          "original_file_path": "macros/adapters/relation.sql",
+          "unique_id": "macro.dbt.default__get_or_create_relation",
+          "macro_sql": "{% macro default__get_or_create_relation(database, schema, identifier, type) %}\n  {%- set target_relation = adapter.get_relation(database=database, schema=schema, identifier=identifier) %}\n\n  {% if target_relation %}\n    {% do return([true, target_relation]) %}\n  {% endif %}\n\n  {%- set new_relation = api.Relation.create(\n      database=database,\n      schema=schema,\n      identifier=identifier,\n      type=type\n  ) -%}\n  {% do return([false, new_relation]) %}\n{% endmacro %}",
+          "depends_on": {
+            "macros": []
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.144591
+        },
+        "macro.dbt.load_cached_relation": {
+          "name": "load_cached_relation",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/adapters/relation.sql",
+          "original_file_path": "macros/adapters/relation.sql",
+          "unique_id": "macro.dbt.load_cached_relation",
+          "macro_sql": "{% macro load_cached_relation(relation) %}\n  {% do return(adapter.get_relation(\n    database=relation.database,\n    schema=relation.schema,\n    identifier=relation.identifier\n  )) -%}\n{% endmacro %}",
+          "depends_on": {
+            "macros": []
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.144814
+        },
+        "macro.dbt.load_relation": {
+          "name": "load_relation",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/adapters/relation.sql",
+          "original_file_path": "macros/adapters/relation.sql",
+          "unique_id": "macro.dbt.load_relation",
+          "macro_sql": "{% macro load_relation(relation) %}\n    {{ return(load_cached_relation(relation)) }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.load_cached_relation"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.144951
+        },
+        "macro.dbt.drop_relation_if_exists": {
+          "name": "drop_relation_if_exists",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/adapters/relation.sql",
+          "original_file_path": "macros/adapters/relation.sql",
+          "unique_id": "macro.dbt.drop_relation_if_exists",
+          "macro_sql": "{% macro drop_relation_if_exists(relation) %}\n  {% if relation is not none %}\n    {{ adapter.drop_relation(relation) }}\n  {% endif %}\n{% endmacro %}",
+          "depends_on": {
+            "macros": []
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.145139
+        },
+        "macro.dbt.collect_freshness": {
+          "name": "collect_freshness",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/adapters/freshness.sql",
+          "original_file_path": "macros/adapters/freshness.sql",
+          "unique_id": "macro.dbt.collect_freshness",
+          "macro_sql": "{% macro collect_freshness(source, loaded_at_field, filter) %}\n  {{ return(adapter.dispatch('collect_freshness', 'dbt')(source, loaded_at_field, filter))}}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.default__collect_freshness"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.145539
+        },
+        "macro.dbt.default__collect_freshness": {
+          "name": "default__collect_freshness",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/adapters/freshness.sql",
+          "original_file_path": "macros/adapters/freshness.sql",
+          "unique_id": "macro.dbt.default__collect_freshness",
+          "macro_sql": "{% macro default__collect_freshness(source, loaded_at_field, filter) %}\n  {% call statement('collect_freshness', fetch_result=True, auto_begin=False) -%}\n    select\n      max({{ loaded_at_field }}) as max_loaded_at,\n      {{ current_timestamp() }} as snapshotted_at\n    from {{ source }}\n    {% if filter %}\n    where {{ filter }}\n    {% endif %}\n  {% endcall %}\n  {{ return(load_result('collect_freshness')) }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.statement",
+              "macro.dbt.current_timestamp"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.1459389
+        },
+        "macro.dbt.copy_grants": {
+          "name": "copy_grants",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/adapters/apply_grants.sql",
+          "original_file_path": "macros/adapters/apply_grants.sql",
+          "unique_id": "macro.dbt.copy_grants",
+          "macro_sql": "{% macro copy_grants() %}\n    {{ return(adapter.dispatch('copy_grants', 'dbt')()) }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.default__copy_grants"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.147651
+        },
+        "macro.dbt.default__copy_grants": {
+          "name": "default__copy_grants",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/adapters/apply_grants.sql",
+          "original_file_path": "macros/adapters/apply_grants.sql",
+          "unique_id": "macro.dbt.default__copy_grants",
+          "macro_sql": "{% macro default__copy_grants() %}\n    {{ return(True) }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": []
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.1477618
+        },
+        "macro.dbt.support_multiple_grantees_per_dcl_statement": {
+          "name": "support_multiple_grantees_per_dcl_statement",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/adapters/apply_grants.sql",
+          "original_file_path": "macros/adapters/apply_grants.sql",
+          "unique_id": "macro.dbt.support_multiple_grantees_per_dcl_statement",
+          "macro_sql": "{% macro support_multiple_grantees_per_dcl_statement() %}\n    {{ return(adapter.dispatch('support_multiple_grantees_per_dcl_statement', 'dbt')()) }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.default__support_multiple_grantees_per_dcl_statement"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.147925
+        },
+        "macro.dbt.default__support_multiple_grantees_per_dcl_statement": {
+          "name": "default__support_multiple_grantees_per_dcl_statement",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/adapters/apply_grants.sql",
+          "original_file_path": "macros/adapters/apply_grants.sql",
+          "unique_id": "macro.dbt.default__support_multiple_grantees_per_dcl_statement",
+          "macro_sql": "\n\n{%- macro default__support_multiple_grantees_per_dcl_statement() -%}\n    {{ return(True) }}\n{%- endmacro -%}\n\n\n",
+          "depends_on": {
+            "macros": []
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.148031
+        },
+        "macro.dbt.should_revoke": {
+          "name": "should_revoke",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/adapters/apply_grants.sql",
+          "original_file_path": "macros/adapters/apply_grants.sql",
+          "unique_id": "macro.dbt.should_revoke",
+          "macro_sql": "{% macro should_revoke(existing_relation, full_refresh_mode=True) %}\n\n    {% if not existing_relation %}\n        {#-- The table doesn't already exist, so no grants to copy over --#}\n        {{ return(False) }}\n    {% elif full_refresh_mode %}\n        {#-- The object is being REPLACED -- whether grants are copied over depends on the value of user config --#}\n        {{ return(copy_grants()) }}\n    {% else %}\n        {#-- The table is being merged/upserted/inserted -- grants will be carried over --#}\n        {{ return(True) }}\n    {% endif %}\n\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.copy_grants"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.1483572
+        },
+        "macro.dbt.get_show_grant_sql": {
+          "name": "get_show_grant_sql",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/adapters/apply_grants.sql",
+          "original_file_path": "macros/adapters/apply_grants.sql",
+          "unique_id": "macro.dbt.get_show_grant_sql",
+          "macro_sql": "{% macro get_show_grant_sql(relation) %}\n    {{ return(adapter.dispatch(\"get_show_grant_sql\", \"dbt\")(relation)) }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.default__get_show_grant_sql"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.1485372
+        },
+        "macro.dbt.default__get_show_grant_sql": {
+          "name": "default__get_show_grant_sql",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/adapters/apply_grants.sql",
+          "original_file_path": "macros/adapters/apply_grants.sql",
+          "unique_id": "macro.dbt.default__get_show_grant_sql",
+          "macro_sql": "{% macro default__get_show_grant_sql(relation) %}\n    show grants on {{ relation }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": []
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.1486342
+        },
+        "macro.dbt.get_grant_sql": {
+          "name": "get_grant_sql",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/adapters/apply_grants.sql",
+          "original_file_path": "macros/adapters/apply_grants.sql",
+          "unique_id": "macro.dbt.get_grant_sql",
+          "macro_sql": "{% macro get_grant_sql(relation, privilege, grantees) %}\n    {{ return(adapter.dispatch('get_grant_sql', 'dbt')(relation, privilege, grantees)) }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.default__get_grant_sql"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.148847
+        },
+        "macro.dbt.default__get_grant_sql": {
+          "name": "default__get_grant_sql",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/adapters/apply_grants.sql",
+          "original_file_path": "macros/adapters/apply_grants.sql",
+          "unique_id": "macro.dbt.default__get_grant_sql",
+          "macro_sql": "\n\n{%- macro default__get_grant_sql(relation, privilege, grantees) -%}\n    grant {{ privilege }} on {{ relation }} to {{ grantees | join(', ') }}\n{%- endmacro -%}\n\n\n",
+          "depends_on": {
+            "macros": []
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.149024
+        },
+        "macro.dbt.get_revoke_sql": {
+          "name": "get_revoke_sql",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/adapters/apply_grants.sql",
+          "original_file_path": "macros/adapters/apply_grants.sql",
+          "unique_id": "macro.dbt.get_revoke_sql",
+          "macro_sql": "{% macro get_revoke_sql(relation, privilege, grantees) %}\n    {{ return(adapter.dispatch('get_revoke_sql', 'dbt')(relation, privilege, grantees)) }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.default__get_revoke_sql"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.1492429
+        },
+        "macro.dbt.default__get_revoke_sql": {
+          "name": "default__get_revoke_sql",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/adapters/apply_grants.sql",
+          "original_file_path": "macros/adapters/apply_grants.sql",
+          "unique_id": "macro.dbt.default__get_revoke_sql",
+          "macro_sql": "\n\n{%- macro default__get_revoke_sql(relation, privilege, grantees) -%}\n    revoke {{ privilege }} on {{ relation }} from {{ grantees | join(', ') }}\n{%- endmacro -%}\n\n\n",
+          "depends_on": {
+            "macros": []
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.1494179
+        },
+        "macro.dbt.get_dcl_statement_list": {
+          "name": "get_dcl_statement_list",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/adapters/apply_grants.sql",
+          "original_file_path": "macros/adapters/apply_grants.sql",
+          "unique_id": "macro.dbt.get_dcl_statement_list",
+          "macro_sql": "{% macro get_dcl_statement_list(relation, grant_config, get_dcl_macro) %}\n    {{ return(adapter.dispatch('get_dcl_statement_list', 'dbt')(relation, grant_config, get_dcl_macro)) }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.default__get_dcl_statement_list"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.1496341
+        },
+        "macro.dbt.default__get_dcl_statement_list": {
+          "name": "default__get_dcl_statement_list",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/adapters/apply_grants.sql",
+          "original_file_path": "macros/adapters/apply_grants.sql",
+          "unique_id": "macro.dbt.default__get_dcl_statement_list",
+          "macro_sql": "\n\n{%- macro default__get_dcl_statement_list(relation, grant_config, get_dcl_macro) -%}\n    {#\n      -- Unpack grant_config into specific privileges and the set of users who need them granted/revoked.\n      -- Depending on whether this database supports multiple grantees per statement, pass in the list of\n      -- all grantees per privilege, or (if not) template one statement per privilege-grantee pair.\n      -- `get_dcl_macro` will be either `get_grant_sql` or `get_revoke_sql`\n    #}\n    {%- set dcl_statements = [] -%}\n    {%- for privilege, grantees in grant_config.items() %}\n        {%- if support_multiple_grantees_per_dcl_statement() and grantees -%}\n          {%- set dcl = get_dcl_macro(relation, privilege, grantees) -%}\n          {%- do dcl_statements.append(dcl) -%}\n        {%- else -%}\n          {%- for grantee in grantees -%}\n              {% set dcl = get_dcl_macro(relation, privilege, [grantee]) %}\n              {%- do dcl_statements.append(dcl) -%}\n          {% endfor -%}\n        {%- endif -%}\n    {%- endfor -%}\n    {{ return(dcl_statements) }}\n{%- endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.support_multiple_grantees_per_dcl_statement"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.150381
+        },
+        "macro.dbt.call_dcl_statements": {
+          "name": "call_dcl_statements",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/adapters/apply_grants.sql",
+          "original_file_path": "macros/adapters/apply_grants.sql",
+          "unique_id": "macro.dbt.call_dcl_statements",
+          "macro_sql": "{% macro call_dcl_statements(dcl_statement_list) %}\n    {{ return(adapter.dispatch(\"call_dcl_statements\", \"dbt\")(dcl_statement_list)) }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.default__call_dcl_statements"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.1505651
+        },
+        "macro.dbt.default__call_dcl_statements": {
+          "name": "default__call_dcl_statements",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/adapters/apply_grants.sql",
+          "original_file_path": "macros/adapters/apply_grants.sql",
+          "unique_id": "macro.dbt.default__call_dcl_statements",
+          "macro_sql": "{% macro default__call_dcl_statements(dcl_statement_list) %}\n    {#\n      -- By default, supply all grant + revoke statements in a single semicolon-separated block,\n      -- so that they're all processed together.\n\n      -- Some databases do not support this. Those adapters will need to override this macro\n      -- to run each statement individually.\n    #}\n    {% call statement('grants') %}\n        {% for dcl_statement in dcl_statement_list %}\n            {{ dcl_statement }};\n        {% endfor %}\n    {% endcall %}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.statement"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.1508
+        },
+        "macro.dbt.apply_grants": {
+          "name": "apply_grants",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/adapters/apply_grants.sql",
+          "original_file_path": "macros/adapters/apply_grants.sql",
+          "unique_id": "macro.dbt.apply_grants",
+          "macro_sql": "{% macro apply_grants(relation, grant_config, should_revoke) %}\n    {{ return(adapter.dispatch(\"apply_grants\", \"dbt\")(relation, grant_config, should_revoke)) }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.default__apply_grants"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.1510222
+        },
+        "macro.dbt.default__apply_grants": {
+          "name": "default__apply_grants",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/adapters/apply_grants.sql",
+          "original_file_path": "macros/adapters/apply_grants.sql",
+          "unique_id": "macro.dbt.default__apply_grants",
+          "macro_sql": "{% macro default__apply_grants(relation, grant_config, should_revoke=True) %}\n    {#-- If grant_config is {} or None, this is a no-op --#}\n    {% if grant_config %}\n        {% if should_revoke %}\n            {#-- We think previous grants may have carried over --#}\n            {#-- Show current grants and calculate diffs --#}\n            {% set current_grants_table = run_query(get_show_grant_sql(relation)) %}\n            {% set current_grants_dict = adapter.standardize_grants_dict(current_grants_table) %}\n            {% set needs_granting = diff_of_two_dicts(grant_config, current_grants_dict) %}\n            {% set needs_revoking = diff_of_two_dicts(current_grants_dict, grant_config) %}\n            {% if not (needs_granting or needs_revoking) %}\n                {{ log('On ' ~ relation ~': All grants are in place, no revocation or granting needed.')}}\n            {% endif %}\n        {% else %}\n            {#-- We don't think there's any chance of previous grants having carried over. --#}\n            {#-- Jump straight to granting what the user has configured. --#}\n            {% set needs_revoking = {} %}\n            {% set needs_granting = grant_config %}\n        {% endif %}\n        {% if needs_granting or needs_revoking %}\n            {% set revoke_statement_list = get_dcl_statement_list(relation, needs_revoking, get_revoke_sql) %}\n            {% set grant_statement_list = get_dcl_statement_list(relation, needs_granting, get_grant_sql) %}\n            {% set dcl_statement_list = revoke_statement_list + grant_statement_list %}\n            {% if dcl_statement_list %}\n                {{ call_dcl_statements(dcl_statement_list) }}\n            {% endif %}\n        {% endif %}\n    {% endif %}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.run_query",
+              "macro.dbt.get_show_grant_sql",
+              "macro.dbt.get_dcl_statement_list",
+              "macro.dbt.call_dcl_statements"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.152139
+        },
+        "macro.dbt.alter_column_comment": {
+          "name": "alter_column_comment",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/adapters/persist_docs.sql",
+          "original_file_path": "macros/adapters/persist_docs.sql",
+          "unique_id": "macro.dbt.alter_column_comment",
+          "macro_sql": "{% macro alter_column_comment(relation, column_dict) -%}\n  {{ return(adapter.dispatch('alter_column_comment', 'dbt')(relation, column_dict)) }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.default__alter_column_comment"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.1528058
+        },
+        "macro.dbt.default__alter_column_comment": {
+          "name": "default__alter_column_comment",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/adapters/persist_docs.sql",
+          "original_file_path": "macros/adapters/persist_docs.sql",
+          "unique_id": "macro.dbt.default__alter_column_comment",
+          "macro_sql": "{% macro default__alter_column_comment(relation, column_dict) -%}\n  {{ exceptions.raise_not_implemented(\n    'alter_column_comment macro not implemented for adapter '+adapter.type()) }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": []
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.152969
+        },
+        "macro.dbt.alter_relation_comment": {
+          "name": "alter_relation_comment",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/adapters/persist_docs.sql",
+          "original_file_path": "macros/adapters/persist_docs.sql",
+          "unique_id": "macro.dbt.alter_relation_comment",
+          "macro_sql": "{% macro alter_relation_comment(relation, relation_comment) -%}\n  {{ return(adapter.dispatch('alter_relation_comment', 'dbt')(relation, relation_comment)) }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.default__alter_relation_comment"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.153198
+        },
+        "macro.dbt.default__alter_relation_comment": {
+          "name": "default__alter_relation_comment",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/adapters/persist_docs.sql",
+          "original_file_path": "macros/adapters/persist_docs.sql",
+          "unique_id": "macro.dbt.default__alter_relation_comment",
+          "macro_sql": "{% macro default__alter_relation_comment(relation, relation_comment) -%}\n  {{ exceptions.raise_not_implemented(\n    'alter_relation_comment macro not implemented for adapter '+adapter.type()) }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": []
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.1533592
+        },
+        "macro.dbt.persist_docs": {
+          "name": "persist_docs",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/adapters/persist_docs.sql",
+          "original_file_path": "macros/adapters/persist_docs.sql",
+          "unique_id": "macro.dbt.persist_docs",
+          "macro_sql": "{% macro persist_docs(relation, model, for_relation=true, for_columns=true) -%}\n  {{ return(adapter.dispatch('persist_docs', 'dbt')(relation, model, for_relation, for_columns)) }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.default__persist_docs"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.153614
+        },
+        "macro.dbt.default__persist_docs": {
+          "name": "default__persist_docs",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/adapters/persist_docs.sql",
+          "original_file_path": "macros/adapters/persist_docs.sql",
+          "unique_id": "macro.dbt.default__persist_docs",
+          "macro_sql": "{% macro default__persist_docs(relation, model, for_relation, for_columns) -%}\n  {% if for_relation and config.persist_relation_docs() and model.description %}\n    {% do run_query(alter_relation_comment(relation, model.description)) %}\n  {% endif %}\n\n  {% if for_columns and config.persist_column_docs() and model.columns %}\n    {% do run_query(alter_column_comment(relation, model.columns)) %}\n  {% endif %}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.run_query",
+              "macro.dbt.alter_relation_comment",
+              "macro.dbt.alter_column_comment"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.1540742
+        },
+        "macro.dbt.get_catalog": {
+          "name": "get_catalog",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/adapters/metadata.sql",
+          "original_file_path": "macros/adapters/metadata.sql",
+          "unique_id": "macro.dbt.get_catalog",
+          "macro_sql": "{% macro get_catalog(information_schema, schemas) -%}\n  {{ return(adapter.dispatch('get_catalog', 'dbt')(information_schema, schemas)) }}\n{%- endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt_duckdb.duckdb__get_catalog"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.155562
+        },
+        "macro.dbt.default__get_catalog": {
+          "name": "default__get_catalog",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/adapters/metadata.sql",
+          "original_file_path": "macros/adapters/metadata.sql",
+          "unique_id": "macro.dbt.default__get_catalog",
+          "macro_sql": "{% macro default__get_catalog(information_schema, schemas) -%}\n\n  {% set typename = adapter.type() %}\n  {% set msg -%}\n    get_catalog not implemented for {{ typename }}\n  {%- endset %}\n\n  {{ exceptions.raise_compiler_error(msg) }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": []
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.155808
+        },
+        "macro.dbt.information_schema_name": {
+          "name": "information_schema_name",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/adapters/metadata.sql",
+          "original_file_path": "macros/adapters/metadata.sql",
+          "unique_id": "macro.dbt.information_schema_name",
+          "macro_sql": "{% macro information_schema_name(database) %}\n  {{ return(adapter.dispatch('information_schema_name', 'dbt')(database)) }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.default__information_schema_name"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.156008
+        },
+        "macro.dbt.default__information_schema_name": {
+          "name": "default__information_schema_name",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/adapters/metadata.sql",
+          "original_file_path": "macros/adapters/metadata.sql",
+          "unique_id": "macro.dbt.default__information_schema_name",
+          "macro_sql": "{% macro default__information_schema_name(database) -%}\n  {%- if database -%}\n    {{ database }}.INFORMATION_SCHEMA\n  {%- else -%}\n    INFORMATION_SCHEMA\n  {%- endif -%}\n{%- endmacro %}",
+          "depends_on": {
+            "macros": []
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.156171
+        },
+        "macro.dbt.list_schemas": {
+          "name": "list_schemas",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/adapters/metadata.sql",
+          "original_file_path": "macros/adapters/metadata.sql",
+          "unique_id": "macro.dbt.list_schemas",
+          "macro_sql": "{% macro list_schemas(database) -%}\n  {{ return(adapter.dispatch('list_schemas', 'dbt')(database)) }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt_duckdb.duckdb__list_schemas"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.1563442
+        },
+        "macro.dbt.default__list_schemas": {
+          "name": "default__list_schemas",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/adapters/metadata.sql",
+          "original_file_path": "macros/adapters/metadata.sql",
+          "unique_id": "macro.dbt.default__list_schemas",
+          "macro_sql": "{% macro default__list_schemas(database) -%}\n  {% set sql %}\n    select distinct schema_name\n    from {{ information_schema_name(database) }}.SCHEMATA\n    where catalog_name ilike '{{ database }}'\n  {% endset %}\n  {{ return(run_query(sql)) }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.information_schema_name",
+              "macro.dbt.run_query"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.156574
+        },
+        "macro.dbt.check_schema_exists": {
+          "name": "check_schema_exists",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/adapters/metadata.sql",
+          "original_file_path": "macros/adapters/metadata.sql",
+          "unique_id": "macro.dbt.check_schema_exists",
+          "macro_sql": "{% macro check_schema_exists(information_schema, schema) -%}\n  {{ return(adapter.dispatch('check_schema_exists', 'dbt')(information_schema, schema)) }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt_duckdb.duckdb__check_schema_exists"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.156766
+        },
+        "macro.dbt.default__check_schema_exists": {
+          "name": "default__check_schema_exists",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/adapters/metadata.sql",
+          "original_file_path": "macros/adapters/metadata.sql",
+          "unique_id": "macro.dbt.default__check_schema_exists",
+          "macro_sql": "{% macro default__check_schema_exists(information_schema, schema) -%}\n  {% set sql -%}\n        select count(*)\n        from {{ information_schema.replace(information_schema_view='SCHEMATA') }}\n        where catalog_name='{{ information_schema.database }}'\n          and schema_name='{{ schema }}'\n  {%- endset %}\n  {{ return(run_query(sql)) }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.replace",
+              "macro.dbt.run_query"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.1570518
+        },
+        "macro.dbt.list_relations_without_caching": {
+          "name": "list_relations_without_caching",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/adapters/metadata.sql",
+          "original_file_path": "macros/adapters/metadata.sql",
+          "unique_id": "macro.dbt.list_relations_without_caching",
+          "macro_sql": "{% macro list_relations_without_caching(schema_relation) %}\n  {{ return(adapter.dispatch('list_relations_without_caching', 'dbt')(schema_relation)) }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt_duckdb.duckdb__list_relations_without_caching"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.157227
+        },
+        "macro.dbt.default__list_relations_without_caching": {
+          "name": "default__list_relations_without_caching",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/adapters/metadata.sql",
+          "original_file_path": "macros/adapters/metadata.sql",
+          "unique_id": "macro.dbt.default__list_relations_without_caching",
+          "macro_sql": "{% macro default__list_relations_without_caching(schema_relation) %}\n  {{ exceptions.raise_not_implemented(\n    'list_relations_without_caching macro not implemented for adapter '+adapter.type()) }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": []
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.1573792
+        },
+        "macro.dbt.get_columns_in_relation": {
+          "name": "get_columns_in_relation",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/adapters/columns.sql",
+          "original_file_path": "macros/adapters/columns.sql",
+          "unique_id": "macro.dbt.get_columns_in_relation",
+          "macro_sql": "{% macro get_columns_in_relation(relation) -%}\n  {{ return(adapter.dispatch('get_columns_in_relation', 'dbt')(relation)) }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt_duckdb.duckdb__get_columns_in_relation"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.159491
+        },
+        "macro.dbt.default__get_columns_in_relation": {
+          "name": "default__get_columns_in_relation",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/adapters/columns.sql",
+          "original_file_path": "macros/adapters/columns.sql",
+          "unique_id": "macro.dbt.default__get_columns_in_relation",
+          "macro_sql": "{% macro default__get_columns_in_relation(relation) -%}\n  {{ exceptions.raise_not_implemented(\n    'get_columns_in_relation macro not implemented for adapter '+adapter.type()) }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": []
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.159711
+        },
+        "macro.dbt.sql_convert_columns_in_relation": {
+          "name": "sql_convert_columns_in_relation",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/adapters/columns.sql",
+          "original_file_path": "macros/adapters/columns.sql",
+          "unique_id": "macro.dbt.sql_convert_columns_in_relation",
+          "macro_sql": "{% macro sql_convert_columns_in_relation(table) -%}\n  {% set columns = [] %}\n  {% for row in table %}\n    {% do columns.append(api.Column(*row)) %}\n  {% endfor %}\n  {{ return(columns) }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": []
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.1600058
+        },
+        "macro.dbt.get_empty_subquery_sql": {
+          "name": "get_empty_subquery_sql",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/adapters/columns.sql",
+          "original_file_path": "macros/adapters/columns.sql",
+          "unique_id": "macro.dbt.get_empty_subquery_sql",
+          "macro_sql": "{% macro get_empty_subquery_sql(select_sql) -%}\n  {{ return(adapter.dispatch('get_empty_subquery_sql', 'dbt')(select_sql)) }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.default__get_empty_subquery_sql"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.160181
+        },
+        "macro.dbt.default__get_empty_subquery_sql": {
+          "name": "default__get_empty_subquery_sql",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/adapters/columns.sql",
+          "original_file_path": "macros/adapters/columns.sql",
+          "unique_id": "macro.dbt.default__get_empty_subquery_sql",
+          "macro_sql": "{% macro default__get_empty_subquery_sql(select_sql) %}\n    select * from (\n        {{ select_sql }}\n    ) as __dbt_sbq\n    where false\n    limit 0\n{% endmacro %}",
+          "depends_on": {
+            "macros": []
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.1602812
+        },
+        "macro.dbt.get_empty_schema_sql": {
+          "name": "get_empty_schema_sql",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/adapters/columns.sql",
+          "original_file_path": "macros/adapters/columns.sql",
+          "unique_id": "macro.dbt.get_empty_schema_sql",
+          "macro_sql": "{% macro get_empty_schema_sql(columns) -%}\n  {{ return(adapter.dispatch('get_empty_schema_sql', 'dbt')(columns)) }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.default__get_empty_schema_sql"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.160449
+        },
+        "macro.dbt.default__get_empty_schema_sql": {
+          "name": "default__get_empty_schema_sql",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/adapters/columns.sql",
+          "original_file_path": "macros/adapters/columns.sql",
+          "unique_id": "macro.dbt.default__get_empty_schema_sql",
+          "macro_sql": "{% macro default__get_empty_schema_sql(columns) %}\n    {%- set col_err = [] -%}\n    select\n    {% for i in columns %}\n      {%- set col = columns[i] -%}\n      {%- if col['data_type'] is not defined -%}\n        {{ col_err.append(col['name']) }}\n      {%- endif -%}\n      cast(null as {{ col['data_type'] }}) as {{ col['name'] }}{{ \", \" if not loop.last }}\n    {%- endfor -%}\n    {%- if (col_err | length) > 0 -%}\n      {{ exceptions.column_type_missing(column_names=col_err) }}\n    {%- endif -%}\n{% endmacro %}",
+          "depends_on": {
+            "macros": []
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.161052
+        },
+        "macro.dbt.get_column_schema_from_query": {
+          "name": "get_column_schema_from_query",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/adapters/columns.sql",
+          "original_file_path": "macros/adapters/columns.sql",
+          "unique_id": "macro.dbt.get_column_schema_from_query",
+          "macro_sql": "{% macro get_column_schema_from_query(select_sql) -%}\n    {% set columns = [] %}\n    {# -- Using an 'empty subquery' here to get the same schema as the given select_sql statement, without necessitating a data scan.#}\n    {% set sql = get_empty_subquery_sql(select_sql) %}\n    {% set column_schema = adapter.get_column_schema_from_query(sql) %}\n    {{ return(column_schema) }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.get_empty_subquery_sql"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.1613472
+        },
+        "macro.dbt.get_columns_in_query": {
+          "name": "get_columns_in_query",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/adapters/columns.sql",
+          "original_file_path": "macros/adapters/columns.sql",
+          "unique_id": "macro.dbt.get_columns_in_query",
+          "macro_sql": "{% macro get_columns_in_query(select_sql) -%}\n  {{ return(adapter.dispatch('get_columns_in_query', 'dbt')(select_sql)) }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.default__get_columns_in_query"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.1615229
+        },
+        "macro.dbt.default__get_columns_in_query": {
+          "name": "default__get_columns_in_query",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/adapters/columns.sql",
+          "original_file_path": "macros/adapters/columns.sql",
+          "unique_id": "macro.dbt.default__get_columns_in_query",
+          "macro_sql": "{% macro default__get_columns_in_query(select_sql) %}\n    {% call statement('get_columns_in_query', fetch_result=True, auto_begin=False) -%}\n        {{ get_empty_subquery_sql(select_sql) }}\n    {% endcall %}\n    {{ return(load_result('get_columns_in_query').table.columns | map(attribute='name') | list) }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.statement",
+              "macro.dbt.get_empty_subquery_sql"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.1618829
+        },
+        "macro.dbt.alter_column_type": {
+          "name": "alter_column_type",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/adapters/columns.sql",
+          "original_file_path": "macros/adapters/columns.sql",
+          "unique_id": "macro.dbt.alter_column_type",
+          "macro_sql": "{% macro alter_column_type(relation, column_name, new_column_type) -%}\n  {{ return(adapter.dispatch('alter_column_type', 'dbt')(relation, column_name, new_column_type)) }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.default__alter_column_type"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.162101
+        },
+        "macro.dbt.default__alter_column_type": {
+          "name": "default__alter_column_type",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/adapters/columns.sql",
+          "original_file_path": "macros/adapters/columns.sql",
+          "unique_id": "macro.dbt.default__alter_column_type",
+          "macro_sql": "{% macro default__alter_column_type(relation, column_name, new_column_type) -%}\n  {#\n    1. Create a new column (w/ temp name and correct type)\n    2. Copy data over to it\n    3. Drop the existing column (cascade!)\n    4. Rename the new column to existing column\n  #}\n  {%- set tmp_column = column_name + \"__dbt_alter\" -%}\n\n  {% call statement('alter_column_type') %}\n    alter table {{ relation }} add column {{ adapter.quote(tmp_column) }} {{ new_column_type }};\n    update {{ relation }} set {{ adapter.quote(tmp_column) }} = {{ adapter.quote(column_name) }};\n    alter table {{ relation }} drop column {{ adapter.quote(column_name) }} cascade;\n    alter table {{ relation }} rename column {{ adapter.quote(tmp_column) }} to {{ adapter.quote(column_name) }}\n  {% endcall %}\n\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.statement"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.162674
+        },
+        "macro.dbt.alter_relation_add_remove_columns": {
+          "name": "alter_relation_add_remove_columns",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/adapters/columns.sql",
+          "original_file_path": "macros/adapters/columns.sql",
+          "unique_id": "macro.dbt.alter_relation_add_remove_columns",
+          "macro_sql": "{% macro alter_relation_add_remove_columns(relation, add_columns = none, remove_columns = none) -%}\n  {{ return(adapter.dispatch('alter_relation_add_remove_columns', 'dbt')(relation, add_columns, remove_columns)) }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.default__alter_relation_add_remove_columns"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.162921
+        },
+        "macro.dbt.default__alter_relation_add_remove_columns": {
+          "name": "default__alter_relation_add_remove_columns",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/adapters/columns.sql",
+          "original_file_path": "macros/adapters/columns.sql",
+          "unique_id": "macro.dbt.default__alter_relation_add_remove_columns",
+          "macro_sql": "{% macro default__alter_relation_add_remove_columns(relation, add_columns, remove_columns) %}\n\n  {% if add_columns is none %}\n    {% set add_columns = [] %}\n  {% endif %}\n  {% if remove_columns is none %}\n    {% set remove_columns = [] %}\n  {% endif %}\n\n  {% set sql -%}\n\n     alter {{ relation.type }} {{ relation }}\n\n            {% for column in add_columns %}\n               add column {{ column.name }} {{ column.data_type }}{{ ',' if not loop.last }}\n            {% endfor %}{{ ',' if add_columns and remove_columns }}\n\n            {% for column in remove_columns %}\n                drop column {{ column.name }}{{ ',' if not loop.last }}\n            {% endfor %}\n\n  {%- endset -%}\n\n  {% do run_query(sql) %}\n\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.run_query"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.163667
+        },
+        "macro.dbt.resolve_model_name": {
+          "name": "resolve_model_name",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/python_model/python.sql",
+          "original_file_path": "macros/python_model/python.sql",
+          "unique_id": "macro.dbt.resolve_model_name",
+          "macro_sql": "{% macro resolve_model_name(input_model_name) %}\n    {{ return(adapter.dispatch('resolve_model_name', 'dbt')(input_model_name)) }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.default__resolve_model_name"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.165334
+        },
+        "macro.dbt.default__resolve_model_name": {
+          "name": "default__resolve_model_name",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/python_model/python.sql",
+          "original_file_path": "macros/python_model/python.sql",
+          "unique_id": "macro.dbt.default__resolve_model_name",
+          "macro_sql": "\n\n{%- macro default__resolve_model_name(input_model_name) -%}\n    {{  input_model_name | string | replace('\"', '\\\"') }}\n{%- endmacro -%}\n\n",
+          "depends_on": {
+            "macros": []
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.165479
+        },
+        "macro.dbt.build_ref_function": {
+          "name": "build_ref_function",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/python_model/python.sql",
+          "original_file_path": "macros/python_model/python.sql",
+          "unique_id": "macro.dbt.build_ref_function",
+          "macro_sql": "{% macro build_ref_function(model) %}\n\n    {%- set ref_dict = {} -%}\n    {%- for _ref in model.refs -%}\n        {% set _ref_args = [_ref.get('package'), _ref['name']] if _ref.get('package') else [_ref['name'],] %}\n        {%- set resolved = ref(*_ref_args, v=_ref.get('version')) -%}\n        {%- if _ref.get('version') -%}\n            {% do _ref_args.extend([\"v\" ~ _ref['version']]) %}\n        {%- endif -%}\n       {%- do ref_dict.update({_ref_args | join('.'): resolve_model_name(resolved)}) -%}\n    {%- endfor -%}\n\ndef ref(*args, **kwargs):\n    refs = {{ ref_dict | tojson }}\n    key = '.'.join(args)\n    version = kwargs.get(\"v\") or kwargs.get(\"version\")\n    if version:\n        key += f\".v{version}\"\n    dbt_load_df_function = kwargs.get(\"dbt_load_df_function\")\n    return dbt_load_df_function(refs[key])\n\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.resolve_model_name"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.166259
+        },
+        "macro.dbt.build_source_function": {
+          "name": "build_source_function",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/python_model/python.sql",
+          "original_file_path": "macros/python_model/python.sql",
+          "unique_id": "macro.dbt.build_source_function",
+          "macro_sql": "{% macro build_source_function(model) %}\n\n    {%- set source_dict = {} -%}\n    {%- for _source in model.sources -%}\n        {%- set resolved = source(*_source) -%}\n        {%- do source_dict.update({_source | join('.'): resolve_model_name(resolved)}) -%}\n    {%- endfor -%}\n\ndef source(*args, dbt_load_df_function):\n    sources = {{ source_dict | tojson }}\n    key = '.'.join(args)\n    return dbt_load_df_function(sources[key])\n\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.resolve_model_name"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.166713
+        },
+        "macro.dbt.build_config_dict": {
+          "name": "build_config_dict",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/python_model/python.sql",
+          "original_file_path": "macros/python_model/python.sql",
+          "unique_id": "macro.dbt.build_config_dict",
+          "macro_sql": "{% macro build_config_dict(model) %}\n    {%- set config_dict = {} -%}\n    {% set config_dbt_used = zip(model.config.config_keys_used, model.config.config_keys_defaults) | list %}\n    {%- for key, default in config_dbt_used -%}\n        {# weird type testing with enum, would be much easier to write this logic in Python! #}\n        {%- if key == \"language\" -%}\n          {%- set value = \"python\" -%}\n        {%- endif -%}\n        {%- set value = model.config.get(key, default) -%}\n        {%- do config_dict.update({key: value}) -%}\n    {%- endfor -%}\nconfig_dict = {{ config_dict }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": []
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.167268
+        },
+        "macro.dbt.py_script_postfix": {
+          "name": "py_script_postfix",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/python_model/python.sql",
+          "original_file_path": "macros/python_model/python.sql",
+          "unique_id": "macro.dbt.py_script_postfix",
+          "macro_sql": "{% macro py_script_postfix(model) %}\n# This part is user provided model code\n# you will need to copy the next section to run the code\n# COMMAND ----------\n# this part is dbt logic for get ref work, do not modify\n\n{{ build_ref_function(model ) }}\n{{ build_source_function(model ) }}\n{{ build_config_dict(model) }}\n\nclass config:\n    def __init__(self, *args, **kwargs):\n        pass\n\n    @staticmethod\n    def get(key, default=None):\n        return config_dict.get(key, default)\n\nclass this:\n    \"\"\"dbt.this() or dbt.this.identifier\"\"\"\n    database = \"{{ this.database }}\"\n    schema = \"{{ this.schema }}\"\n    identifier = \"{{ this.identifier }}\"\n    {% set this_relation_name = resolve_model_name(this) %}\n    def __repr__(self):\n        return '{{ this_relation_name  }}'\n\n\nclass dbtObj:\n    def __init__(self, load_df_function) -> None:\n        self.source = lambda *args: source(*args, dbt_load_df_function=load_df_function)\n        self.ref = lambda *args, **kwargs: ref(*args, **kwargs, dbt_load_df_function=load_df_function)\n        self.config = config\n        self.this = this()\n        self.is_incremental = {{ is_incremental() }}\n\n# COMMAND ----------\n{{py_script_comment()}}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.build_ref_function",
+              "macro.dbt.build_source_function",
+              "macro.dbt.build_config_dict",
+              "macro.dbt.resolve_model_name",
+              "macro.dbt.is_incremental",
+              "macro.dbt.py_script_comment"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.1677508
+        },
+        "macro.dbt.py_script_comment": {
+          "name": "py_script_comment",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/python_model/python.sql",
+          "original_file_path": "macros/python_model/python.sql",
+          "unique_id": "macro.dbt.py_script_comment",
+          "macro_sql": "{%macro py_script_comment()%}\n{%endmacro%}",
+          "depends_on": {
+            "macros": []
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.16782
+        },
+        "macro.dbt.test_unique": {
+          "name": "test_unique",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "tests/generic/builtin.sql",
+          "original_file_path": "tests/generic/builtin.sql",
+          "unique_id": "macro.dbt.test_unique",
+          "macro_sql": "{% test unique(model, column_name) %}\n    {% set macro = adapter.dispatch('test_unique', 'dbt') %}\n    {{ macro(model, column_name) }}\n{% endtest %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.default__test_unique"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.168311
+        },
+        "macro.dbt.test_not_null": {
+          "name": "test_not_null",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "tests/generic/builtin.sql",
+          "original_file_path": "tests/generic/builtin.sql",
+          "unique_id": "macro.dbt.test_not_null",
+          "macro_sql": "{% test not_null(model, column_name) %}\n    {% set macro = adapter.dispatch('test_not_null', 'dbt') %}\n    {{ macro(model, column_name) }}\n{% endtest %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.default__test_not_null"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.168535
+        },
+        "macro.dbt.test_accepted_values": {
+          "name": "test_accepted_values",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "tests/generic/builtin.sql",
+          "original_file_path": "tests/generic/builtin.sql",
+          "unique_id": "macro.dbt.test_accepted_values",
+          "macro_sql": "{% test accepted_values(model, column_name, values, quote=True) %}\n    {% set macro = adapter.dispatch('test_accepted_values', 'dbt') %}\n    {{ macro(model, column_name, values, quote) }}\n{% endtest %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.default__test_accepted_values"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.168813
+        },
+        "macro.dbt.test_relationships": {
+          "name": "test_relationships",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "tests/generic/builtin.sql",
+          "original_file_path": "tests/generic/builtin.sql",
+          "unique_id": "macro.dbt.test_relationships",
+          "macro_sql": "{% test relationships(model, column_name, to, field) %}\n    {% set macro = adapter.dispatch('test_relationships', 'dbt') %}\n    {{ macro(model, column_name, to, field) }}\n{% endtest %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.default__test_relationships"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240826.16908
+        }
+      },
+      "docs": {
+        "doc.jaffle_shop.__overview__": {
+          "name": "__overview__",
+          "resource_type": "doc",
+          "package_name": "jaffle_shop",
+          "path": "overview.md",
+          "original_file_path": "models/overview.md",
+          "unique_id": "doc.jaffle_shop.__overview__",
+          "block_contents": "## Data Documentation for Jaffle Shop\n\n`jaffle_shop` is a fictional ecommerce store.\n\nThis [dbt](https://www.getdbt.com/) project is for testing out code.\n\nThe source code can be found [here](https://github.com/clrcrl/jaffle_shop)."
+        },
+        "doc.jaffle_shop.orders_status": {
+          "name": "orders_status",
+          "resource_type": "doc",
+          "package_name": "jaffle_shop",
+          "path": "marts/docs.md",
+          "original_file_path": "models/marts/docs.md",
+          "unique_id": "doc.jaffle_shop.orders_status",
+          "block_contents": "Orders can be one of the following statuses:\n\n| status         | description                                                                                                            |\n|----------------|------------------------------------------------------------------------------------------------------------------------|\n| placed         | The order has been placed but has not yet left the warehouse                                                           |\n| shipped        | The order has ben shipped to the customer and is currently in transit                                                  |\n| completed      | The order has been received by the customer                                                                            |\n| return_pending | The customer has indicated that they would like to return the order, but it has not yet been received at the warehouse |\n| returned       | The order has been returned by the customer and received at the warehouse                                              |"
+        },
+        "doc.dbt.__overview__": {
+          "name": "__overview__",
+          "resource_type": "doc",
+          "package_name": "dbt",
+          "path": "overview.md",
+          "original_file_path": "docs/overview.md",
+          "unique_id": "doc.dbt.__overview__",
+          "block_contents": "### Welcome!\n\nWelcome to the auto-generated documentation for your dbt project!\n\n### Navigation\n\nYou can use the `Project` and `Database` navigation tabs on the left side of the window to explore the models\nin your project.\n\n#### Project Tab\nThe `Project` tab mirrors the directory structure of your dbt project. In this tab, you can see all of the\nmodels defined in your dbt project, as well as models imported from dbt packages.\n\n#### Database Tab\nThe `Database` tab also exposes your models, but in a format that looks more like a database explorer. This view\nshows relations (tables and views) grouped into database schemas. Note that ephemeral models are _not_ shown\nin this interface, as they do not exist in the database.\n\n### Graph Exploration\nYou can click the blue icon on the bottom-right corner of the page to view the lineage graph of your models.\n\nOn model pages, you'll see the immediate parents and children of the model you're exploring. By clicking the `Expand`\nbutton at the top-right of this lineage pane, you'll be able to see all of the models that are used to build,\nor are built from, the model you're exploring.\n\nOnce expanded, you'll be able to use the `--select` and `--exclude` model selection syntax to filter the\nmodels in the graph. For more information on model selection, check out the [dbt docs](https://docs.getdbt.com/docs/model-selection-syntax).\n\nNote that you can also right-click on models to interactively filter and explore the graph.\n\n---\n\n### More information\n\n- [What is dbt](https://docs.getdbt.com/docs/introduction)?\n- Read the [dbt viewpoint](https://docs.getdbt.com/docs/viewpoint)\n- [Installation](https://docs.getdbt.com/docs/installation)\n- Join the [dbt Community](https://www.getdbt.com/community/) for questions and discussion"
+        }
+      },
+      "exposures": {},
+      "metrics": {
+        "metric.jaffle_shop.expenses": {
+          "name": "expenses",
+          "resource_type": "metric",
+          "package_name": "jaffle_shop",
+          "path": "marts/expenses.yml",
+          "original_file_path": "models/marts/expenses.yml",
+          "unique_id": "metric.jaffle_shop.expenses",
+          "fqn": [
+            "jaffle_shop",
+            "marts",
+            "expenses"
+          ],
+          "description": "The total expenses of our jaffle business",
+          "label": "Expenses",
+          "calculation_method": "sum",
+          "expression": "amount / 4",
+          "filters": [
+            {
+              "field": "status",
+              "operator": "=",
+              "value": "'completed'"
+            }
+          ],
+          "time_grains": [
+            "day",
+            "week",
+            "month",
+            "year"
+          ],
+          "dimensions": [],
+          "timestamp": "order_date",
+          "model": "ref('orders')",
+          "meta": {},
+          "tags": [
+            "piperider"
+          ],
+          "config": {
+            "enabled": true
+          },
+          "unrendered_config": {},
+          "sources": [],
+          "depends_on": {
+            "macros": [],
+            "nodes": [
+              "model.jaffle_shop.orders"
+            ]
+          },
+          "refs": [
+            {
+              "name": "orders"
+            }
+          ],
+          "metrics": [],
+          "created_at": 1687240826.4259121
+        },
+        "metric.jaffle_shop.average_order_amount": {
+          "name": "average_order_amount",
+          "resource_type": "metric",
+          "package_name": "jaffle_shop",
+          "path": "marts/average_order_amount.yml",
+          "original_file_path": "models/marts/average_order_amount.yml",
+          "unique_id": "metric.jaffle_shop.average_order_amount",
+          "fqn": [
+            "jaffle_shop",
+            "marts",
+            "average_order_amount"
+          ],
+          "description": "The average size of a jaffle order",
+          "label": "Average Order Amount",
+          "calculation_method": "average",
+          "expression": "amount",
+          "filters": [],
+          "time_grains": [
+            "day",
+            "week",
+            "month"
+          ],
+          "dimensions": [],
+          "timestamp": "order_date",
+          "model": "ref('orders')",
+          "meta": {},
+          "tags": [
+            "piperider"
+          ],
+          "config": {
+            "enabled": true
+          },
+          "unrendered_config": {},
+          "sources": [],
+          "depends_on": {
+            "macros": [],
+            "nodes": [
+              "model.jaffle_shop.orders"
+            ]
+          },
+          "refs": [
+            {
+              "name": "orders"
+            }
+          ],
+          "metrics": [],
+          "created_at": 1687240826.443954
+        },
+        "metric.jaffle_shop.revenue": {
+          "name": "revenue",
+          "resource_type": "metric",
+          "package_name": "jaffle_shop",
+          "path": "marts/revenue.yml",
+          "original_file_path": "models/marts/revenue.yml",
+          "unique_id": "metric.jaffle_shop.revenue",
+          "fqn": [
+            "jaffle_shop",
+            "marts",
+            "revenue"
+          ],
+          "description": "The total revenue of our jaffle business",
+          "label": "Revenue",
+          "calculation_method": "sum",
+          "expression": "amount",
+          "filters": [
+            {
+              "field": "status",
+              "operator": "=",
+              "value": "'completed'"
+            }
+          ],
+          "time_grains": [
+            "day",
+            "week",
+            "month",
+            "year"
+          ],
+          "dimensions": [],
+          "timestamp": "order_date",
+          "model": "ref('orders')",
+          "meta": {},
+          "tags": [
+            "piperider"
+          ],
+          "config": {
+            "enabled": true
+          },
+          "unrendered_config": {},
+          "sources": [],
+          "depends_on": {
+            "macros": [],
+            "nodes": [
+              "model.jaffle_shop.orders"
+            ]
+          },
+          "refs": [
+            {
+              "name": "orders"
+            }
+          ],
+          "metrics": [],
+          "created_at": 1687240826.446327
+        },
+        "metric.jaffle_shop.profit": {
+          "name": "profit",
+          "resource_type": "metric",
+          "package_name": "jaffle_shop",
+          "path": "marts/profit.yml",
+          "original_file_path": "models/marts/profit.yml",
+          "unique_id": "metric.jaffle_shop.profit",
+          "fqn": [
+            "jaffle_shop",
+            "marts",
+            "profit"
+          ],
+          "description": "The total money we get to take home from our jaffle business",
+          "label": "Profit",
+          "calculation_method": "derived",
+          "expression": "revenue - expenses",
+          "filters": [],
+          "time_grains": [
+            "hour",
+            "day",
+            "week",
+            "month",
+            "year"
+          ],
+          "dimensions": [],
+          "timestamp": "order_date",
+          "meta": {},
+          "tags": [
+            "piperider"
+          ],
+          "config": {
+            "enabled": true
+          },
+          "unrendered_config": {},
+          "sources": [],
+          "depends_on": {
+            "macros": [],
+            "nodes": [
+              "metric.jaffle_shop.revenue",
+              "metric.jaffle_shop.expenses"
+            ]
+          },
+          "refs": [],
+          "metrics": [
+            [
+              "revenue"
+            ],
+            [
+              "expenses"
+            ]
+          ],
+          "created_at": 1687240826.448195
+        }
+      },
+      "groups": {},
+      "selectors": {},
+      "disabled": {},
+      "parent_map": {
+        "model.jaffle_shop.int_order_payments_pivoted": [
+          "model.jaffle_shop.stg_orders",
+          "model.jaffle_shop.stg_payments"
+        ],
+        "model.jaffle_shop.int_customer_order_history_joined": [
+          "model.jaffle_shop.stg_customers",
+          "model.jaffle_shop.stg_orders",
+          "model.jaffle_shop.stg_payments"
+        ],
+        "model.jaffle_shop.stg_customers": [
+          "seed.jaffle_shop.raw_customers"
+        ],
+        "model.jaffle_shop.stg_payments": [
+          "seed.jaffle_shop.raw_payments"
+        ],
+        "model.jaffle_shop.stg_orders": [
+          "seed.jaffle_shop.raw_orders"
+        ],
+        "model.jaffle_shop.stg_statuses": [
+          "seed.jaffle_shop.raw_statuses"
+        ],
+        "model.jaffle_shop.orders": [
+          "model.jaffle_shop.int_customer_order_history_joined",
+          "model.jaffle_shop.int_order_payments_pivoted",
+          "model.jaffle_shop.stg_statuses"
+        ],
+        "seed.jaffle_shop.raw_statuses": [],
+        "seed.jaffle_shop.raw_customers": [],
+        "seed.jaffle_shop.raw_orders": [],
+        "seed.jaffle_shop.raw_payments": [],
+        "test.jaffle_shop.unique_int_customer_order_history_joined_customer_id.995635f7d9": [
+          "model.jaffle_shop.int_customer_order_history_joined"
+        ],
+        "test.jaffle_shop.not_null_int_customer_order_history_joined_customer_id.5eeb8cdf92": [
+          "model.jaffle_shop.int_customer_order_history_joined"
+        ],
+        "test.jaffle_shop.unique_int_order_payments_pivoted_order_id.34a0f3307d": [
+          "model.jaffle_shop.int_order_payments_pivoted"
+        ],
+        "test.jaffle_shop.not_null_int_order_payments_pivoted_order_id.787ba994a8": [
+          "model.jaffle_shop.int_order_payments_pivoted"
+        ],
+        "test.jaffle_shop.not_null_int_order_payments_pivoted_customer_id.3db59c6de4": [
+          "model.jaffle_shop.int_order_payments_pivoted"
+        ],
+        "test.jaffle_shop.relationships_int_order_payments_pivoted_customer_id__customer_id__ref_int_customer_order_history_joined_.654a1aa35d": [
+          "model.jaffle_shop.int_customer_order_history_joined",
+          "model.jaffle_shop.int_order_payments_pivoted"
+        ],
+        "test.jaffle_shop.accepted_values_int_order_payments_pivoted_status__placed__shipped__completed__return_pending__returned.0ccdff53e8": [
+          "model.jaffle_shop.int_order_payments_pivoted"
+        ],
+        "test.jaffle_shop.not_null_int_order_payments_pivoted_amount.b7598e0e3b": [
+          "model.jaffle_shop.int_order_payments_pivoted"
+        ],
+        "test.jaffle_shop.not_null_int_order_payments_pivoted_credit_card_amount.ae9c42d967": [
+          "model.jaffle_shop.int_order_payments_pivoted"
+        ],
+        "test.jaffle_shop.not_null_int_order_payments_pivoted_coupon_amount.2532b538c2": [
+          "model.jaffle_shop.int_order_payments_pivoted"
+        ],
+        "test.jaffle_shop.not_null_int_order_payments_pivoted_bank_transfer_amount.1a9e62933b": [
+          "model.jaffle_shop.int_order_payments_pivoted"
+        ],
+        "test.jaffle_shop.not_null_int_order_payments_pivoted_gift_card_amount.710d789cc0": [
+          "model.jaffle_shop.int_order_payments_pivoted"
+        ],
+        "test.jaffle_shop.unique_stg_customers_customer_id.c7614daada": [
+          "model.jaffle_shop.stg_customers"
+        ],
+        "test.jaffle_shop.not_null_stg_customers_customer_id.e2cfb1f9aa": [
+          "model.jaffle_shop.stg_customers"
+        ],
+        "test.jaffle_shop.unique_stg_orders_order_id.e3b841c71a": [
+          "model.jaffle_shop.stg_orders"
+        ],
+        "test.jaffle_shop.not_null_stg_orders_order_id.81cfe2fe64": [
+          "model.jaffle_shop.stg_orders"
+        ],
+        "test.jaffle_shop.accepted_values_stg_orders_status__placed__shipped__completed__return_pending__returned.080fb20aad": [
+          "model.jaffle_shop.stg_orders"
+        ],
+        "test.jaffle_shop.unique_stg_payments_payment_id.3744510712": [
+          "model.jaffle_shop.stg_payments"
+        ],
+        "test.jaffle_shop.not_null_stg_payments_payment_id.c19cc50075": [
+          "model.jaffle_shop.stg_payments"
+        ],
+        "test.jaffle_shop.accepted_values_stg_payments_payment_method__credit_card__coupon__bank_transfer__gift_card.3c3820f278": [
+          "model.jaffle_shop.stg_payments"
+        ],
+        "test.jaffle_shop.unique_orders_order_id.fed79b3a6e": [
+          "model.jaffle_shop.orders"
+        ],
+        "test.jaffle_shop.not_null_orders_order_id.cf6c17daed": [
+          "model.jaffle_shop.orders"
+        ],
+        "test.jaffle_shop.not_null_orders_customer_id.c5f02694af": [
+          "model.jaffle_shop.orders"
+        ],
+        "test.jaffle_shop.accepted_values_orders_status__placed__shipped__completed__return_pending__returned.be6b5b5ec3": [
+          "model.jaffle_shop.orders"
+        ],
+        "test.jaffle_shop.not_null_orders_amount.106140f9fd": [
+          "model.jaffle_shop.orders"
+        ],
+        "test.jaffle_shop.not_null_orders_credit_card_amount.d3ca593b59": [
+          "model.jaffle_shop.orders"
+        ],
+        "test.jaffle_shop.not_null_orders_coupon_amount.ab90c90625": [
+          "model.jaffle_shop.orders"
+        ],
+        "test.jaffle_shop.not_null_orders_bank_transfer_amount.7743500c49": [
+          "model.jaffle_shop.orders"
+        ],
+        "test.jaffle_shop.not_null_orders_gift_card_amount.413a0d2d7a": [
+          "model.jaffle_shop.orders"
+        ],
+        "metric.jaffle_shop.expenses": [
+          "model.jaffle_shop.orders"
+        ],
+        "metric.jaffle_shop.average_order_amount": [
+          "model.jaffle_shop.orders"
+        ],
+        "metric.jaffle_shop.revenue": [
+          "model.jaffle_shop.orders"
+        ],
+        "metric.jaffle_shop.profit": [
+          "metric.jaffle_shop.expenses",
+          "metric.jaffle_shop.revenue"
+        ]
+      },
+      "child_map": {
+        "model.jaffle_shop.int_order_payments_pivoted": [
+          "model.jaffle_shop.orders",
+          "test.jaffle_shop.accepted_values_int_order_payments_pivoted_status__placed__shipped__completed__return_pending__returned.0ccdff53e8",
+          "test.jaffle_shop.not_null_int_order_payments_pivoted_amount.b7598e0e3b",
+          "test.jaffle_shop.not_null_int_order_payments_pivoted_bank_transfer_amount.1a9e62933b",
+          "test.jaffle_shop.not_null_int_order_payments_pivoted_coupon_amount.2532b538c2",
+          "test.jaffle_shop.not_null_int_order_payments_pivoted_credit_card_amount.ae9c42d967",
+          "test.jaffle_shop.not_null_int_order_payments_pivoted_customer_id.3db59c6de4",
+          "test.jaffle_shop.not_null_int_order_payments_pivoted_gift_card_amount.710d789cc0",
+          "test.jaffle_shop.not_null_int_order_payments_pivoted_order_id.787ba994a8",
+          "test.jaffle_shop.relationships_int_order_payments_pivoted_customer_id__customer_id__ref_int_customer_order_history_joined_.654a1aa35d",
+          "test.jaffle_shop.unique_int_order_payments_pivoted_order_id.34a0f3307d"
+        ],
+        "model.jaffle_shop.int_customer_order_history_joined": [
+          "model.jaffle_shop.orders",
+          "test.jaffle_shop.not_null_int_customer_order_history_joined_customer_id.5eeb8cdf92",
+          "test.jaffle_shop.relationships_int_order_payments_pivoted_customer_id__customer_id__ref_int_customer_order_history_joined_.654a1aa35d",
+          "test.jaffle_shop.unique_int_customer_order_history_joined_customer_id.995635f7d9"
+        ],
+        "model.jaffle_shop.stg_customers": [
+          "model.jaffle_shop.int_customer_order_history_joined",
+          "test.jaffle_shop.not_null_stg_customers_customer_id.e2cfb1f9aa",
+          "test.jaffle_shop.unique_stg_customers_customer_id.c7614daada"
+        ],
+        "model.jaffle_shop.stg_payments": [
+          "model.jaffle_shop.int_customer_order_history_joined",
+          "model.jaffle_shop.int_order_payments_pivoted",
+          "test.jaffle_shop.accepted_values_stg_payments_payment_method__credit_card__coupon__bank_transfer__gift_card.3c3820f278",
+          "test.jaffle_shop.not_null_stg_payments_payment_id.c19cc50075",
+          "test.jaffle_shop.unique_stg_payments_payment_id.3744510712"
+        ],
+        "model.jaffle_shop.stg_orders": [
+          "model.jaffle_shop.int_customer_order_history_joined",
+          "model.jaffle_shop.int_order_payments_pivoted",
+          "test.jaffle_shop.accepted_values_stg_orders_status__placed__shipped__completed__return_pending__returned.080fb20aad",
+          "test.jaffle_shop.not_null_stg_orders_order_id.81cfe2fe64",
+          "test.jaffle_shop.unique_stg_orders_order_id.e3b841c71a"
+        ],
+        "model.jaffle_shop.stg_statuses": [
+          "model.jaffle_shop.orders"
+        ],
+        "model.jaffle_shop.orders": [
+          "metric.jaffle_shop.average_order_amount",
+          "metric.jaffle_shop.expenses",
+          "metric.jaffle_shop.revenue",
+          "test.jaffle_shop.accepted_values_orders_status__placed__shipped__completed__return_pending__returned.be6b5b5ec3",
+          "test.jaffle_shop.not_null_orders_amount.106140f9fd",
+          "test.jaffle_shop.not_null_orders_bank_transfer_amount.7743500c49",
+          "test.jaffle_shop.not_null_orders_coupon_amount.ab90c90625",
+          "test.jaffle_shop.not_null_orders_credit_card_amount.d3ca593b59",
+          "test.jaffle_shop.not_null_orders_customer_id.c5f02694af",
+          "test.jaffle_shop.not_null_orders_gift_card_amount.413a0d2d7a",
+          "test.jaffle_shop.not_null_orders_order_id.cf6c17daed",
+          "test.jaffle_shop.unique_orders_order_id.fed79b3a6e"
+        ],
+        "seed.jaffle_shop.raw_statuses": [
+          "model.jaffle_shop.stg_statuses"
+        ],
+        "seed.jaffle_shop.raw_customers": [
+          "model.jaffle_shop.stg_customers"
+        ],
+        "seed.jaffle_shop.raw_orders": [
+          "model.jaffle_shop.stg_orders"
+        ],
+        "seed.jaffle_shop.raw_payments": [
+          "model.jaffle_shop.stg_payments"
+        ],
+        "test.jaffle_shop.unique_int_customer_order_history_joined_customer_id.995635f7d9": [],
+        "test.jaffle_shop.not_null_int_customer_order_history_joined_customer_id.5eeb8cdf92": [],
+        "test.jaffle_shop.unique_int_order_payments_pivoted_order_id.34a0f3307d": [],
+        "test.jaffle_shop.not_null_int_order_payments_pivoted_order_id.787ba994a8": [],
+        "test.jaffle_shop.not_null_int_order_payments_pivoted_customer_id.3db59c6de4": [],
+        "test.jaffle_shop.relationships_int_order_payments_pivoted_customer_id__customer_id__ref_int_customer_order_history_joined_.654a1aa35d": [],
+        "test.jaffle_shop.accepted_values_int_order_payments_pivoted_status__placed__shipped__completed__return_pending__returned.0ccdff53e8": [],
+        "test.jaffle_shop.not_null_int_order_payments_pivoted_amount.b7598e0e3b": [],
+        "test.jaffle_shop.not_null_int_order_payments_pivoted_credit_card_amount.ae9c42d967": [],
+        "test.jaffle_shop.not_null_int_order_payments_pivoted_coupon_amount.2532b538c2": [],
+        "test.jaffle_shop.not_null_int_order_payments_pivoted_bank_transfer_amount.1a9e62933b": [],
+        "test.jaffle_shop.not_null_int_order_payments_pivoted_gift_card_amount.710d789cc0": [],
+        "test.jaffle_shop.unique_stg_customers_customer_id.c7614daada": [],
+        "test.jaffle_shop.not_null_stg_customers_customer_id.e2cfb1f9aa": [],
+        "test.jaffle_shop.unique_stg_orders_order_id.e3b841c71a": [],
+        "test.jaffle_shop.not_null_stg_orders_order_id.81cfe2fe64": [],
+        "test.jaffle_shop.accepted_values_stg_orders_status__placed__shipped__completed__return_pending__returned.080fb20aad": [],
+        "test.jaffle_shop.unique_stg_payments_payment_id.3744510712": [],
+        "test.jaffle_shop.not_null_stg_payments_payment_id.c19cc50075": [],
+        "test.jaffle_shop.accepted_values_stg_payments_payment_method__credit_card__coupon__bank_transfer__gift_card.3c3820f278": [],
+        "test.jaffle_shop.unique_orders_order_id.fed79b3a6e": [],
+        "test.jaffle_shop.not_null_orders_order_id.cf6c17daed": [],
+        "test.jaffle_shop.not_null_orders_customer_id.c5f02694af": [],
+        "test.jaffle_shop.accepted_values_orders_status__placed__shipped__completed__return_pending__returned.be6b5b5ec3": [],
+        "test.jaffle_shop.not_null_orders_amount.106140f9fd": [],
+        "test.jaffle_shop.not_null_orders_credit_card_amount.d3ca593b59": [],
+        "test.jaffle_shop.not_null_orders_coupon_amount.ab90c90625": [],
+        "test.jaffle_shop.not_null_orders_bank_transfer_amount.7743500c49": [],
+        "test.jaffle_shop.not_null_orders_gift_card_amount.413a0d2d7a": [],
+        "metric.jaffle_shop.expenses": [
+          "metric.jaffle_shop.profit"
+        ],
+        "metric.jaffle_shop.average_order_amount": [],
+        "metric.jaffle_shop.revenue": [
+          "metric.jaffle_shop.profit"
+        ],
+        "metric.jaffle_shop.profit": []
+      },
+      "group_map": {}
+    },
+    "run_results": {
+      "metadata": {
+        "dbt_schema_version": "https://schemas.getdbt.com/dbt/run-results/v4.json",
+        "dbt_version": "1.5.1",
+        "generated_at": "2023-06-20T06:00:27.511024Z",
+        "invocation_id": "68dcc536-79d0-4e08-bec3-e3d2c7680f62",
+        "env": {}
+      },
+      "results": [
+        {
+          "status": "success",
+          "timing": [
+            {
+              "name": "compile",
+              "started_at": "2023-06-20T06:00:26.528113Z",
+              "completed_at": "2023-06-20T06:00:26.528114Z"
+            },
+            {
+              "name": "execute",
+              "started_at": "2023-06-20T06:00:26.528543Z",
+              "completed_at": "2023-06-20T06:00:26.638184Z"
+            }
+          ],
+          "thread_id": "Thread-1 (worker)",
+          "execution_time": 0.11636900901794434,
+          "adapter_response": {
+            "_message": "INSERT 100",
+            "code": "INSERT",
+            "rows_affected": 100
+          },
+          "message": "INSERT 100",
+          "unique_id": "seed.jaffle_shop.raw_customers"
+        },
+        {
+          "status": "success",
+          "timing": [
+            {
+              "name": "compile",
+              "started_at": "2023-06-20T06:00:26.646240Z",
+              "completed_at": "2023-06-20T06:00:26.646241Z"
+            },
+            {
+              "name": "execute",
+              "started_at": "2023-06-20T06:00:26.646693Z",
+              "completed_at": "2023-06-20T06:00:26.740114Z"
+            }
+          ],
+          "thread_id": "Thread-1 (worker)",
+          "execution_time": 0.09899401664733887,
+          "adapter_response": {
+            "_message": "INSERT 99",
+            "code": "INSERT",
+            "rows_affected": 99
+          },
+          "message": "INSERT 99",
+          "unique_id": "seed.jaffle_shop.raw_orders"
+        },
+        {
+          "status": "success",
+          "timing": [
+            {
+              "name": "compile",
+              "started_at": "2023-06-20T06:00:26.746879Z",
+              "completed_at": "2023-06-20T06:00:26.746880Z"
+            },
+            {
+              "name": "execute",
+              "started_at": "2023-06-20T06:00:26.747294Z",
+              "completed_at": "2023-06-20T06:00:26.851464Z"
+            }
+          ],
+          "thread_id": "Thread-1 (worker)",
+          "execution_time": 0.1090090274810791,
+          "adapter_response": {
+            "_message": "INSERT 113",
+            "code": "INSERT",
+            "rows_affected": 113
+          },
+          "message": "INSERT 113",
+          "unique_id": "seed.jaffle_shop.raw_payments"
+        },
+        {
+          "status": "success",
+          "timing": [
+            {
+              "name": "compile",
+              "started_at": "2023-06-20T06:00:26.857541Z",
+              "completed_at": "2023-06-20T06:00:26.857542Z"
+            },
+            {
+              "name": "execute",
+              "started_at": "2023-06-20T06:00:26.857945Z",
+              "completed_at": "2023-06-20T06:00:26.871423Z"
+            }
+          ],
+          "thread_id": "Thread-1 (worker)",
+          "execution_time": 0.01707005500793457,
+          "adapter_response": {
+            "_message": "INSERT 4",
+            "code": "INSERT",
+            "rows_affected": 4
+          },
+          "message": "INSERT 4",
+          "unique_id": "seed.jaffle_shop.raw_statuses"
+        },
+        {
+          "status": "success",
+          "timing": [
+            {
+              "name": "compile",
+              "started_at": "2023-06-20T06:00:26.876396Z",
+              "completed_at": "2023-06-20T06:00:26.878670Z"
+            },
+            {
+              "name": "execute",
+              "started_at": "2023-06-20T06:00:26.879212Z",
+              "completed_at": "2023-06-20T06:00:26.913551Z"
+            }
+          ],
+          "thread_id": "Thread-1 (worker)",
+          "execution_time": 0.03976106643676758,
+          "adapter_response": {
+            "_message": "OK"
+          },
+          "message": "OK",
+          "unique_id": "model.jaffle_shop.stg_customers"
+        },
+        {
+          "status": "success",
+          "timing": [
+            {
+              "name": "compile",
+              "started_at": "2023-06-20T06:00:26.917888Z",
+              "completed_at": "2023-06-20T06:00:26.919602Z"
+            },
+            {
+              "name": "execute",
+              "started_at": "2023-06-20T06:00:26.920069Z",
+              "completed_at": "2023-06-20T06:00:26.936511Z"
+            }
+          ],
+          "thread_id": "Thread-1 (worker)",
+          "execution_time": 0.021069049835205078,
+          "adapter_response": {
+            "_message": "OK"
+          },
+          "message": "OK",
+          "unique_id": "model.jaffle_shop.stg_orders"
+        },
+        {
+          "status": "success",
+          "timing": [
+            {
+              "name": "compile",
+              "started_at": "2023-06-20T06:00:26.940621Z",
+              "completed_at": "2023-06-20T06:00:26.942475Z"
+            },
+            {
+              "name": "execute",
+              "started_at": "2023-06-20T06:00:26.942950Z",
+              "completed_at": "2023-06-20T06:00:26.958072Z"
+            }
+          ],
+          "thread_id": "Thread-1 (worker)",
+          "execution_time": 0.01991105079650879,
+          "adapter_response": {
+            "_message": "OK"
+          },
+          "message": "OK",
+          "unique_id": "model.jaffle_shop.stg_payments"
+        },
+        {
+          "status": "success",
+          "timing": [
+            {
+              "name": "compile",
+              "started_at": "2023-06-20T06:00:26.962248Z",
+              "completed_at": "2023-06-20T06:00:26.963946Z"
+            },
+            {
+              "name": "execute",
+              "started_at": "2023-06-20T06:00:26.964400Z",
+              "completed_at": "2023-06-20T06:00:26.980301Z"
+            }
+          ],
+          "thread_id": "Thread-1 (worker)",
+          "execution_time": 0.02044987678527832,
+          "adapter_response": {
+            "_message": "OK"
+          },
+          "message": "OK",
+          "unique_id": "model.jaffle_shop.stg_statuses"
+        },
+        {
+          "status": "pass",
+          "timing": [
+            {
+              "name": "compile",
+              "started_at": "2023-06-20T06:00:26.984214Z",
+              "completed_at": "2023-06-20T06:00:26.990005Z"
+            },
+            {
+              "name": "execute",
+              "started_at": "2023-06-20T06:00:26.990509Z",
+              "completed_at": "2023-06-20T06:00:27.003649Z"
+            }
+          ],
+          "thread_id": "Thread-1 (worker)",
+          "execution_time": 0.021502971649169922,
+          "adapter_response": {
+            "_message": "OK"
+          },
+          "failures": 0,
+          "unique_id": "test.jaffle_shop.not_null_stg_customers_customer_id.e2cfb1f9aa"
+        },
+        {
+          "status": "pass",
+          "timing": [
+            {
+              "name": "compile",
+              "started_at": "2023-06-20T06:00:27.007135Z",
+              "completed_at": "2023-06-20T06:00:27.011207Z"
+            },
+            {
+              "name": "execute",
+              "started_at": "2023-06-20T06:00:27.011694Z",
+              "completed_at": "2023-06-20T06:00:27.019201Z"
+            }
+          ],
+          "thread_id": "Thread-1 (worker)",
+          "execution_time": 0.01418924331665039,
+          "adapter_response": {
+            "_message": "OK"
+          },
+          "failures": 0,
+          "unique_id": "test.jaffle_shop.unique_stg_customers_customer_id.c7614daada"
+        },
+        {
+          "status": "pass",
+          "timing": [
+            {
+              "name": "compile",
+              "started_at": "2023-06-20T06:00:27.022575Z",
+              "completed_at": "2023-06-20T06:00:27.026702Z"
+            },
+            {
+              "name": "execute",
+              "started_at": "2023-06-20T06:00:27.027232Z",
+              "completed_at": "2023-06-20T06:00:27.035513Z"
+            }
+          ],
+          "thread_id": "Thread-1 (worker)",
+          "execution_time": 0.015168905258178711,
+          "adapter_response": {
+            "_message": "OK"
+          },
+          "failures": 0,
+          "unique_id": "test.jaffle_shop.accepted_values_stg_orders_status__placed__shipped__completed__return_pending__returned.080fb20aad"
+        },
+        {
+          "status": "pass",
+          "timing": [
+            {
+              "name": "compile",
+              "started_at": "2023-06-20T06:00:27.039321Z",
+              "completed_at": "2023-06-20T06:00:27.042172Z"
+            },
+            {
+              "name": "execute",
+              "started_at": "2023-06-20T06:00:27.042668Z",
+              "completed_at": "2023-06-20T06:00:27.050077Z"
+            }
+          ],
+          "thread_id": "Thread-1 (worker)",
+          "execution_time": 0.01304006576538086,
+          "adapter_response": {
+            "_message": "OK"
+          },
+          "failures": 0,
+          "unique_id": "test.jaffle_shop.not_null_stg_orders_order_id.81cfe2fe64"
+        },
+        {
+          "status": "pass",
+          "timing": [
+            {
+              "name": "compile",
+              "started_at": "2023-06-20T06:00:27.053832Z",
+              "completed_at": "2023-06-20T06:00:27.057211Z"
+            },
+            {
+              "name": "execute",
+              "started_at": "2023-06-20T06:00:27.057752Z",
+              "completed_at": "2023-06-20T06:00:27.064647Z"
+            }
+          ],
+          "thread_id": "Thread-1 (worker)",
+          "execution_time": 0.013007879257202148,
+          "adapter_response": {
+            "_message": "OK"
+          },
+          "failures": 0,
+          "unique_id": "test.jaffle_shop.unique_stg_orders_order_id.e3b841c71a"
+        },
+        {
+          "status": "pass",
+          "timing": [
+            {
+              "name": "compile",
+              "started_at": "2023-06-20T06:00:27.068208Z",
+              "completed_at": "2023-06-20T06:00:27.071959Z"
+            },
+            {
+              "name": "execute",
+              "started_at": "2023-06-20T06:00:27.072443Z",
+              "completed_at": "2023-06-20T06:00:27.079760Z"
+            }
+          ],
+          "thread_id": "Thread-1 (worker)",
+          "execution_time": 0.013860702514648438,
+          "adapter_response": {
+            "_message": "OK"
+          },
+          "failures": 0,
+          "unique_id": "test.jaffle_shop.accepted_values_stg_payments_payment_method__credit_card__coupon__bank_transfer__gift_card.3c3820f278"
+        },
+        {
+          "status": "pass",
+          "timing": [
+            {
+              "name": "compile",
+              "started_at": "2023-06-20T06:00:27.083300Z",
+              "completed_at": "2023-06-20T06:00:27.086246Z"
+            },
+            {
+              "name": "execute",
+              "started_at": "2023-06-20T06:00:27.086743Z",
+              "completed_at": "2023-06-20T06:00:27.094086Z"
+            }
+          ],
+          "thread_id": "Thread-1 (worker)",
+          "execution_time": 0.013110876083374023,
+          "adapter_response": {
+            "_message": "OK"
+          },
+          "failures": 0,
+          "unique_id": "test.jaffle_shop.not_null_stg_payments_payment_id.c19cc50075"
+        },
+        {
+          "status": "pass",
+          "timing": [
+            {
+              "name": "compile",
+              "started_at": "2023-06-20T06:00:27.097916Z",
+              "completed_at": "2023-06-20T06:00:27.100842Z"
+            },
+            {
+              "name": "execute",
+              "started_at": "2023-06-20T06:00:27.101322Z",
+              "completed_at": "2023-06-20T06:00:27.108465Z"
+            }
+          ],
+          "thread_id": "Thread-1 (worker)",
+          "execution_time": 0.012841939926147461,
+          "adapter_response": {
+            "_message": "OK"
+          },
+          "failures": 0,
+          "unique_id": "test.jaffle_shop.unique_stg_payments_payment_id.3744510712"
+        },
+        {
+          "status": "success",
+          "timing": [
+            {
+              "name": "compile",
+              "started_at": "2023-06-20T06:00:27.112238Z",
+              "completed_at": "2023-06-20T06:00:27.115403Z"
+            },
+            {
+              "name": "execute",
+              "started_at": "2023-06-20T06:00:27.115882Z",
+              "completed_at": "2023-06-20T06:00:27.148810Z"
+            }
+          ],
+          "thread_id": "Thread-1 (worker)",
+          "execution_time": 0.040032148361206055,
+          "adapter_response": {
+            "_message": "OK"
+          },
+          "message": "OK",
+          "unique_id": "model.jaffle_shop.int_customer_order_history_joined"
+        },
+        {
+          "status": "success",
+          "timing": [
+            {
+              "name": "compile",
+              "started_at": "2023-06-20T06:00:27.154205Z",
+              "completed_at": "2023-06-20T06:00:27.156934Z"
+            },
+            {
+              "name": "execute",
+              "started_at": "2023-06-20T06:00:27.157421Z",
+              "completed_at": "2023-06-20T06:00:27.175518Z"
+            }
+          ],
+          "thread_id": "Thread-1 (worker)",
+          "execution_time": 0.024906158447265625,
+          "adapter_response": {
+            "_message": "OK"
+          },
+          "message": "OK",
+          "unique_id": "model.jaffle_shop.int_order_payments_pivoted"
+        },
+        {
+          "status": "pass",
+          "timing": [
+            {
+              "name": "compile",
+              "started_at": "2023-06-20T06:00:27.180878Z",
+              "completed_at": "2023-06-20T06:00:27.183507Z"
+            },
+            {
+              "name": "execute",
+              "started_at": "2023-06-20T06:00:27.184006Z",
+              "completed_at": "2023-06-20T06:00:27.191059Z"
+            }
+          ],
+          "thread_id": "Thread-1 (worker)",
+          "execution_time": 0.012493133544921875,
+          "adapter_response": {
+            "_message": "OK"
+          },
+          "failures": 0,
+          "unique_id": "test.jaffle_shop.not_null_int_customer_order_history_joined_customer_id.5eeb8cdf92"
+        },
+        {
+          "status": "pass",
+          "timing": [
+            {
+              "name": "compile",
+              "started_at": "2023-06-20T06:00:27.194713Z",
+              "completed_at": "2023-06-20T06:00:27.197517Z"
+            },
+            {
+              "name": "execute",
+              "started_at": "2023-06-20T06:00:27.198018Z",
+              "completed_at": "2023-06-20T06:00:27.205099Z"
+            }
+          ],
+          "thread_id": "Thread-1 (worker)",
+          "execution_time": 0.012713909149169922,
+          "adapter_response": {
+            "_message": "OK"
+          },
+          "failures": 0,
+          "unique_id": "test.jaffle_shop.unique_int_customer_order_history_joined_customer_id.995635f7d9"
+        },
+        {
+          "status": "pass",
+          "timing": [
+            {
+              "name": "compile",
+              "started_at": "2023-06-20T06:00:27.209015Z",
+              "completed_at": "2023-06-20T06:00:27.213557Z"
+            },
+            {
+              "name": "execute",
+              "started_at": "2023-06-20T06:00:27.214093Z",
+              "completed_at": "2023-06-20T06:00:27.221114Z"
+            }
+          ],
+          "thread_id": "Thread-1 (worker)",
+          "execution_time": 0.014431953430175781,
+          "adapter_response": {
+            "_message": "OK"
+          },
+          "failures": 0,
+          "unique_id": "test.jaffle_shop.accepted_values_int_order_payments_pivoted_status__placed__shipped__completed__return_pending__returned.0ccdff53e8"
+        },
+        {
+          "status": "pass",
+          "timing": [
+            {
+              "name": "compile",
+              "started_at": "2023-06-20T06:00:27.224768Z",
+              "completed_at": "2023-06-20T06:00:27.227436Z"
+            },
+            {
+              "name": "execute",
+              "started_at": "2023-06-20T06:00:27.227890Z",
+              "completed_at": "2023-06-20T06:00:27.235318Z"
+            }
+          ],
+          "thread_id": "Thread-1 (worker)",
+          "execution_time": 0.012724876403808594,
+          "adapter_response": {
+            "_message": "OK"
+          },
+          "failures": 0,
+          "unique_id": "test.jaffle_shop.not_null_int_order_payments_pivoted_amount.b7598e0e3b"
+        },
+        {
+          "status": "pass",
+          "timing": [
+            {
+              "name": "compile",
+              "started_at": "2023-06-20T06:00:27.238654Z",
+              "completed_at": "2023-06-20T06:00:27.241272Z"
+            },
+            {
+              "name": "execute",
+              "started_at": "2023-06-20T06:00:27.241809Z",
+              "completed_at": "2023-06-20T06:00:27.248565Z"
+            }
+          ],
+          "thread_id": "Thread-1 (worker)",
+          "execution_time": 0.012054681777954102,
+          "adapter_response": {
+            "_message": "OK"
+          },
+          "failures": 0,
+          "unique_id": "test.jaffle_shop.not_null_int_order_payments_pivoted_bank_transfer_amount.1a9e62933b"
+        },
+        {
+          "status": "pass",
+          "timing": [
+            {
+              "name": "compile",
+              "started_at": "2023-06-20T06:00:27.252086Z",
+              "completed_at": "2023-06-20T06:00:27.255160Z"
+            },
+            {
+              "name": "execute",
+              "started_at": "2023-06-20T06:00:27.255648Z",
+              "completed_at": "2023-06-20T06:00:27.262253Z"
+            }
+          ],
+          "thread_id": "Thread-1 (worker)",
+          "execution_time": 0.012449026107788086,
+          "adapter_response": {
+            "_message": "OK"
+          },
+          "failures": 0,
+          "unique_id": "test.jaffle_shop.not_null_int_order_payments_pivoted_coupon_amount.2532b538c2"
+        },
+        {
+          "status": "pass",
+          "timing": [
+            {
+              "name": "compile",
+              "started_at": "2023-06-20T06:00:27.266022Z",
+              "completed_at": "2023-06-20T06:00:27.268936Z"
+            },
+            {
+              "name": "execute",
+              "started_at": "2023-06-20T06:00:27.269421Z",
+              "completed_at": "2023-06-20T06:00:27.275880Z"
+            }
+          ],
+          "thread_id": "Thread-1 (worker)",
+          "execution_time": 0.012072086334228516,
+          "adapter_response": {
+            "_message": "OK"
+          },
+          "failures": 0,
+          "unique_id": "test.jaffle_shop.not_null_int_order_payments_pivoted_credit_card_amount.ae9c42d967"
+        },
+        {
+          "status": "pass",
+          "timing": [
+            {
+              "name": "compile",
+              "started_at": "2023-06-20T06:00:27.279472Z",
+              "completed_at": "2023-06-20T06:00:27.282623Z"
+            },
+            {
+              "name": "execute",
+              "started_at": "2023-06-20T06:00:27.283151Z",
+              "completed_at": "2023-06-20T06:00:27.290133Z"
+            }
+          ],
+          "thread_id": "Thread-1 (worker)",
+          "execution_time": 0.012980937957763672,
+          "adapter_response": {
+            "_message": "OK"
+          },
+          "failures": 0,
+          "unique_id": "test.jaffle_shop.not_null_int_order_payments_pivoted_customer_id.3db59c6de4"
+        },
+        {
+          "status": "pass",
+          "timing": [
+            {
+              "name": "compile",
+              "started_at": "2023-06-20T06:00:27.293843Z",
+              "completed_at": "2023-06-20T06:00:27.296661Z"
+            },
+            {
+              "name": "execute",
+              "started_at": "2023-06-20T06:00:27.297177Z",
+              "completed_at": "2023-06-20T06:00:27.304790Z"
+            }
+          ],
+          "thread_id": "Thread-1 (worker)",
+          "execution_time": 0.013557910919189453,
+          "adapter_response": {
+            "_message": "OK"
+          },
+          "failures": 0,
+          "unique_id": "test.jaffle_shop.not_null_int_order_payments_pivoted_gift_card_amount.710d789cc0"
+        },
+        {
+          "status": "pass",
+          "timing": [
+            {
+              "name": "compile",
+              "started_at": "2023-06-20T06:00:27.308907Z",
+              "completed_at": "2023-06-20T06:00:27.311859Z"
+            },
+            {
+              "name": "execute",
+              "started_at": "2023-06-20T06:00:27.312329Z",
+              "completed_at": "2023-06-20T06:00:27.319211Z"
+            }
+          ],
+          "thread_id": "Thread-1 (worker)",
+          "execution_time": 0.012573957443237305,
+          "adapter_response": {
+            "_message": "OK"
+          },
+          "failures": 0,
+          "unique_id": "test.jaffle_shop.not_null_int_order_payments_pivoted_order_id.787ba994a8"
+        },
+        {
+          "status": "pass",
+          "timing": [
+            {
+              "name": "compile",
+              "started_at": "2023-06-20T06:00:27.323145Z",
+              "completed_at": "2023-06-20T06:00:27.326946Z"
+            },
+            {
+              "name": "execute",
+              "started_at": "2023-06-20T06:00:27.327452Z",
+              "completed_at": "2023-06-20T06:00:27.334812Z"
+            }
+          ],
+          "thread_id": "Thread-1 (worker)",
+          "execution_time": 0.014199018478393555,
+          "adapter_response": {
+            "_message": "OK"
+          },
+          "failures": 0,
+          "unique_id": "test.jaffle_shop.relationships_int_order_payments_pivoted_customer_id__customer_id__ref_int_customer_order_history_joined_.654a1aa35d"
+        },
+        {
+          "status": "pass",
+          "timing": [
+            {
+              "name": "compile",
+              "started_at": "2023-06-20T06:00:27.338818Z",
+              "completed_at": "2023-06-20T06:00:27.341958Z"
+            },
+            {
+              "name": "execute",
+              "started_at": "2023-06-20T06:00:27.342432Z",
+              "completed_at": "2023-06-20T06:00:27.348974Z"
+            }
+          ],
+          "thread_id": "Thread-1 (worker)",
+          "execution_time": 0.012499094009399414,
+          "adapter_response": {
+            "_message": "OK"
+          },
+          "failures": 0,
+          "unique_id": "test.jaffle_shop.unique_int_order_payments_pivoted_order_id.34a0f3307d"
+        },
+        {
+          "status": "success",
+          "timing": [
+            {
+              "name": "compile",
+              "started_at": "2023-06-20T06:00:27.352912Z",
+              "completed_at": "2023-06-20T06:00:27.355426Z"
+            },
+            {
+              "name": "execute",
+              "started_at": "2023-06-20T06:00:27.355949Z",
+              "completed_at": "2023-06-20T06:00:27.375295Z"
+            }
+          ],
+          "thread_id": "Thread-1 (worker)",
+          "execution_time": 0.027177810668945312,
+          "adapter_response": {
+            "_message": "OK"
+          },
+          "message": "OK",
+          "unique_id": "model.jaffle_shop.orders"
+        },
+        {
+          "status": "pass",
+          "timing": [
+            {
+              "name": "compile",
+              "started_at": "2023-06-20T06:00:27.382097Z",
+              "completed_at": "2023-06-20T06:00:27.386773Z"
+            },
+            {
+              "name": "execute",
+              "started_at": "2023-06-20T06:00:27.387346Z",
+              "completed_at": "2023-06-20T06:00:27.394599Z"
+            }
+          ],
+          "thread_id": "Thread-1 (worker)",
+          "execution_time": 0.014630317687988281,
+          "adapter_response": {
+            "_message": "OK"
+          },
+          "failures": 0,
+          "unique_id": "test.jaffle_shop.accepted_values_orders_status__placed__shipped__completed__return_pending__returned.be6b5b5ec3"
+        },
+        {
+          "status": "pass",
+          "timing": [
+            {
+              "name": "compile",
+              "started_at": "2023-06-20T06:00:27.398112Z",
+              "completed_at": "2023-06-20T06:00:27.401033Z"
+            },
+            {
+              "name": "execute",
+              "started_at": "2023-06-20T06:00:27.401533Z",
+              "completed_at": "2023-06-20T06:00:27.408007Z"
+            }
+          ],
+          "thread_id": "Thread-1 (worker)",
+          "execution_time": 0.012104988098144531,
+          "adapter_response": {
+            "_message": "OK"
+          },
+          "failures": 0,
+          "unique_id": "test.jaffle_shop.not_null_orders_amount.106140f9fd"
+        },
+        {
+          "status": "pass",
+          "timing": [
+            {
+              "name": "compile",
+              "started_at": "2023-06-20T06:00:27.411555Z",
+              "completed_at": "2023-06-20T06:00:27.414406Z"
+            },
+            {
+              "name": "execute",
+              "started_at": "2023-06-20T06:00:27.414900Z",
+              "completed_at": "2023-06-20T06:00:27.421477Z"
+            }
+          ],
+          "thread_id": "Thread-1 (worker)",
+          "execution_time": 0.012016773223876953,
+          "adapter_response": {
+            "_message": "OK"
+          },
+          "failures": 0,
+          "unique_id": "test.jaffle_shop.not_null_orders_bank_transfer_amount.7743500c49"
+        },
+        {
+          "status": "pass",
+          "timing": [
+            {
+              "name": "compile",
+              "started_at": "2023-06-20T06:00:27.424966Z",
+              "completed_at": "2023-06-20T06:00:27.429008Z"
+            },
+            {
+              "name": "execute",
+              "started_at": "2023-06-20T06:00:27.429479Z",
+              "completed_at": "2023-06-20T06:00:27.435902Z"
+            }
+          ],
+          "thread_id": "Thread-1 (worker)",
+          "execution_time": 0.013096332550048828,
+          "adapter_response": {
+            "_message": "OK"
+          },
+          "failures": 0,
+          "unique_id": "test.jaffle_shop.not_null_orders_coupon_amount.ab90c90625"
+        },
+        {
+          "status": "pass",
+          "timing": [
+            {
+              "name": "compile",
+              "started_at": "2023-06-20T06:00:27.439272Z",
+              "completed_at": "2023-06-20T06:00:27.441996Z"
+            },
+            {
+              "name": "execute",
+              "started_at": "2023-06-20T06:00:27.442498Z",
+              "completed_at": "2023-06-20T06:00:27.448903Z"
+            }
+          ],
+          "thread_id": "Thread-1 (worker)",
+          "execution_time": 0.011701107025146484,
+          "adapter_response": {
+            "_message": "OK"
+          },
+          "failures": 0,
+          "unique_id": "test.jaffle_shop.not_null_orders_credit_card_amount.d3ca593b59"
+        },
+        {
+          "status": "pass",
+          "timing": [
+            {
+              "name": "compile",
+              "started_at": "2023-06-20T06:00:27.452166Z",
+              "completed_at": "2023-06-20T06:00:27.454842Z"
+            },
+            {
+              "name": "execute",
+              "started_at": "2023-06-20T06:00:27.455292Z",
+              "completed_at": "2023-06-20T06:00:27.461476Z"
+            }
+          ],
+          "thread_id": "Thread-1 (worker)",
+          "execution_time": 0.011438131332397461,
+          "adapter_response": {
+            "_message": "OK"
+          },
+          "failures": 0,
+          "unique_id": "test.jaffle_shop.not_null_orders_customer_id.c5f02694af"
+        },
+        {
+          "status": "pass",
+          "timing": [
+            {
+              "name": "compile",
+              "started_at": "2023-06-20T06:00:27.465013Z",
+              "completed_at": "2023-06-20T06:00:27.467890Z"
+            },
+            {
+              "name": "execute",
+              "started_at": "2023-06-20T06:00:27.468415Z",
+              "completed_at": "2023-06-20T06:00:27.474979Z"
+            }
+          ],
+          "thread_id": "Thread-1 (worker)",
+          "execution_time": 0.012096166610717773,
+          "adapter_response": {
+            "_message": "OK"
+          },
+          "failures": 0,
+          "unique_id": "test.jaffle_shop.not_null_orders_gift_card_amount.413a0d2d7a"
+        },
+        {
+          "status": "pass",
+          "timing": [
+            {
+              "name": "compile",
+              "started_at": "2023-06-20T06:00:27.478531Z",
+              "completed_at": "2023-06-20T06:00:27.481361Z"
+            },
+            {
+              "name": "execute",
+              "started_at": "2023-06-20T06:00:27.481830Z",
+              "completed_at": "2023-06-20T06:00:27.489312Z"
+            }
+          ],
+          "thread_id": "Thread-1 (worker)",
+          "execution_time": 0.01281881332397461,
+          "adapter_response": {
+            "_message": "OK"
+          },
+          "failures": 0,
+          "unique_id": "test.jaffle_shop.not_null_orders_order_id.cf6c17daed"
+        },
+        {
+          "status": "pass",
+          "timing": [
+            {
+              "name": "compile",
+              "started_at": "2023-06-20T06:00:27.492663Z",
+              "completed_at": "2023-06-20T06:00:27.495535Z"
+            },
+            {
+              "name": "execute",
+              "started_at": "2023-06-20T06:00:27.496011Z",
+              "completed_at": "2023-06-20T06:00:27.502728Z"
+            }
+          ],
+          "thread_id": "Thread-1 (worker)",
+          "execution_time": 0.01222085952758789,
+          "adapter_response": {
+            "_message": "OK"
+          },
+          "failures": 0,
+          "unique_id": "test.jaffle_shop.unique_orders_order_id.fed79b3a6e"
+        }
+      ],
+      "elapsed_time": 1.0353682041168213,
+      "args": {
+        "version_check": true,
+        "resource_types": [],
+        "exclude": [],
+        "partial_parse": true,
+        "favor_state": false,
+        "populate_cache": true,
+        "select": [],
+        "quiet": false,
+        "strict_mode": false,
+        "which": "build",
+        "log_level": "info",
+        "send_anonymous_usage_stats": true,
+        "show": false,
+        "defer": false,
+        "log_format_file": "debug",
+        "write_json": true,
+        "macro_debugging": false,
+        "introspect": true,
+        "print": true,
+        "use_colors_file": true,
+        "project_dir": "/Users/popcorny/Documents/infuseai/repo/jaffle_shop",
+        "indirect_selection": "eager",
+        "log_format": "default",
+        "static_parser": true,
+        "printer_width": 80,
+        "log_path": "/Users/popcorny/Documents/infuseai/repo/jaffle_shop/logs",
+        "log_level_file": "debug",
+        "cache_selected_only": false,
+        "enable_legacy_logger": false,
+        "vars": {},
+        "warn_error_options": {
+          "include": [],
+          "exclude": []
+        },
+        "use_colors": true,
+        "profiles_dir": "/Users/popcorny/Documents/infuseai/repo/jaffle_shop"
+      }
+    }
+  },
+  "id": "837e860cf60a4ad69fcd533d45c35eae",
+  "created_at": "2023-06-20T06:00:35.640298Z",
+  "datasource": {
+    "name": "dev",
+    "type": "duckdb"
+  },
+  "version": "0.28.0.dev",
+  "project_id": "2e470b721f5a4114aa7cf9b73eca760d",
+  "user_id": "14774b4c7d7d414990ec53cf6d35b159",
+  "metadata_version": "1971e39ce02a6dff03c3e9b149d140a4",
+  "cloud": {}
+}

--- a/tests/mock_dbt_data/sc-31587-metrics-input.json
+++ b/tests/mock_dbt_data/sc-31587-metrics-input.json
@@ -1,0 +1,20435 @@
+{
+  "tables": {
+    "int_order_payments_pivoted": {
+      "name": "int_order_payments_pivoted",
+      "row_count": 99,
+      "samples": 99,
+      "samples_p": 1,
+      "col_count": 9,
+      "columns": {
+        "order_id": {
+          "name": "order_id",
+          "type": "integer",
+          "schema_type": "INTEGER",
+          "total": 99,
+          "samples": 99,
+          "samples_p": 1,
+          "non_nulls": 99,
+          "non_nulls_p": 1,
+          "nulls": 0,
+          "nulls_p": 0,
+          "valids": 99,
+          "valids_p": 1,
+          "invalids": 0,
+          "invalids_p": 0,
+          "zeros": 0,
+          "zeros_p": 0,
+          "negatives": 0,
+          "negatives_p": 0,
+          "positives": 99,
+          "positives_p": 1,
+          "distinct": 99,
+          "distinct_p": 1,
+          "min": 1,
+          "max": 99,
+          "sum": 4950,
+          "avg": 50,
+          "stddev": 28.722813232690147,
+          "duplicates": 0,
+          "duplicates_p": 0,
+          "non_duplicates": 99,
+          "non_duplicates_p": 1,
+          "histogram": {
+            "labels": [
+              "1 _ 3",
+              "3 _ 5",
+              "5 _ 7",
+              "7 _ 9",
+              "9 _ 11",
+              "11 _ 13",
+              "13 _ 15",
+              "15 _ 17",
+              "17 _ 19",
+              "19 _ 21",
+              "21 _ 23",
+              "23 _ 25",
+              "25 _ 27",
+              "27 _ 29",
+              "29 _ 31",
+              "31 _ 33",
+              "33 _ 35",
+              "35 _ 37",
+              "37 _ 39",
+              "39 _ 41",
+              "41 _ 43",
+              "43 _ 45",
+              "45 _ 47",
+              "47 _ 49",
+              "49 _ 51",
+              "51 _ 53",
+              "53 _ 55",
+              "55 _ 57",
+              "57 _ 59",
+              "59 _ 61",
+              "61 _ 63",
+              "63 _ 65",
+              "65 _ 67",
+              "67 _ 69",
+              "69 _ 71",
+              "71 _ 73",
+              "73 _ 75",
+              "75 _ 77",
+              "77 _ 79",
+              "79 _ 81",
+              "81 _ 83",
+              "83 _ 85",
+              "85 _ 87",
+              "87 _ 89",
+              "89 _ 91",
+              "91 _ 93",
+              "93 _ 95",
+              "95 _ 97",
+              "97 _ 99",
+              "99 _ 101"
+            ],
+            "counts": [
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              1
+            ],
+            "bin_edges": [
+              1,
+              3,
+              5,
+              7,
+              9,
+              11,
+              13,
+              15,
+              17,
+              19,
+              21,
+              23,
+              25,
+              27,
+              29,
+              31,
+              33,
+              35,
+              37,
+              39,
+              41,
+              43,
+              45,
+              47,
+              49,
+              51,
+              53,
+              55,
+              57,
+              59,
+              61,
+              63,
+              65,
+              67,
+              69,
+              71,
+              73,
+              75,
+              77,
+              79,
+              81,
+              83,
+              85,
+              87,
+              89,
+              91,
+              93,
+              95,
+              97,
+              99,
+              101
+            ]
+          },
+          "p5": 5,
+          "p25": 25,
+          "p50": 50,
+          "p75": 75,
+          "p95": 95,
+          "topk": {
+            "values": [
+              "1",
+              "2",
+              "3",
+              "4",
+              "5",
+              "6",
+              "7",
+              "8",
+              "9",
+              "10",
+              "11",
+              "12",
+              "13",
+              "14",
+              "15",
+              "16",
+              "17",
+              "18",
+              "19",
+              "20",
+              "21",
+              "22",
+              "23",
+              "24",
+              "25",
+              "26",
+              "27",
+              "28",
+              "29",
+              "30",
+              "31",
+              "32",
+              "33",
+              "34",
+              "35",
+              "36",
+              "37",
+              "38",
+              "39",
+              "40",
+              "41",
+              "42",
+              "43",
+              "44",
+              "45",
+              "46",
+              "47",
+              "48",
+              "49",
+              "50"
+            ],
+            "counts": [
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1
+            ]
+          },
+          "profile_duration": "0.03",
+          "elapsed_milli": 33,
+          "description": "This is a unique identifier for an order"
+        },
+        "customer_id": {
+          "name": "customer_id",
+          "type": "integer",
+          "schema_type": "INTEGER",
+          "total": 99,
+          "samples": 99,
+          "samples_p": 1,
+          "non_nulls": 99,
+          "non_nulls_p": 1,
+          "nulls": 0,
+          "nulls_p": 0,
+          "valids": 99,
+          "valids_p": 1,
+          "invalids": 0,
+          "invalids_p": 0,
+          "zeros": 0,
+          "zeros_p": 0,
+          "negatives": 0,
+          "negatives_p": 0,
+          "positives": 99,
+          "positives_p": 1,
+          "distinct": 62,
+          "distinct_p": 0.6262626262626263,
+          "min": 1,
+          "max": 99,
+          "sum": 4777,
+          "avg": 48.25252525252525,
+          "stddev": 27.781341350472967,
+          "duplicates": 66,
+          "duplicates_p": 0.6666666666666666,
+          "non_duplicates": 33,
+          "non_duplicates_p": 0.3333333333333333,
+          "histogram": {
+            "labels": [
+              "1 _ 3",
+              "3 _ 5",
+              "5 _ 7",
+              "7 _ 9",
+              "9 _ 11",
+              "11 _ 13",
+              "13 _ 15",
+              "15 _ 17",
+              "17 _ 19",
+              "19 _ 21",
+              "21 _ 23",
+              "23 _ 25",
+              "25 _ 27",
+              "27 _ 29",
+              "29 _ 31",
+              "31 _ 33",
+              "33 _ 35",
+              "35 _ 37",
+              "37 _ 39",
+              "39 _ 41",
+              "41 _ 43",
+              "43 _ 45",
+              "45 _ 47",
+              "47 _ 49",
+              "49 _ 51",
+              "51 _ 53",
+              "53 _ 55",
+              "55 _ 57",
+              "57 _ 59",
+              "59 _ 61",
+              "61 _ 63",
+              "63 _ 65",
+              "65 _ 67",
+              "67 _ 69",
+              "69 _ 71",
+              "71 _ 73",
+              "73 _ 75",
+              "75 _ 77",
+              "77 _ 79",
+              "79 _ 81",
+              "81 _ 83",
+              "83 _ 85",
+              "85 _ 87",
+              "87 _ 89",
+              "89 _ 91",
+              "91 _ 93",
+              "93 _ 95",
+              "95 _ 97",
+              "97 _ 99",
+              "99 _ 101"
+            ],
+            "counts": [
+              3,
+              3,
+              1,
+              3,
+              1,
+              2,
+              1,
+              1,
+              1,
+              2,
+              4,
+              0,
+              4,
+              3,
+              2,
+              2,
+              2,
+              3,
+              1,
+              2,
+              3,
+              0,
+              2,
+              2,
+              2,
+              4,
+              7,
+              0,
+              2,
+              1,
+              0,
+              4,
+              3,
+              1,
+              4,
+              3,
+              0,
+              1,
+              0,
+              3,
+              0,
+              2,
+              3,
+              1,
+              3,
+              2,
+              3,
+              0,
+              0,
+              2
+            ],
+            "bin_edges": [
+              1,
+              3,
+              5,
+              7,
+              9,
+              11,
+              13,
+              15,
+              17,
+              19,
+              21,
+              23,
+              25,
+              27,
+              29,
+              31,
+              33,
+              35,
+              37,
+              39,
+              41,
+              43,
+              45,
+              47,
+              49,
+              51,
+              53,
+              55,
+              57,
+              59,
+              61,
+              63,
+              65,
+              67,
+              69,
+              71,
+              73,
+              75,
+              77,
+              79,
+              81,
+              83,
+              85,
+              87,
+              89,
+              91,
+              93,
+              95,
+              97,
+              99,
+              101
+            ]
+          },
+          "p5": 3,
+          "p25": 26,
+          "p50": 50,
+          "p75": 70,
+          "p95": 93,
+          "topk": {
+            "values": [
+              "54",
+              "3",
+              "22",
+              "51",
+              "66",
+              "71",
+              "1",
+              "8",
+              "25",
+              "26",
+              "27",
+              "30",
+              "35",
+              "42",
+              "46",
+              "47",
+              "50",
+              "53",
+              "57",
+              "63",
+              "64",
+              "69",
+              "70",
+              "79",
+              "84",
+              "85",
+              "90",
+              "94",
+              "99",
+              "2",
+              "6",
+              "7",
+              "9",
+              "11",
+              "12",
+              "13",
+              "16",
+              "18",
+              "19",
+              "20",
+              "21",
+              "28",
+              "31",
+              "32",
+              "33",
+              "34",
+              "36",
+              "38",
+              "39",
+              "40"
+            ],
+            "counts": [
+              5,
+              3,
+              3,
+              3,
+              3,
+              3,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1
+            ]
+          },
+          "profile_duration": "0.03",
+          "elapsed_milli": 32,
+          "description": "Foreign key to the customers table"
+        },
+        "order_date": {
+          "name": "order_date",
+          "type": "datetime",
+          "schema_type": "DATE",
+          "total": 99,
+          "samples": 99,
+          "samples_p": 1,
+          "non_nulls": 99,
+          "non_nulls_p": 1,
+          "nulls": 0,
+          "nulls_p": 0,
+          "valids": 99,
+          "valids_p": 1,
+          "invalids": 0,
+          "invalids_p": 0,
+          "distinct": 69,
+          "distinct_p": 0.696969696969697,
+          "min": "2023-03-14",
+          "max": "2023-06-20",
+          "duplicates": 53,
+          "duplicates_p": 0.5353535353535354,
+          "non_duplicates": 46,
+          "non_duplicates_p": 0.46464646464646464,
+          "histogram": {
+            "labels": [
+              "2023-03-01 - 2023-04-01",
+              "2023-04-01 - 2023-05-01",
+              "2023-05-01 - 2023-06-01",
+              "2023-06-01 - 2023-07-01"
+            ],
+            "counts": [
+              17,
+              28,
+              31,
+              23
+            ],
+            "bin_edges": [
+              "2023-03-01",
+              "2023-04-01",
+              "2023-05-01",
+              "2023-06-01",
+              "2023-07-01"
+            ]
+          },
+          "profile_duration": "0.02",
+          "elapsed_milli": 18,
+          "description": "Date (UTC) that the order was placed"
+        },
+        "status": {
+          "name": "status",
+          "type": "string",
+          "schema_type": "VARCHAR",
+          "total": 99,
+          "samples": 99,
+          "samples_p": 1,
+          "non_nulls": 99,
+          "non_nulls_p": 1,
+          "nulls": 0,
+          "nulls_p": 0,
+          "valids": 99,
+          "valids_p": 1,
+          "invalids": 0,
+          "invalids_p": 0,
+          "zero_length": 0,
+          "zero_length_p": 0,
+          "non_zero_length": 99,
+          "non_zero_length_p": 1,
+          "distinct": 5,
+          "distinct_p": 0.050505050505050504,
+          "min": 6,
+          "min_length": 6,
+          "max": 14,
+          "max_length": 14,
+          "avg": 8.404040404040405,
+          "avg_length": 8.404040404040405,
+          "stddev": 1.3844559228926323,
+          "stddev_length": 1.3844559228926323,
+          "duplicates": 99,
+          "duplicates_p": 1,
+          "non_duplicates": 0,
+          "non_duplicates_p": 0,
+          "topk": {
+            "values": [
+              "completed",
+              "shipped",
+              "placed",
+              "returned",
+              "return_pending"
+            ],
+            "counts": [
+              67,
+              13,
+              13,
+              4,
+              2
+            ]
+          },
+          "histogram": {
+            "labels": [
+              "6",
+              "7",
+              "8",
+              "9",
+              "10",
+              "11",
+              "12",
+              "13",
+              "14"
+            ],
+            "counts": [
+              13,
+              13,
+              4,
+              67,
+              0,
+              0,
+              0,
+              0,
+              2
+            ],
+            "bin_edges": [
+              6,
+              7,
+              8,
+              9,
+              10,
+              11,
+              12,
+              13,
+              14,
+              15
+            ]
+          },
+          "histogram_length": {
+            "labels": [
+              "6",
+              "7",
+              "8",
+              "9",
+              "10",
+              "11",
+              "12",
+              "13",
+              "14"
+            ],
+            "counts": [
+              13,
+              13,
+              4,
+              67,
+              0,
+              0,
+              0,
+              0,
+              2
+            ],
+            "bin_edges": [
+              6,
+              7,
+              8,
+              9,
+              10,
+              11,
+              12,
+              13,
+              14,
+              15
+            ]
+          },
+          "profile_duration": "0.03",
+          "elapsed_milli": 25,
+          "description": "Orders can be one of the following statuses:\n\n| status         | description                                                                                                            |\n|----------------|------------------------------------------------------------------------------------------------------------------------|\n| placed         | The order has been placed but has not yet left the warehouse                                                           |\n| shipped        | The order has ben shipped to the customer and is currently in transit                                                  |\n| completed      | The order has been received by the customer                                                                            |\n| return_pending | The customer has indicated that they would like to return the order, but it has not yet been received at the warehouse |\n| returned       | The order has been returned by the customer and received at the warehouse                                              |"
+        },
+        "credit_card_amount": {
+          "name": "credit_card_amount",
+          "type": "integer",
+          "schema_type": "BIGINT",
+          "total": 99,
+          "samples": 99,
+          "samples_p": 1,
+          "non_nulls": 99,
+          "non_nulls_p": 1,
+          "nulls": 0,
+          "nulls_p": 0,
+          "valids": 99,
+          "valids_p": 1,
+          "invalids": 0,
+          "invalids_p": 0,
+          "zeros": 50,
+          "zeros_p": 0.5050505050505051,
+          "negatives": 0,
+          "negatives_p": 0,
+          "positives": 49,
+          "positives_p": 0.494949494949495,
+          "distinct": 25,
+          "distinct_p": 0.25252525252525254,
+          "min": 0,
+          "max": 30,
+          "sum": 871,
+          "avg": 8.797979797979798,
+          "stddev": 10.95908885492767,
+          "duplicates": 91,
+          "duplicates_p": 0.9191919191919192,
+          "non_duplicates": 8,
+          "non_duplicates_p": 0.08080808080808081,
+          "histogram": {
+            "labels": [
+              "0",
+              "1",
+              "2",
+              "3",
+              "4",
+              "5",
+              "6",
+              "7",
+              "8",
+              "9",
+              "10",
+              "11",
+              "12",
+              "13",
+              "14",
+              "15",
+              "16",
+              "17",
+              "18",
+              "19",
+              "20",
+              "21",
+              "22",
+              "23",
+              "24",
+              "25",
+              "26",
+              "27",
+              "28",
+              "29",
+              "30"
+            ],
+            "counts": [
+              50,
+              2,
+              0,
+              2,
+              2,
+              2,
+              1,
+              0,
+              1,
+              0,
+              2,
+              0,
+              2,
+              2,
+              1,
+              2,
+              2,
+              1,
+              1,
+              4,
+              1,
+              0,
+              3,
+              3,
+              1,
+              0,
+              3,
+              2,
+              1,
+              5,
+              3
+            ],
+            "bin_edges": [
+              0,
+              1,
+              2,
+              3,
+              4,
+              5,
+              6,
+              7,
+              8,
+              9,
+              10,
+              11,
+              12,
+              13,
+              14,
+              15,
+              16,
+              17,
+              18,
+              19,
+              20,
+              21,
+              22,
+              23,
+              24,
+              25,
+              26,
+              27,
+              28,
+              29,
+              30,
+              31
+            ]
+          },
+          "p5": 0,
+          "p25": 0,
+          "p50": 0,
+          "p75": 19,
+          "p95": 29,
+          "topk": {
+            "values": [
+              "0",
+              "29",
+              "19",
+              "22",
+              "23",
+              "26",
+              "30",
+              "1",
+              "3",
+              "4",
+              "5",
+              "10",
+              "12",
+              "13",
+              "15",
+              "16",
+              "27",
+              "6",
+              "8",
+              "14",
+              "17",
+              "18",
+              "20",
+              "24",
+              "28"
+            ],
+            "counts": [
+              50,
+              5,
+              4,
+              3,
+              3,
+              3,
+              3,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1
+            ]
+          },
+          "profile_duration": "0.04",
+          "elapsed_milli": 35,
+          "description": "Amount of the order (AUD) paid for by credit card"
+        },
+        "coupon_amount": {
+          "name": "coupon_amount",
+          "type": "integer",
+          "schema_type": "BIGINT",
+          "total": 99,
+          "samples": 99,
+          "samples_p": 1,
+          "non_nulls": 99,
+          "non_nulls_p": 1,
+          "nulls": 0,
+          "nulls_p": 0,
+          "valids": 99,
+          "valids_p": 1,
+          "invalids": 0,
+          "invalids_p": 0,
+          "zeros": 86,
+          "zeros_p": 0.8686868686868687,
+          "negatives": 0,
+          "negatives_p": 0,
+          "positives": 13,
+          "positives_p": 0.13131313131313133,
+          "distinct": 12,
+          "distinct_p": 0.12121212121212122,
+          "min": 0,
+          "max": 26,
+          "sum": 185,
+          "avg": 1.8686868686868687,
+          "stddev": 5.955012405351227,
+          "duplicates": 89,
+          "duplicates_p": 0.898989898989899,
+          "non_duplicates": 10,
+          "non_duplicates_p": 0.10101010101010101,
+          "histogram": {
+            "labels": [
+              "0",
+              "1",
+              "2",
+              "3",
+              "4",
+              "5",
+              "6",
+              "7",
+              "8",
+              "9",
+              "10",
+              "11",
+              "12",
+              "13",
+              "14",
+              "15",
+              "16",
+              "17",
+              "18",
+              "19",
+              "20",
+              "21",
+              "22",
+              "23",
+              "24",
+              "25",
+              "26"
+            ],
+            "counts": [
+              86,
+              1,
+              3,
+              0,
+              0,
+              0,
+              0,
+              1,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              1,
+              1,
+              1,
+              0,
+              0,
+              0,
+              1,
+              1,
+              1,
+              1,
+              1
+            ],
+            "bin_edges": [
+              0,
+              1,
+              2,
+              3,
+              4,
+              5,
+              6,
+              7,
+              8,
+              9,
+              10,
+              11,
+              12,
+              13,
+              14,
+              15,
+              16,
+              17,
+              18,
+              19,
+              20,
+              21,
+              22,
+              23,
+              24,
+              25,
+              26,
+              27
+            ]
+          },
+          "p5": 0,
+          "p25": 0,
+          "p50": 0,
+          "p75": 0,
+          "p95": 20,
+          "topk": {
+            "values": [
+              "0",
+              "2",
+              "1",
+              "7",
+              "16",
+              "17",
+              "18",
+              "22",
+              "23",
+              "24",
+              "25",
+              "26"
+            ],
+            "counts": [
+              86,
+              3,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1
+            ]
+          },
+          "profile_duration": "0.04",
+          "elapsed_milli": 35,
+          "description": "Amount of the order (AUD) paid for by coupon"
+        },
+        "bank_transfer_amount": {
+          "name": "bank_transfer_amount",
+          "type": "integer",
+          "schema_type": "BIGINT",
+          "total": 99,
+          "samples": 99,
+          "samples_p": 1,
+          "non_nulls": 99,
+          "non_nulls_p": 1,
+          "nulls": 0,
+          "nulls_p": 0,
+          "valids": 99,
+          "valids_p": 1,
+          "invalids": 0,
+          "invalids_p": 0,
+          "zeros": 67,
+          "zeros_p": 0.6767676767676768,
+          "negatives": 0,
+          "negatives_p": 0,
+          "positives": 32,
+          "positives_p": 0.32323232323232326,
+          "distinct": 19,
+          "distinct_p": 0.1919191919191919,
+          "min": 0,
+          "max": 26,
+          "sum": 411,
+          "avg": 4.151515151515151,
+          "stddev": 7.420825132023677,
+          "duplicates": 89,
+          "duplicates_p": 0.898989898989899,
+          "non_duplicates": 10,
+          "non_duplicates_p": 0.10101010101010101,
+          "histogram": {
+            "labels": [
+              "0",
+              "1",
+              "2",
+              "3",
+              "4",
+              "5",
+              "6",
+              "7",
+              "8",
+              "9",
+              "10",
+              "11",
+              "12",
+              "13",
+              "14",
+              "15",
+              "16",
+              "17",
+              "18",
+              "19",
+              "20",
+              "21",
+              "22",
+              "23",
+              "24",
+              "25",
+              "26"
+            ],
+            "counts": [
+              67,
+              0,
+              3,
+              3,
+              1,
+              1,
+              0,
+              0,
+              3,
+              1,
+              1,
+              1,
+              1,
+              0,
+              2,
+              4,
+              1,
+              2,
+              0,
+              2,
+              1,
+              0,
+              1,
+              0,
+              0,
+              1,
+              3
+            ],
+            "bin_edges": [
+              0,
+              1,
+              2,
+              3,
+              4,
+              5,
+              6,
+              7,
+              8,
+              9,
+              10,
+              11,
+              12,
+              13,
+              14,
+              15,
+              16,
+              17,
+              18,
+              19,
+              20,
+              21,
+              22,
+              23,
+              24,
+              25,
+              26,
+              27
+            ]
+          },
+          "p5": 0,
+          "p25": 0,
+          "p50": 0,
+          "p75": 5,
+          "p95": 21,
+          "topk": {
+            "values": [
+              "0",
+              "15",
+              "2",
+              "3",
+              "8",
+              "26",
+              "14",
+              "17",
+              "19",
+              "4",
+              "5",
+              "9",
+              "10",
+              "11",
+              "12",
+              "16",
+              "20",
+              "22",
+              "25"
+            ],
+            "counts": [
+              67,
+              4,
+              3,
+              3,
+              3,
+              3,
+              2,
+              2,
+              2,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1
+            ]
+          },
+          "profile_duration": "0.04",
+          "elapsed_milli": 40,
+          "description": "Amount of the order (AUD) paid for by bank transfer"
+        },
+        "gift_card_amount": {
+          "name": "gift_card_amount",
+          "type": "integer",
+          "schema_type": "BIGINT",
+          "total": 99,
+          "samples": 99,
+          "samples_p": 1,
+          "non_nulls": 99,
+          "non_nulls_p": 1,
+          "nulls": 0,
+          "nulls_p": 0,
+          "valids": 99,
+          "valids_p": 1,
+          "invalids": 0,
+          "invalids_p": 0,
+          "zeros": 87,
+          "zeros_p": 0.8787878787878788,
+          "negatives": 0,
+          "negatives_p": 0,
+          "positives": 12,
+          "positives_p": 0.12121212121212122,
+          "distinct": 11,
+          "distinct_p": 0.1111111111111111,
+          "min": 0,
+          "max": 30,
+          "sum": 205,
+          "avg": 2.0707070707070705,
+          "stddev": 6.392362351566517,
+          "duplicates": 91,
+          "duplicates_p": 0.9191919191919192,
+          "non_duplicates": 8,
+          "non_duplicates_p": 0.08080808080808081,
+          "histogram": {
+            "labels": [
+              "0",
+              "1",
+              "2",
+              "3",
+              "4",
+              "5",
+              "6",
+              "7",
+              "8",
+              "9",
+              "10",
+              "11",
+              "12",
+              "13",
+              "14",
+              "15",
+              "16",
+              "17",
+              "18",
+              "19",
+              "20",
+              "21",
+              "22",
+              "23",
+              "24",
+              "25",
+              "26",
+              "27",
+              "28",
+              "29",
+              "30"
+            ],
+            "counts": [
+              87,
+              0,
+              0,
+              1,
+              0,
+              0,
+              2,
+              0,
+              0,
+              0,
+              0,
+              1,
+              0,
+              0,
+              1,
+              0,
+              0,
+              1,
+              1,
+              0,
+              0,
+              0,
+              0,
+              2,
+              0,
+              0,
+              1,
+              0,
+              1,
+              0,
+              1
+            ],
+            "bin_edges": [
+              0,
+              1,
+              2,
+              3,
+              4,
+              5,
+              6,
+              7,
+              8,
+              9,
+              10,
+              11,
+              12,
+              13,
+              14,
+              15,
+              16,
+              17,
+              18,
+              19,
+              20,
+              21,
+              22,
+              23,
+              24,
+              25,
+              26,
+              27,
+              28,
+              29,
+              30,
+              31
+            ]
+          },
+          "p5": 0,
+          "p25": 0,
+          "p50": 0,
+          "p75": 0,
+          "p95": 21,
+          "topk": {
+            "values": [
+              "0",
+              "6",
+              "23",
+              "3",
+              "11",
+              "14",
+              "17",
+              "18",
+              "26",
+              "28",
+              "30"
+            ],
+            "counts": [
+              87,
+              2,
+              2,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1
+            ]
+          },
+          "profile_duration": "0.04",
+          "elapsed_milli": 43,
+          "description": "Amount of the order (AUD) paid for by gift card"
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "schema_type": "BIGINT",
+          "total": 99,
+          "samples": 99,
+          "samples_p": 1,
+          "non_nulls": 99,
+          "non_nulls_p": 1,
+          "nulls": 0,
+          "nulls_p": 0,
+          "valids": 99,
+          "valids_p": 1,
+          "invalids": 0,
+          "invalids_p": 0,
+          "zeros": 1,
+          "zeros_p": 0.010101010101010102,
+          "negatives": 0,
+          "negatives_p": 0,
+          "positives": 98,
+          "positives_p": 0.98989898989899,
+          "distinct": 32,
+          "distinct_p": 0.32323232323232326,
+          "min": 0,
+          "max": 58,
+          "sum": 1672,
+          "avg": 16.88888888888889,
+          "stddev": 10.736062525374603,
+          "duplicates": 91,
+          "duplicates_p": 0.9191919191919192,
+          "non_duplicates": 8,
+          "non_duplicates_p": 0.08080808080808081,
+          "histogram": {
+            "labels": [
+              "0 _ 2",
+              "2 _ 4",
+              "4 _ 6",
+              "6 _ 8",
+              "8 _ 10",
+              "10 _ 12",
+              "12 _ 14",
+              "14 _ 16",
+              "16 _ 18",
+              "18 _ 20",
+              "20 _ 22",
+              "22 _ 24",
+              "24 _ 26",
+              "26 _ 28",
+              "28 _ 30",
+              "30 _ 32",
+              "32 _ 34",
+              "34 _ 36",
+              "36 _ 38",
+              "38 _ 40",
+              "40 _ 42",
+              "42 _ 44",
+              "44 _ 46",
+              "46 _ 48",
+              "48 _ 50",
+              "50 _ 52",
+              "52 _ 54",
+              "54 _ 56",
+              "56 _ 58",
+              "58 _ 60"
+            ],
+            "counts": [
+              4,
+              11,
+              4,
+              3,
+              5,
+              4,
+              5,
+              8,
+              9,
+              7,
+              1,
+              11,
+              5,
+              9,
+              8,
+              3,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              1,
+              1
+            ],
+            "bin_edges": [
+              0,
+              2,
+              4,
+              6,
+              8,
+              10,
+              12,
+              14,
+              16,
+              18,
+              20,
+              22,
+              24,
+              26,
+              28,
+              30,
+              32,
+              34,
+              36,
+              38,
+              40,
+              42,
+              44,
+              46,
+              48,
+              50,
+              52,
+              54,
+              56,
+              58,
+              60
+            ]
+          },
+          "p5": 2,
+          "p25": 8,
+          "p50": 17,
+          "p75": 24,
+          "p95": 30,
+          "topk": {
+            "values": [
+              "23",
+              "26",
+              "3",
+              "17",
+              "19",
+              "29",
+              "2",
+              "15",
+              "8",
+              "22",
+              "1",
+              "10",
+              "12",
+              "14",
+              "16",
+              "24",
+              "30",
+              "4",
+              "5",
+              "6",
+              "13",
+              "25",
+              "27",
+              "28",
+              "0",
+              "7",
+              "9",
+              "11",
+              "18",
+              "20",
+              "56",
+              "58"
+            ],
+            "counts": [
+              7,
+              7,
+              6,
+              6,
+              6,
+              6,
+              5,
+              5,
+              4,
+              4,
+              3,
+              3,
+              3,
+              3,
+              3,
+              3,
+              3,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1
+            ]
+          },
+          "profile_duration": "0.04",
+          "elapsed_milli": 43,
+          "description": "Total amount (AUD) of the order"
+        }
+      },
+      "profile_duration": "0.04",
+      "elapsed_milli": 43,
+      "description": "This table has basic information about orders, as well as some derived facts based on payments"
+    },
+    "int_customer_order_history_joined": {
+      "name": "int_customer_order_history_joined",
+      "row_count": 100,
+      "samples": 100,
+      "samples_p": 1,
+      "col_count": 7,
+      "columns": {
+        "customer_id": {
+          "name": "customer_id",
+          "type": "integer",
+          "schema_type": "INTEGER",
+          "total": 100,
+          "samples": 100,
+          "samples_p": 1,
+          "non_nulls": 100,
+          "non_nulls_p": 1,
+          "nulls": 0,
+          "nulls_p": 0,
+          "valids": 100,
+          "valids_p": 1,
+          "invalids": 0,
+          "invalids_p": 0,
+          "zeros": 0,
+          "zeros_p": 0,
+          "negatives": 0,
+          "negatives_p": 0,
+          "positives": 100,
+          "positives_p": 1,
+          "distinct": 100,
+          "distinct_p": 1,
+          "min": 1,
+          "max": 100,
+          "sum": 5050,
+          "avg": 50.5,
+          "stddev": 29.011491975882013,
+          "duplicates": 0,
+          "duplicates_p": 0,
+          "non_duplicates": 100,
+          "non_duplicates_p": 1,
+          "histogram": {
+            "labels": [
+              "1 _ 3",
+              "3 _ 5",
+              "5 _ 7",
+              "7 _ 9",
+              "9 _ 11",
+              "11 _ 13",
+              "13 _ 15",
+              "15 _ 17",
+              "17 _ 19",
+              "19 _ 21",
+              "21 _ 23",
+              "23 _ 25",
+              "25 _ 27",
+              "27 _ 29",
+              "29 _ 31",
+              "31 _ 33",
+              "33 _ 35",
+              "35 _ 37",
+              "37 _ 39",
+              "39 _ 41",
+              "41 _ 43",
+              "43 _ 45",
+              "45 _ 47",
+              "47 _ 49",
+              "49 _ 51",
+              "51 _ 53",
+              "53 _ 55",
+              "55 _ 57",
+              "57 _ 59",
+              "59 _ 61",
+              "61 _ 63",
+              "63 _ 65",
+              "65 _ 67",
+              "67 _ 69",
+              "69 _ 71",
+              "71 _ 73",
+              "73 _ 75",
+              "75 _ 77",
+              "77 _ 79",
+              "79 _ 81",
+              "81 _ 83",
+              "83 _ 85",
+              "85 _ 87",
+              "87 _ 89",
+              "89 _ 91",
+              "91 _ 93",
+              "93 _ 95",
+              "95 _ 97",
+              "97 _ 99",
+              "99 _ 101"
+            ],
+            "counts": [
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2
+            ],
+            "bin_edges": [
+              1,
+              3,
+              5,
+              7,
+              9,
+              11,
+              13,
+              15,
+              17,
+              19,
+              21,
+              23,
+              25,
+              27,
+              29,
+              31,
+              33,
+              35,
+              37,
+              39,
+              41,
+              43,
+              45,
+              47,
+              49,
+              51,
+              53,
+              55,
+              57,
+              59,
+              61,
+              63,
+              65,
+              67,
+              69,
+              71,
+              73,
+              75,
+              77,
+              79,
+              81,
+              83,
+              85,
+              87,
+              89,
+              91,
+              93,
+              95,
+              97,
+              99,
+              101
+            ]
+          },
+          "p5": 6,
+          "p25": 26,
+          "p50": 50,
+          "p75": 76,
+          "p95": 95,
+          "topk": {
+            "values": [
+              "1",
+              "2",
+              "3",
+              "4",
+              "5",
+              "6",
+              "7",
+              "8",
+              "9",
+              "10",
+              "11",
+              "12",
+              "13",
+              "14",
+              "15",
+              "16",
+              "17",
+              "18",
+              "19",
+              "20",
+              "21",
+              "22",
+              "23",
+              "24",
+              "25",
+              "26",
+              "27",
+              "28",
+              "29",
+              "30",
+              "31",
+              "32",
+              "33",
+              "34",
+              "35",
+              "36",
+              "37",
+              "38",
+              "39",
+              "40",
+              "41",
+              "42",
+              "43",
+              "44",
+              "45",
+              "46",
+              "47",
+              "48",
+              "49",
+              "50"
+            ],
+            "counts": [
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1
+            ]
+          },
+          "profile_duration": "0.02",
+          "elapsed_milli": 24,
+          "description": "This is a unique identifier for a customer"
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "string",
+          "schema_type": "VARCHAR",
+          "total": 100,
+          "samples": 100,
+          "samples_p": 1,
+          "non_nulls": 100,
+          "non_nulls_p": 1,
+          "nulls": 0,
+          "nulls_p": 0,
+          "valids": 100,
+          "valids_p": 1,
+          "invalids": 0,
+          "invalids_p": 0,
+          "zero_length": 0,
+          "zero_length_p": 0,
+          "non_zero_length": 100,
+          "non_zero_length_p": 1,
+          "distinct": 79,
+          "distinct_p": 0.79,
+          "min": 3,
+          "min_length": 3,
+          "max": 10,
+          "max_length": 10,
+          "avg": 5.86,
+          "avg_length": 5.86,
+          "stddev": 1.5571276327412809,
+          "stddev_length": 1.5571276327412809,
+          "duplicates": 40,
+          "duplicates_p": 0.4,
+          "non_duplicates": 60,
+          "non_duplicates_p": 0.6,
+          "topk": {
+            "values": [
+              "Adam",
+              "Shirley",
+              "Michael",
+              "Kathleen",
+              "Jennifer",
+              "Virginia",
+              "Willie",
+              "Benjamin",
+              "Lisa",
+              "Christina",
+              "Jane",
+              "Katherine",
+              "Norma",
+              "Anne",
+              "Paul",
+              "David",
+              "Phillip",
+              "Kathryn",
+              "Harry",
+              "Shawn",
+              "Sarah",
+              "Martin",
+              "Frank",
+              "Fred",
+              "Amy",
+              "Amanda",
+              "Johnny",
+              "Anna",
+              "Sean",
+              "Victor",
+              "Aaron",
+              "Thomas",
+              "Sara",
+              "Harold",
+              "Dennis",
+              "Louise",
+              "Maria",
+              "Diana",
+              "Marie",
+              "Howard",
+              "Laura",
+              "Rose",
+              "Edward",
+              "Jesse",
+              "Janet",
+              "Helen",
+              "Gerald",
+              "Barbara",
+              "Jack",
+              "Theresa"
+            ],
+            "counts": [
+              3,
+              3,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1
+            ]
+          },
+          "histogram": {
+            "labels": [
+              "3",
+              "4",
+              "5",
+              "6",
+              "7",
+              "8",
+              "9",
+              "10"
+            ],
+            "counts": [
+              1,
+              22,
+              24,
+              20,
+              16,
+              11,
+              5,
+              1
+            ],
+            "bin_edges": [
+              3,
+              4,
+              5,
+              6,
+              7,
+              8,
+              9,
+              10,
+              11
+            ]
+          },
+          "histogram_length": {
+            "labels": [
+              "3",
+              "4",
+              "5",
+              "6",
+              "7",
+              "8",
+              "9",
+              "10"
+            ],
+            "counts": [
+              1,
+              22,
+              24,
+              20,
+              16,
+              11,
+              5,
+              1
+            ],
+            "bin_edges": [
+              3,
+              4,
+              5,
+              6,
+              7,
+              8,
+              9,
+              10,
+              11
+            ]
+          },
+          "profile_duration": "0.02",
+          "elapsed_milli": 18,
+          "description": "Customer's first name. PII."
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "string",
+          "schema_type": "VARCHAR",
+          "total": 100,
+          "samples": 100,
+          "samples_p": 1,
+          "non_nulls": 100,
+          "non_nulls_p": 1,
+          "nulls": 0,
+          "nulls_p": 0,
+          "valids": 100,
+          "valids_p": 1,
+          "invalids": 0,
+          "invalids_p": 0,
+          "zero_length": 0,
+          "zero_length_p": 0,
+          "non_zero_length": 100,
+          "non_zero_length_p": 1,
+          "distinct": 19,
+          "distinct_p": 0.19,
+          "min": 2,
+          "min_length": 2,
+          "max": 2,
+          "max_length": 2,
+          "avg": 2,
+          "avg_length": 2,
+          "stddev": 0,
+          "stddev_length": 0,
+          "duplicates": 98,
+          "duplicates_p": 0.98,
+          "non_duplicates": 2,
+          "non_duplicates_p": 0.02,
+          "topk": {
+            "values": [
+              "R.",
+              "H.",
+              "W.",
+              "M.",
+              "P.",
+              "C.",
+              "A.",
+              "F.",
+              "B.",
+              "K.",
+              "G.",
+              "O.",
+              "S.",
+              "D.",
+              "J.",
+              "T.",
+              "N.",
+              "E.",
+              "L."
+            ],
+            "counts": [
+              13,
+              11,
+              11,
+              8,
+              7,
+              7,
+              6,
+              5,
+              5,
+              4,
+              4,
+              4,
+              3,
+              3,
+              3,
+              2,
+              2,
+              1,
+              1
+            ]
+          },
+          "histogram": {
+            "labels": [
+              "2"
+            ],
+            "counts": [
+              100
+            ],
+            "bin_edges": [
+              2,
+              3
+            ]
+          },
+          "histogram_length": {
+            "labels": [
+              "2"
+            ],
+            "counts": [
+              100
+            ],
+            "bin_edges": [
+              2,
+              3
+            ]
+          },
+          "profile_duration": "0.02",
+          "elapsed_milli": 21,
+          "description": "Customer's last name. PII."
+        },
+        "first_order": {
+          "name": "first_order",
+          "type": "datetime",
+          "schema_type": "DATE",
+          "total": 100,
+          "samples": 100,
+          "samples_p": 1,
+          "non_nulls": 62,
+          "non_nulls_p": 0.62,
+          "nulls": 38,
+          "nulls_p": 0.38,
+          "valids": 62,
+          "valids_p": 0.62,
+          "invalids": 0,
+          "invalids_p": 0,
+          "distinct": 46,
+          "distinct_p": 0.7419354838709677,
+          "min": "2023-03-14",
+          "max": "2023-06-18",
+          "duplicates": 29,
+          "duplicates_p": 0.46774193548387094,
+          "non_duplicates": 33,
+          "non_duplicates_p": 0.532258064516129,
+          "histogram": {
+            "labels": [
+              "2023-03-01 - 2023-04-01",
+              "2023-04-01 - 2023-05-01",
+              "2023-05-01 - 2023-06-01",
+              "2023-06-01 - 2023-07-01"
+            ],
+            "counts": [
+              17,
+              19,
+              15,
+              11
+            ],
+            "bin_edges": [
+              "2023-03-01",
+              "2023-04-01",
+              "2023-05-01",
+              "2023-06-01",
+              "2023-07-01"
+            ]
+          },
+          "profile_duration": "0.02",
+          "elapsed_milli": 16,
+          "description": "Date (UTC) of a customer's first order"
+        },
+        "most_recent_order": {
+          "name": "most_recent_order",
+          "type": "datetime",
+          "schema_type": "DATE",
+          "total": 100,
+          "samples": 100,
+          "samples_p": 1,
+          "non_nulls": 62,
+          "non_nulls_p": 0.62,
+          "nulls": 38,
+          "nulls_p": 0.38,
+          "valids": 62,
+          "valids_p": 0.62,
+          "invalids": 0,
+          "invalids_p": 0,
+          "distinct": 52,
+          "distinct_p": 0.8387096774193549,
+          "min": "2023-03-22",
+          "max": "2023-06-20",
+          "duplicates": 18,
+          "duplicates_p": 0.2903225806451613,
+          "non_duplicates": 44,
+          "non_duplicates_p": 0.7096774193548387,
+          "histogram": {
+            "labels": [
+              "2023-03-01 - 2023-04-01",
+              "2023-04-01 - 2023-05-01",
+              "2023-05-01 - 2023-06-01",
+              "2023-06-01 - 2023-07-01"
+            ],
+            "counts": [
+              6,
+              14,
+              23,
+              19
+            ],
+            "bin_edges": [
+              "2023-03-01",
+              "2023-04-01",
+              "2023-05-01",
+              "2023-06-01",
+              "2023-07-01"
+            ]
+          },
+          "profile_duration": "0.02",
+          "elapsed_milli": 16,
+          "description": "Date (UTC) of a customer's most recent order"
+        },
+        "number_of_orders": {
+          "name": "number_of_orders",
+          "type": "integer",
+          "schema_type": "BIGINT",
+          "total": 100,
+          "samples": 100,
+          "samples_p": 1,
+          "non_nulls": 62,
+          "non_nulls_p": 0.62,
+          "nulls": 38,
+          "nulls_p": 0.38,
+          "valids": 62,
+          "valids_p": 0.62,
+          "invalids": 0,
+          "invalids_p": 0,
+          "zeros": 0,
+          "zeros_p": 0,
+          "negatives": 0,
+          "negatives_p": 0,
+          "positives": 62,
+          "positives_p": 0.62,
+          "distinct": 4,
+          "distinct_p": 0.06451612903225806,
+          "min": 1,
+          "max": 5,
+          "sum": 99,
+          "avg": 1.596774193548387,
+          "stddev": 0.7779687173818423,
+          "duplicates": 61,
+          "duplicates_p": 0.9838709677419355,
+          "non_duplicates": 1,
+          "non_duplicates_p": 0.016129032258064516,
+          "histogram": {
+            "labels": [
+              "1",
+              "2",
+              "3",
+              "4",
+              "5"
+            ],
+            "counts": [
+              33,
+              23,
+              5,
+              0,
+              1
+            ],
+            "bin_edges": [
+              1,
+              2,
+              3,
+              4,
+              5,
+              6
+            ]
+          },
+          "p5": 1,
+          "p25": 1,
+          "p50": 1,
+          "p75": 2,
+          "p95": 3,
+          "topk": {
+            "values": [
+              "1",
+              "2",
+              "3",
+              "5"
+            ],
+            "counts": [
+              33,
+              23,
+              5,
+              1
+            ]
+          },
+          "profile_duration": "0.03",
+          "elapsed_milli": 25,
+          "description": "Count of the number of orders a customer has placed"
+        },
+        "customer_lifetime_value": {
+          "name": "customer_lifetime_value",
+          "type": "integer",
+          "schema_type": "BIGINT",
+          "total": 100,
+          "samples": 100,
+          "samples_p": 1,
+          "non_nulls": 62,
+          "non_nulls_p": 0.62,
+          "nulls": 38,
+          "nulls_p": 0.38,
+          "valids": 62,
+          "valids_p": 0.62,
+          "invalids": 0,
+          "invalids_p": 0,
+          "zeros": 0,
+          "zeros_p": 0,
+          "negatives": 0,
+          "negatives_p": 0,
+          "positives": 62,
+          "positives_p": 0.62,
+          "distinct": 35,
+          "distinct_p": 0.5645161290322581,
+          "min": 1,
+          "max": 99,
+          "sum": 1672,
+          "avg": 26.967741935483872,
+          "stddev": 18.812245525263663,
+          "duplicates": 44,
+          "duplicates_p": 0.7096774193548387,
+          "non_duplicates": 18,
+          "non_duplicates_p": 0.2903225806451613,
+          "histogram": {
+            "labels": [
+              "1 _ 3",
+              "3 _ 5",
+              "5 _ 7",
+              "7 _ 9",
+              "9 _ 11",
+              "11 _ 13",
+              "13 _ 15",
+              "15 _ 17",
+              "17 _ 19",
+              "19 _ 21",
+              "21 _ 23",
+              "23 _ 25",
+              "25 _ 27",
+              "27 _ 29",
+              "29 _ 31",
+              "31 _ 33",
+              "33 _ 35",
+              "35 _ 37",
+              "37 _ 39",
+              "39 _ 41",
+              "41 _ 43",
+              "43 _ 45",
+              "45 _ 47",
+              "47 _ 49",
+              "49 _ 51",
+              "51 _ 53",
+              "53 _ 55",
+              "55 _ 57",
+              "57 _ 59",
+              "59 _ 61",
+              "61 _ 63",
+              "63 _ 65",
+              "65 _ 67",
+              "67 _ 69",
+              "69 _ 71",
+              "71 _ 73",
+              "73 _ 75",
+              "75 _ 77",
+              "77 _ 79",
+              "79 _ 81",
+              "81 _ 83",
+              "83 _ 85",
+              "85 _ 87",
+              "87 _ 89",
+              "89 _ 91",
+              "91 _ 93",
+              "93 _ 95",
+              "95 _ 97",
+              "97 _ 99",
+              "99 _ 101"
+            ],
+            "counts": [
+              3,
+              6,
+              0,
+              3,
+              2,
+              1,
+              2,
+              3,
+              2,
+              0,
+              1,
+              5,
+              3,
+              5,
+              6,
+              1,
+              3,
+              2,
+              0,
+              2,
+              0,
+              3,
+              1,
+              1,
+              0,
+              1,
+              1,
+              0,
+              2,
+              0,
+              0,
+              1,
+              1,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              1
+            ],
+            "bin_edges": [
+              1,
+              3,
+              5,
+              7,
+              9,
+              11,
+              13,
+              15,
+              17,
+              19,
+              21,
+              23,
+              25,
+              27,
+              29,
+              31,
+              33,
+              35,
+              37,
+              39,
+              41,
+              43,
+              45,
+              47,
+              49,
+              51,
+              53,
+              55,
+              57,
+              59,
+              61,
+              63,
+              65,
+              67,
+              69,
+              71,
+              73,
+              75,
+              77,
+              79,
+              81,
+              83,
+              85,
+              87,
+              89,
+              91,
+              93,
+              95,
+              97,
+              99,
+              101
+            ]
+          },
+          "p5": 3,
+          "p25": 14,
+          "p50": 26,
+          "p75": 36,
+          "p95": 60,
+          "topk": {
+            "values": [
+              "3",
+              "27",
+              "8",
+              "23",
+              "26",
+              "29",
+              "30",
+              "2",
+              "10",
+              "14",
+              "15",
+              "24",
+              "33",
+              "36",
+              "39",
+              "44",
+              "57",
+              "1",
+              "4",
+              "12",
+              "16",
+              "17",
+              "18",
+              "22",
+              "28",
+              "32",
+              "34",
+              "43",
+              "45",
+              "47",
+              "52",
+              "54",
+              "64",
+              "65",
+              "99"
+            ],
+            "counts": [
+              5,
+              4,
+              3,
+              3,
+              3,
+              3,
+              3,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1
+            ]
+          },
+          "profile_duration": "0.03",
+          "elapsed_milli": 27
+        }
+      },
+      "profile_duration": "0.03",
+      "elapsed_milli": 27,
+      "description": "This table has basic information about a customer, as well as some derived facts based on a customer's orders"
+    },
+    "stg_customers": {
+      "name": "stg_customers",
+      "row_count": 100,
+      "samples": 100,
+      "samples_p": 1,
+      "col_count": 3,
+      "columns": {
+        "customer_id": {
+          "name": "customer_id",
+          "type": "integer",
+          "schema_type": "INTEGER",
+          "total": 100,
+          "samples": 100,
+          "samples_p": 1,
+          "non_nulls": 100,
+          "non_nulls_p": 1,
+          "nulls": 0,
+          "nulls_p": 0,
+          "valids": 100,
+          "valids_p": 1,
+          "invalids": 0,
+          "invalids_p": 0,
+          "zeros": 0,
+          "zeros_p": 0,
+          "negatives": 0,
+          "negatives_p": 0,
+          "positives": 100,
+          "positives_p": 1,
+          "distinct": 100,
+          "distinct_p": 1,
+          "min": 1,
+          "max": 100,
+          "sum": 5050,
+          "avg": 50.5,
+          "stddev": 29.011491975882016,
+          "duplicates": 0,
+          "duplicates_p": 0,
+          "non_duplicates": 100,
+          "non_duplicates_p": 1,
+          "histogram": {
+            "labels": [
+              "1 _ 3",
+              "3 _ 5",
+              "5 _ 7",
+              "7 _ 9",
+              "9 _ 11",
+              "11 _ 13",
+              "13 _ 15",
+              "15 _ 17",
+              "17 _ 19",
+              "19 _ 21",
+              "21 _ 23",
+              "23 _ 25",
+              "25 _ 27",
+              "27 _ 29",
+              "29 _ 31",
+              "31 _ 33",
+              "33 _ 35",
+              "35 _ 37",
+              "37 _ 39",
+              "39 _ 41",
+              "41 _ 43",
+              "43 _ 45",
+              "45 _ 47",
+              "47 _ 49",
+              "49 _ 51",
+              "51 _ 53",
+              "53 _ 55",
+              "55 _ 57",
+              "57 _ 59",
+              "59 _ 61",
+              "61 _ 63",
+              "63 _ 65",
+              "65 _ 67",
+              "67 _ 69",
+              "69 _ 71",
+              "71 _ 73",
+              "73 _ 75",
+              "75 _ 77",
+              "77 _ 79",
+              "79 _ 81",
+              "81 _ 83",
+              "83 _ 85",
+              "85 _ 87",
+              "87 _ 89",
+              "89 _ 91",
+              "91 _ 93",
+              "93 _ 95",
+              "95 _ 97",
+              "97 _ 99",
+              "99 _ 101"
+            ],
+            "counts": [
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2
+            ],
+            "bin_edges": [
+              1,
+              3,
+              5,
+              7,
+              9,
+              11,
+              13,
+              15,
+              17,
+              19,
+              21,
+              23,
+              25,
+              27,
+              29,
+              31,
+              33,
+              35,
+              37,
+              39,
+              41,
+              43,
+              45,
+              47,
+              49,
+              51,
+              53,
+              55,
+              57,
+              59,
+              61,
+              63,
+              65,
+              67,
+              69,
+              71,
+              73,
+              75,
+              77,
+              79,
+              81,
+              83,
+              85,
+              87,
+              89,
+              91,
+              93,
+              95,
+              97,
+              99,
+              101
+            ]
+          },
+          "p5": 6,
+          "p25": 26,
+          "p50": 50,
+          "p75": 76,
+          "p95": 95,
+          "topk": {
+            "values": [
+              "1",
+              "2",
+              "3",
+              "4",
+              "5",
+              "6",
+              "7",
+              "8",
+              "9",
+              "10",
+              "11",
+              "12",
+              "13",
+              "14",
+              "15",
+              "16",
+              "17",
+              "18",
+              "19",
+              "20",
+              "21",
+              "22",
+              "23",
+              "24",
+              "25",
+              "26",
+              "27",
+              "28",
+              "29",
+              "30",
+              "31",
+              "32",
+              "33",
+              "34",
+              "35",
+              "36",
+              "37",
+              "38",
+              "39",
+              "40",
+              "41",
+              "42",
+              "43",
+              "44",
+              "45",
+              "46",
+              "47",
+              "48",
+              "49",
+              "50"
+            ],
+            "counts": [
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1
+            ]
+          },
+          "profile_duration": "0.01",
+          "elapsed_milli": 13
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "string",
+          "schema_type": "VARCHAR",
+          "total": 100,
+          "samples": 100,
+          "samples_p": 1,
+          "non_nulls": 100,
+          "non_nulls_p": 1,
+          "nulls": 0,
+          "nulls_p": 0,
+          "valids": 100,
+          "valids_p": 1,
+          "invalids": 0,
+          "invalids_p": 0,
+          "zero_length": 0,
+          "zero_length_p": 0,
+          "non_zero_length": 100,
+          "non_zero_length_p": 1,
+          "distinct": 79,
+          "distinct_p": 0.79,
+          "min": 3,
+          "min_length": 3,
+          "max": 10,
+          "max_length": 10,
+          "avg": 5.86,
+          "avg_length": 5.86,
+          "stddev": 1.5571276327412809,
+          "stddev_length": 1.5571276327412809,
+          "duplicates": 40,
+          "duplicates_p": 0.4,
+          "non_duplicates": 60,
+          "non_duplicates_p": 0.6,
+          "topk": {
+            "values": [
+              "Shirley",
+              "Adam",
+              "Michael",
+              "Kathleen",
+              "Katherine",
+              "Jennifer",
+              "Virginia",
+              "Willie",
+              "David",
+              "Benjamin",
+              "Lisa",
+              "Christina",
+              "Jane",
+              "Norma",
+              "Anne",
+              "Paul",
+              "Kathryn",
+              "Harry",
+              "Phillip",
+              "Shawn",
+              "Jimmy",
+              "Sarah",
+              "Martin",
+              "Frank",
+              "Henry",
+              "Fred",
+              "Amy",
+              "Steve",
+              "Teresa",
+              "Amanda",
+              "Kimberly",
+              "Johnny",
+              "Anna",
+              "Sean",
+              "Mildred",
+              "Victor",
+              "Aaron",
+              "Thomas",
+              "Sara",
+              "Harold",
+              "Dennis",
+              "Louise",
+              "Maria",
+              "Diana",
+              "Kelly",
+              "Scott",
+              "Marie",
+              "Lillian",
+              "Judy",
+              "Billy"
+            ],
+            "counts": [
+              3,
+              3,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1
+            ]
+          },
+          "histogram": {
+            "labels": [
+              "3",
+              "4",
+              "5",
+              "6",
+              "7",
+              "8",
+              "9",
+              "10"
+            ],
+            "counts": [
+              1,
+              22,
+              24,
+              20,
+              16,
+              11,
+              5,
+              1
+            ],
+            "bin_edges": [
+              3,
+              4,
+              5,
+              6,
+              7,
+              8,
+              9,
+              10,
+              11
+            ]
+          },
+          "histogram_length": {
+            "labels": [
+              "3",
+              "4",
+              "5",
+              "6",
+              "7",
+              "8",
+              "9",
+              "10"
+            ],
+            "counts": [
+              1,
+              22,
+              24,
+              20,
+              16,
+              11,
+              5,
+              1
+            ],
+            "bin_edges": [
+              3,
+              4,
+              5,
+              6,
+              7,
+              8,
+              9,
+              10,
+              11
+            ]
+          },
+          "profile_duration": "0.01",
+          "elapsed_milli": 12
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "string",
+          "schema_type": "VARCHAR",
+          "total": 100,
+          "samples": 100,
+          "samples_p": 1,
+          "non_nulls": 100,
+          "non_nulls_p": 1,
+          "nulls": 0,
+          "nulls_p": 0,
+          "valids": 100,
+          "valids_p": 1,
+          "invalids": 0,
+          "invalids_p": 0,
+          "zero_length": 0,
+          "zero_length_p": 0,
+          "non_zero_length": 100,
+          "non_zero_length_p": 1,
+          "distinct": 19,
+          "distinct_p": 0.19,
+          "min": 2,
+          "min_length": 2,
+          "max": 2,
+          "max_length": 2,
+          "avg": 2,
+          "avg_length": 2,
+          "stddev": 0,
+          "stddev_length": 0,
+          "duplicates": 98,
+          "duplicates_p": 0.98,
+          "non_duplicates": 2,
+          "non_duplicates_p": 0.02,
+          "topk": {
+            "values": [
+              "R.",
+              "W.",
+              "H.",
+              "M.",
+              "P.",
+              "C.",
+              "A.",
+              "F.",
+              "B.",
+              "K.",
+              "G.",
+              "O.",
+              "S.",
+              "D.",
+              "J.",
+              "T.",
+              "N.",
+              "L.",
+              "E."
+            ],
+            "counts": [
+              13,
+              11,
+              11,
+              8,
+              7,
+              7,
+              6,
+              5,
+              5,
+              4,
+              4,
+              4,
+              3,
+              3,
+              3,
+              2,
+              2,
+              1,
+              1
+            ]
+          },
+          "histogram": {
+            "labels": [
+              "2"
+            ],
+            "counts": [
+              100
+            ],
+            "bin_edges": [
+              2,
+              3
+            ]
+          },
+          "histogram_length": {
+            "labels": [
+              "2"
+            ],
+            "counts": [
+              100
+            ],
+            "bin_edges": [
+              2,
+              3
+            ]
+          },
+          "profile_duration": "0.01",
+          "elapsed_milli": 13
+        }
+      },
+      "profile_duration": "0.01",
+      "elapsed_milli": 14
+    },
+    "stg_payments": {
+      "name": "stg_payments",
+      "row_count": 113,
+      "samples": 113,
+      "samples_p": 1,
+      "col_count": 4,
+      "columns": {
+        "payment_id": {
+          "name": "payment_id",
+          "type": "integer",
+          "schema_type": "INTEGER",
+          "total": 113,
+          "samples": 113,
+          "samples_p": 1,
+          "non_nulls": 113,
+          "non_nulls_p": 1,
+          "nulls": 0,
+          "nulls_p": 0,
+          "valids": 113,
+          "valids_p": 1,
+          "invalids": 0,
+          "invalids_p": 0,
+          "zeros": 0,
+          "zeros_p": 0,
+          "negatives": 0,
+          "negatives_p": 0,
+          "positives": 113,
+          "positives_p": 1,
+          "distinct": 113,
+          "distinct_p": 1,
+          "min": 1,
+          "max": 113,
+          "sum": 6441,
+          "avg": 57,
+          "stddev": 32.76430985081175,
+          "duplicates": 0,
+          "duplicates_p": 0,
+          "non_duplicates": 113,
+          "non_duplicates_p": 1,
+          "histogram": {
+            "labels": [
+              "1 _ 4",
+              "4 _ 7",
+              "7 _ 10",
+              "10 _ 13",
+              "13 _ 16",
+              "16 _ 19",
+              "19 _ 22",
+              "22 _ 25",
+              "25 _ 28",
+              "28 _ 31",
+              "31 _ 34",
+              "34 _ 37",
+              "37 _ 40",
+              "40 _ 43",
+              "43 _ 46",
+              "46 _ 49",
+              "49 _ 52",
+              "52 _ 55",
+              "55 _ 58",
+              "58 _ 61",
+              "61 _ 64",
+              "64 _ 67",
+              "67 _ 70",
+              "70 _ 73",
+              "73 _ 76",
+              "76 _ 79",
+              "79 _ 82",
+              "82 _ 85",
+              "85 _ 88",
+              "88 _ 91",
+              "91 _ 94",
+              "94 _ 97",
+              "97 _ 100",
+              "100 _ 103",
+              "103 _ 106",
+              "106 _ 109",
+              "109 _ 112",
+              "112 _ 115"
+            ],
+            "counts": [
+              3,
+              3,
+              3,
+              3,
+              3,
+              3,
+              3,
+              3,
+              3,
+              3,
+              3,
+              3,
+              3,
+              3,
+              3,
+              3,
+              3,
+              3,
+              3,
+              3,
+              3,
+              3,
+              3,
+              3,
+              3,
+              3,
+              3,
+              3,
+              3,
+              3,
+              3,
+              3,
+              3,
+              3,
+              3,
+              3,
+              3,
+              2
+            ],
+            "bin_edges": [
+              1,
+              4,
+              7,
+              10,
+              13,
+              16,
+              19,
+              22,
+              25,
+              28,
+              31,
+              34,
+              37,
+              40,
+              43,
+              46,
+              49,
+              52,
+              55,
+              58,
+              61,
+              64,
+              67,
+              70,
+              73,
+              76,
+              79,
+              82,
+              85,
+              88,
+              91,
+              94,
+              97,
+              100,
+              103,
+              106,
+              109,
+              112,
+              115
+            ]
+          },
+          "p5": 6,
+          "p25": 29,
+          "p50": 57,
+          "p75": 85,
+          "p95": 108,
+          "topk": {
+            "values": [
+              "1",
+              "2",
+              "3",
+              "4",
+              "5",
+              "6",
+              "7",
+              "8",
+              "9",
+              "10",
+              "11",
+              "12",
+              "13",
+              "14",
+              "15",
+              "16",
+              "17",
+              "18",
+              "19",
+              "20",
+              "21",
+              "22",
+              "23",
+              "24",
+              "25",
+              "26",
+              "27",
+              "28",
+              "29",
+              "30",
+              "31",
+              "32",
+              "33",
+              "34",
+              "35",
+              "36",
+              "37",
+              "38",
+              "39",
+              "40",
+              "41",
+              "42",
+              "43",
+              "44",
+              "45",
+              "46",
+              "47",
+              "48",
+              "49",
+              "50"
+            ],
+            "counts": [
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1
+            ]
+          },
+          "profile_duration": "0.02",
+          "elapsed_milli": 19
+        },
+        "order_id": {
+          "name": "order_id",
+          "type": "integer",
+          "schema_type": "INTEGER",
+          "total": 113,
+          "samples": 113,
+          "samples_p": 1,
+          "non_nulls": 113,
+          "non_nulls_p": 1,
+          "nulls": 0,
+          "nulls_p": 0,
+          "valids": 113,
+          "valids_p": 1,
+          "invalids": 0,
+          "invalids_p": 0,
+          "zeros": 0,
+          "zeros_p": 0,
+          "negatives": 0,
+          "negatives_p": 0,
+          "positives": 113,
+          "positives_p": 1,
+          "distinct": 99,
+          "distinct_p": 0.8761061946902655,
+          "min": 1,
+          "max": 99,
+          "sum": 5654,
+          "avg": 50.0353982300885,
+          "stddev": 28.54317819535489,
+          "duplicates": 27,
+          "duplicates_p": 0.23893805309734514,
+          "non_duplicates": 86,
+          "non_duplicates_p": 0.7610619469026548,
+          "histogram": {
+            "labels": [
+              "1 _ 3",
+              "3 _ 5",
+              "5 _ 7",
+              "7 _ 9",
+              "9 _ 11",
+              "11 _ 13",
+              "13 _ 15",
+              "15 _ 17",
+              "17 _ 19",
+              "19 _ 21",
+              "21 _ 23",
+              "23 _ 25",
+              "25 _ 27",
+              "27 _ 29",
+              "29 _ 31",
+              "31 _ 33",
+              "33 _ 35",
+              "35 _ 37",
+              "37 _ 39",
+              "39 _ 41",
+              "41 _ 43",
+              "43 _ 45",
+              "45 _ 47",
+              "47 _ 49",
+              "49 _ 51",
+              "51 _ 53",
+              "53 _ 55",
+              "55 _ 57",
+              "57 _ 59",
+              "59 _ 61",
+              "61 _ 63",
+              "63 _ 65",
+              "65 _ 67",
+              "67 _ 69",
+              "69 _ 71",
+              "71 _ 73",
+              "73 _ 75",
+              "75 _ 77",
+              "77 _ 79",
+              "79 _ 81",
+              "81 _ 83",
+              "83 _ 85",
+              "85 _ 87",
+              "87 _ 89",
+              "89 _ 91",
+              "91 _ 93",
+              "93 _ 95",
+              "95 _ 97",
+              "97 _ 99",
+              "99 _ 101"
+            ],
+            "counts": [
+              2,
+              2,
+              2,
+              2,
+              3,
+              2,
+              3,
+              2,
+              3,
+              2,
+              2,
+              2,
+              4,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              3,
+              3,
+              3,
+              2,
+              3,
+              2,
+              2,
+              2,
+              2,
+              3,
+              2,
+              2,
+              2,
+              2,
+              3,
+              3,
+              2,
+              2,
+              2,
+              3,
+              2,
+              3,
+              2,
+              2,
+              2,
+              1
+            ],
+            "bin_edges": [
+              1,
+              3,
+              5,
+              7,
+              9,
+              11,
+              13,
+              15,
+              17,
+              19,
+              21,
+              23,
+              25,
+              27,
+              29,
+              31,
+              33,
+              35,
+              37,
+              39,
+              41,
+              43,
+              45,
+              47,
+              49,
+              51,
+              53,
+              55,
+              57,
+              59,
+              61,
+              63,
+              65,
+              67,
+              69,
+              71,
+              73,
+              75,
+              77,
+              79,
+              81,
+              83,
+              85,
+              87,
+              89,
+              91,
+              93,
+              95,
+              97,
+              99,
+              101
+            ]
+          },
+          "p5": 6,
+          "p25": 25,
+          "p50": 51,
+          "p75": 75,
+          "p95": 94,
+          "topk": {
+            "values": [
+              "25",
+              "9",
+              "13",
+              "18",
+              "49",
+              "51",
+              "54",
+              "58",
+              "67",
+              "77",
+              "79",
+              "87",
+              "92",
+              "1",
+              "2",
+              "3",
+              "4",
+              "5",
+              "6",
+              "7",
+              "8",
+              "10",
+              "11",
+              "12",
+              "14",
+              "15",
+              "16",
+              "17",
+              "19",
+              "20",
+              "21",
+              "22",
+              "23",
+              "24",
+              "26",
+              "27",
+              "28",
+              "29",
+              "30",
+              "31",
+              "32",
+              "33",
+              "34",
+              "35",
+              "36",
+              "37",
+              "38",
+              "39",
+              "40",
+              "41"
+            ],
+            "counts": [
+              3,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1
+            ]
+          },
+          "profile_duration": "0.02",
+          "elapsed_milli": 19
+        },
+        "payment_method": {
+          "name": "payment_method",
+          "type": "string",
+          "schema_type": "VARCHAR",
+          "total": 113,
+          "samples": 113,
+          "samples_p": 1,
+          "non_nulls": 113,
+          "non_nulls_p": 1,
+          "nulls": 0,
+          "nulls_p": 0,
+          "valids": 113,
+          "valids_p": 1,
+          "invalids": 0,
+          "invalids_p": 0,
+          "zero_length": 0,
+          "zero_length_p": 0,
+          "non_zero_length": 113,
+          "non_zero_length_p": 1,
+          "distinct": 4,
+          "distinct_p": 0.035398230088495575,
+          "min": 6,
+          "min_length": 6,
+          "max": 13,
+          "max_length": 13,
+          "avg": 10.79646017699115,
+          "avg_length": 10.79646017699115,
+          "stddev": 2.113558661338224,
+          "stddev_length": 2.113558661338224,
+          "duplicates": 113,
+          "duplicates_p": 1,
+          "non_duplicates": 0,
+          "non_duplicates_p": 0,
+          "topk": {
+            "values": [
+              "credit_card",
+              "bank_transfer",
+              "coupon",
+              "gift_card"
+            ],
+            "counts": [
+              55,
+              33,
+              13,
+              12
+            ]
+          },
+          "histogram": {
+            "labels": [
+              "6",
+              "7",
+              "8",
+              "9",
+              "10",
+              "11",
+              "12",
+              "13"
+            ],
+            "counts": [
+              13,
+              0,
+              0,
+              12,
+              0,
+              55,
+              0,
+              33
+            ],
+            "bin_edges": [
+              6,
+              7,
+              8,
+              9,
+              10,
+              11,
+              12,
+              13,
+              14
+            ]
+          },
+          "histogram_length": {
+            "labels": [
+              "6",
+              "7",
+              "8",
+              "9",
+              "10",
+              "11",
+              "12",
+              "13"
+            ],
+            "counts": [
+              13,
+              0,
+              0,
+              12,
+              0,
+              55,
+              0,
+              33
+            ],
+            "bin_edges": [
+              6,
+              7,
+              8,
+              9,
+              10,
+              11,
+              12,
+              13,
+              14
+            ]
+          },
+          "profile_duration": "0.02",
+          "elapsed_milli": 18
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "schema_type": "INTEGER",
+          "total": 113,
+          "samples": 113,
+          "samples_p": 1,
+          "non_nulls": 113,
+          "non_nulls_p": 1,
+          "nulls": 0,
+          "nulls_p": 0,
+          "valids": 113,
+          "valids_p": 1,
+          "invalids": 0,
+          "invalids_p": 0,
+          "zeros": 3,
+          "zeros_p": 0.02654867256637168,
+          "negatives": 0,
+          "negatives_p": 0,
+          "positives": 110,
+          "positives_p": 0.9734513274336283,
+          "distinct": 30,
+          "distinct_p": 0.26548672566371684,
+          "min": 0,
+          "max": 30,
+          "sum": 1672,
+          "avg": 14.79646017699115,
+          "stddev": 9.19836873351873,
+          "duplicates": 110,
+          "duplicates_p": 0.9734513274336283,
+          "non_duplicates": 3,
+          "non_duplicates_p": 0.02654867256637168,
+          "histogram": {
+            "labels": [
+              "0",
+              "1",
+              "2",
+              "3",
+              "4",
+              "5",
+              "6",
+              "7",
+              "8",
+              "9",
+              "10",
+              "11",
+              "12",
+              "13",
+              "14",
+              "15",
+              "16",
+              "17",
+              "18",
+              "19",
+              "20",
+              "21",
+              "22",
+              "23",
+              "24",
+              "25",
+              "26",
+              "27",
+              "28",
+              "29",
+              "30"
+            ],
+            "counts": [
+              3,
+              4,
+              6,
+              6,
+              3,
+              4,
+              4,
+              1,
+              5,
+              3,
+              3,
+              2,
+              3,
+              1,
+              4,
+              5,
+              4,
+              5,
+              4,
+              6,
+              2,
+              0,
+              5,
+              6,
+              2,
+              2,
+              8,
+              1,
+              2,
+              6,
+              3
+            ],
+            "bin_edges": [
+              0,
+              1,
+              2,
+              3,
+              4,
+              5,
+              6,
+              7,
+              8,
+              9,
+              10,
+              11,
+              12,
+              13,
+              14,
+              15,
+              16,
+              17,
+              18,
+              19,
+              20,
+              21,
+              22,
+              23,
+              24,
+              25,
+              26,
+              27,
+              28,
+              29,
+              30,
+              31
+            ]
+          },
+          "p5": 1,
+          "p25": 6,
+          "p50": 15,
+          "p75": 23,
+          "p95": 29,
+          "topk": {
+            "values": [
+              "26",
+              "23",
+              "3",
+              "2",
+              "19",
+              "29",
+              "17",
+              "22",
+              "8",
+              "15",
+              "1",
+              "6",
+              "16",
+              "5",
+              "14",
+              "18",
+              "10",
+              "0",
+              "12",
+              "30",
+              "9",
+              "4",
+              "20",
+              "25",
+              "11",
+              "28",
+              "24",
+              "27",
+              "13",
+              "7"
+            ],
+            "counts": [
+              8,
+              6,
+              6,
+              6,
+              6,
+              6,
+              5,
+              5,
+              5,
+              5,
+              4,
+              4,
+              4,
+              4,
+              4,
+              4,
+              3,
+              3,
+              3,
+              3,
+              3,
+              3,
+              2,
+              2,
+              2,
+              2,
+              2,
+              1,
+              1,
+              1
+            ]
+          },
+          "profile_duration": "0.02",
+          "elapsed_milli": 19
+        }
+      },
+      "profile_duration": "0.02",
+      "elapsed_milli": 20
+    },
+    "stg_orders": {
+      "name": "stg_orders",
+      "row_count": 99,
+      "samples": 99,
+      "samples_p": 1,
+      "col_count": 4,
+      "columns": {
+        "order_id": {
+          "name": "order_id",
+          "type": "integer",
+          "schema_type": "INTEGER",
+          "total": 99,
+          "samples": 99,
+          "samples_p": 1,
+          "non_nulls": 99,
+          "non_nulls_p": 1,
+          "nulls": 0,
+          "nulls_p": 0,
+          "valids": 99,
+          "valids_p": 1,
+          "invalids": 0,
+          "invalids_p": 0,
+          "zeros": 0,
+          "zeros_p": 0,
+          "negatives": 0,
+          "negatives_p": 0,
+          "positives": 99,
+          "positives_p": 1,
+          "distinct": 99,
+          "distinct_p": 1,
+          "min": 1,
+          "max": 99,
+          "sum": 4950,
+          "avg": 50,
+          "stddev": 28.722813232690143,
+          "duplicates": 0,
+          "duplicates_p": 0,
+          "non_duplicates": 99,
+          "non_duplicates_p": 1,
+          "histogram": {
+            "labels": [
+              "1 _ 3",
+              "3 _ 5",
+              "5 _ 7",
+              "7 _ 9",
+              "9 _ 11",
+              "11 _ 13",
+              "13 _ 15",
+              "15 _ 17",
+              "17 _ 19",
+              "19 _ 21",
+              "21 _ 23",
+              "23 _ 25",
+              "25 _ 27",
+              "27 _ 29",
+              "29 _ 31",
+              "31 _ 33",
+              "33 _ 35",
+              "35 _ 37",
+              "37 _ 39",
+              "39 _ 41",
+              "41 _ 43",
+              "43 _ 45",
+              "45 _ 47",
+              "47 _ 49",
+              "49 _ 51",
+              "51 _ 53",
+              "53 _ 55",
+              "55 _ 57",
+              "57 _ 59",
+              "59 _ 61",
+              "61 _ 63",
+              "63 _ 65",
+              "65 _ 67",
+              "67 _ 69",
+              "69 _ 71",
+              "71 _ 73",
+              "73 _ 75",
+              "75 _ 77",
+              "77 _ 79",
+              "79 _ 81",
+              "81 _ 83",
+              "83 _ 85",
+              "85 _ 87",
+              "87 _ 89",
+              "89 _ 91",
+              "91 _ 93",
+              "93 _ 95",
+              "95 _ 97",
+              "97 _ 99",
+              "99 _ 101"
+            ],
+            "counts": [
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              1
+            ],
+            "bin_edges": [
+              1,
+              3,
+              5,
+              7,
+              9,
+              11,
+              13,
+              15,
+              17,
+              19,
+              21,
+              23,
+              25,
+              27,
+              29,
+              31,
+              33,
+              35,
+              37,
+              39,
+              41,
+              43,
+              45,
+              47,
+              49,
+              51,
+              53,
+              55,
+              57,
+              59,
+              61,
+              63,
+              65,
+              67,
+              69,
+              71,
+              73,
+              75,
+              77,
+              79,
+              81,
+              83,
+              85,
+              87,
+              89,
+              91,
+              93,
+              95,
+              97,
+              99,
+              101
+            ]
+          },
+          "p5": 5,
+          "p25": 25,
+          "p50": 50,
+          "p75": 75,
+          "p95": 95,
+          "topk": {
+            "values": [
+              "1",
+              "2",
+              "3",
+              "4",
+              "5",
+              "6",
+              "7",
+              "8",
+              "9",
+              "10",
+              "11",
+              "12",
+              "13",
+              "14",
+              "15",
+              "16",
+              "17",
+              "18",
+              "19",
+              "20",
+              "21",
+              "22",
+              "23",
+              "24",
+              "25",
+              "26",
+              "27",
+              "28",
+              "29",
+              "30",
+              "31",
+              "32",
+              "33",
+              "34",
+              "35",
+              "36",
+              "37",
+              "38",
+              "39",
+              "40",
+              "41",
+              "42",
+              "43",
+              "44",
+              "45",
+              "46",
+              "47",
+              "48",
+              "49",
+              "50"
+            ],
+            "counts": [
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1
+            ]
+          },
+          "profile_duration": "0.02",
+          "elapsed_milli": 18
+        },
+        "customer_id": {
+          "name": "customer_id",
+          "type": "integer",
+          "schema_type": "INTEGER",
+          "total": 99,
+          "samples": 99,
+          "samples_p": 1,
+          "non_nulls": 99,
+          "non_nulls_p": 1,
+          "nulls": 0,
+          "nulls_p": 0,
+          "valids": 99,
+          "valids_p": 1,
+          "invalids": 0,
+          "invalids_p": 0,
+          "zeros": 0,
+          "zeros_p": 0,
+          "negatives": 0,
+          "negatives_p": 0,
+          "positives": 99,
+          "positives_p": 1,
+          "distinct": 62,
+          "distinct_p": 0.6262626262626263,
+          "min": 1,
+          "max": 99,
+          "sum": 4777,
+          "avg": 48.25252525252525,
+          "stddev": 27.781341350472957,
+          "duplicates": 66,
+          "duplicates_p": 0.6666666666666666,
+          "non_duplicates": 33,
+          "non_duplicates_p": 0.3333333333333333,
+          "histogram": {
+            "labels": [
+              "1 _ 3",
+              "3 _ 5",
+              "5 _ 7",
+              "7 _ 9",
+              "9 _ 11",
+              "11 _ 13",
+              "13 _ 15",
+              "15 _ 17",
+              "17 _ 19",
+              "19 _ 21",
+              "21 _ 23",
+              "23 _ 25",
+              "25 _ 27",
+              "27 _ 29",
+              "29 _ 31",
+              "31 _ 33",
+              "33 _ 35",
+              "35 _ 37",
+              "37 _ 39",
+              "39 _ 41",
+              "41 _ 43",
+              "43 _ 45",
+              "45 _ 47",
+              "47 _ 49",
+              "49 _ 51",
+              "51 _ 53",
+              "53 _ 55",
+              "55 _ 57",
+              "57 _ 59",
+              "59 _ 61",
+              "61 _ 63",
+              "63 _ 65",
+              "65 _ 67",
+              "67 _ 69",
+              "69 _ 71",
+              "71 _ 73",
+              "73 _ 75",
+              "75 _ 77",
+              "77 _ 79",
+              "79 _ 81",
+              "81 _ 83",
+              "83 _ 85",
+              "85 _ 87",
+              "87 _ 89",
+              "89 _ 91",
+              "91 _ 93",
+              "93 _ 95",
+              "95 _ 97",
+              "97 _ 99",
+              "99 _ 101"
+            ],
+            "counts": [
+              3,
+              3,
+              1,
+              3,
+              1,
+              2,
+              1,
+              1,
+              1,
+              2,
+              4,
+              0,
+              4,
+              3,
+              2,
+              2,
+              2,
+              3,
+              1,
+              2,
+              3,
+              0,
+              2,
+              2,
+              2,
+              4,
+              7,
+              0,
+              2,
+              1,
+              0,
+              4,
+              3,
+              1,
+              4,
+              3,
+              0,
+              1,
+              0,
+              3,
+              0,
+              2,
+              3,
+              1,
+              3,
+              2,
+              3,
+              0,
+              0,
+              2
+            ],
+            "bin_edges": [
+              1,
+              3,
+              5,
+              7,
+              9,
+              11,
+              13,
+              15,
+              17,
+              19,
+              21,
+              23,
+              25,
+              27,
+              29,
+              31,
+              33,
+              35,
+              37,
+              39,
+              41,
+              43,
+              45,
+              47,
+              49,
+              51,
+              53,
+              55,
+              57,
+              59,
+              61,
+              63,
+              65,
+              67,
+              69,
+              71,
+              73,
+              75,
+              77,
+              79,
+              81,
+              83,
+              85,
+              87,
+              89,
+              91,
+              93,
+              95,
+              97,
+              99,
+              101
+            ]
+          },
+          "p5": 3,
+          "p25": 26,
+          "p50": 50,
+          "p75": 70,
+          "p95": 93,
+          "topk": {
+            "values": [
+              "54",
+              "3",
+              "22",
+              "51",
+              "66",
+              "71",
+              "1",
+              "8",
+              "25",
+              "26",
+              "27",
+              "30",
+              "35",
+              "42",
+              "46",
+              "47",
+              "50",
+              "53",
+              "57",
+              "63",
+              "64",
+              "69",
+              "70",
+              "79",
+              "84",
+              "85",
+              "90",
+              "94",
+              "99",
+              "2",
+              "6",
+              "7",
+              "9",
+              "11",
+              "12",
+              "13",
+              "16",
+              "18",
+              "19",
+              "20",
+              "21",
+              "28",
+              "31",
+              "32",
+              "33",
+              "34",
+              "36",
+              "38",
+              "39",
+              "40"
+            ],
+            "counts": [
+              5,
+              3,
+              3,
+              3,
+              3,
+              3,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1
+            ]
+          },
+          "profile_duration": "0.02",
+          "elapsed_milli": 18
+        },
+        "order_date": {
+          "name": "order_date",
+          "type": "datetime",
+          "schema_type": "DATE",
+          "total": 99,
+          "samples": 99,
+          "samples_p": 1,
+          "non_nulls": 99,
+          "non_nulls_p": 1,
+          "nulls": 0,
+          "nulls_p": 0,
+          "valids": 99,
+          "valids_p": 1,
+          "invalids": 0,
+          "invalids_p": 0,
+          "distinct": 69,
+          "distinct_p": 0.696969696969697,
+          "min": "2023-03-14",
+          "max": "2023-06-20",
+          "duplicates": 53,
+          "duplicates_p": 0.5353535353535354,
+          "non_duplicates": 46,
+          "non_duplicates_p": 0.46464646464646464,
+          "histogram": {
+            "labels": [
+              "2023-03-01 - 2023-04-01",
+              "2023-04-01 - 2023-05-01",
+              "2023-05-01 - 2023-06-01",
+              "2023-06-01 - 2023-07-01"
+            ],
+            "counts": [
+              17,
+              28,
+              31,
+              23
+            ],
+            "bin_edges": [
+              "2023-03-01",
+              "2023-04-01",
+              "2023-05-01",
+              "2023-06-01",
+              "2023-07-01"
+            ]
+          },
+          "profile_duration": "0.01",
+          "elapsed_milli": 14
+        },
+        "status": {
+          "name": "status",
+          "type": "string",
+          "schema_type": "VARCHAR",
+          "total": 99,
+          "samples": 99,
+          "samples_p": 1,
+          "non_nulls": 99,
+          "non_nulls_p": 1,
+          "nulls": 0,
+          "nulls_p": 0,
+          "valids": 99,
+          "valids_p": 1,
+          "invalids": 0,
+          "invalids_p": 0,
+          "zero_length": 0,
+          "zero_length_p": 0,
+          "non_zero_length": 99,
+          "non_zero_length_p": 1,
+          "distinct": 5,
+          "distinct_p": 0.050505050505050504,
+          "min": 6,
+          "min_length": 6,
+          "max": 14,
+          "max_length": 14,
+          "avg": 8.404040404040405,
+          "avg_length": 8.404040404040405,
+          "stddev": 1.384455922892632,
+          "stddev_length": 1.384455922892632,
+          "duplicates": 99,
+          "duplicates_p": 1,
+          "non_duplicates": 0,
+          "non_duplicates_p": 0,
+          "topk": {
+            "values": [
+              "completed",
+              "shipped",
+              "placed",
+              "returned",
+              "return_pending"
+            ],
+            "counts": [
+              67,
+              13,
+              13,
+              4,
+              2
+            ]
+          },
+          "histogram": {
+            "labels": [
+              "6",
+              "7",
+              "8",
+              "9",
+              "10",
+              "11",
+              "12",
+              "13",
+              "14"
+            ],
+            "counts": [
+              13,
+              13,
+              4,
+              67,
+              0,
+              0,
+              0,
+              0,
+              2
+            ],
+            "bin_edges": [
+              6,
+              7,
+              8,
+              9,
+              10,
+              11,
+              12,
+              13,
+              14,
+              15
+            ]
+          },
+          "histogram_length": {
+            "labels": [
+              "6",
+              "7",
+              "8",
+              "9",
+              "10",
+              "11",
+              "12",
+              "13",
+              "14"
+            ],
+            "counts": [
+              13,
+              13,
+              4,
+              67,
+              0,
+              0,
+              0,
+              0,
+              2
+            ],
+            "bin_edges": [
+              6,
+              7,
+              8,
+              9,
+              10,
+              11,
+              12,
+              13,
+              14,
+              15
+            ]
+          },
+          "profile_duration": "0.02",
+          "elapsed_milli": 18
+        }
+      },
+      "profile_duration": "0.02",
+      "elapsed_milli": 18
+    },
+    "orders": {
+      "name": "orders",
+      "row_count": 99,
+      "samples": 99,
+      "samples_p": 1,
+      "col_count": 15,
+      "columns": {
+        "order_id": {
+          "name": "order_id",
+          "type": "integer",
+          "schema_type": "INTEGER",
+          "total": 99,
+          "samples": 99,
+          "samples_p": 1,
+          "non_nulls": 99,
+          "non_nulls_p": 1,
+          "nulls": 0,
+          "nulls_p": 0,
+          "valids": 99,
+          "valids_p": 1,
+          "invalids": 0,
+          "invalids_p": 0,
+          "zeros": 0,
+          "zeros_p": 0,
+          "negatives": 0,
+          "negatives_p": 0,
+          "positives": 99,
+          "positives_p": 1,
+          "distinct": 99,
+          "distinct_p": 1,
+          "min": 1,
+          "max": 99,
+          "sum": 4950,
+          "avg": 50,
+          "stddev": 28.722813232690143,
+          "duplicates": 0,
+          "duplicates_p": 0,
+          "non_duplicates": 99,
+          "non_duplicates_p": 1,
+          "histogram": {
+            "labels": [
+              "1 _ 3",
+              "3 _ 5",
+              "5 _ 7",
+              "7 _ 9",
+              "9 _ 11",
+              "11 _ 13",
+              "13 _ 15",
+              "15 _ 17",
+              "17 _ 19",
+              "19 _ 21",
+              "21 _ 23",
+              "23 _ 25",
+              "25 _ 27",
+              "27 _ 29",
+              "29 _ 31",
+              "31 _ 33",
+              "33 _ 35",
+              "35 _ 37",
+              "37 _ 39",
+              "39 _ 41",
+              "41 _ 43",
+              "43 _ 45",
+              "45 _ 47",
+              "47 _ 49",
+              "49 _ 51",
+              "51 _ 53",
+              "53 _ 55",
+              "55 _ 57",
+              "57 _ 59",
+              "59 _ 61",
+              "61 _ 63",
+              "63 _ 65",
+              "65 _ 67",
+              "67 _ 69",
+              "69 _ 71",
+              "71 _ 73",
+              "73 _ 75",
+              "75 _ 77",
+              "77 _ 79",
+              "79 _ 81",
+              "81 _ 83",
+              "83 _ 85",
+              "85 _ 87",
+              "87 _ 89",
+              "89 _ 91",
+              "91 _ 93",
+              "93 _ 95",
+              "95 _ 97",
+              "97 _ 99",
+              "99 _ 101"
+            ],
+            "counts": [
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              1
+            ],
+            "bin_edges": [
+              1,
+              3,
+              5,
+              7,
+              9,
+              11,
+              13,
+              15,
+              17,
+              19,
+              21,
+              23,
+              25,
+              27,
+              29,
+              31,
+              33,
+              35,
+              37,
+              39,
+              41,
+              43,
+              45,
+              47,
+              49,
+              51,
+              53,
+              55,
+              57,
+              59,
+              61,
+              63,
+              65,
+              67,
+              69,
+              71,
+              73,
+              75,
+              77,
+              79,
+              81,
+              83,
+              85,
+              87,
+              89,
+              91,
+              93,
+              95,
+              97,
+              99,
+              101
+            ]
+          },
+          "p5": 5,
+          "p25": 25,
+          "p50": 50,
+          "p75": 75,
+          "p95": 95,
+          "topk": {
+            "values": [
+              "1",
+              "2",
+              "3",
+              "4",
+              "5",
+              "6",
+              "7",
+              "8",
+              "9",
+              "10",
+              "11",
+              "12",
+              "13",
+              "14",
+              "15",
+              "16",
+              "17",
+              "18",
+              "19",
+              "20",
+              "21",
+              "22",
+              "23",
+              "24",
+              "25",
+              "26",
+              "27",
+              "28",
+              "29",
+              "30",
+              "31",
+              "32",
+              "33",
+              "34",
+              "35",
+              "36",
+              "37",
+              "38",
+              "39",
+              "40",
+              "41",
+              "42",
+              "43",
+              "44",
+              "45",
+              "46",
+              "47",
+              "48",
+              "49",
+              "50"
+            ],
+            "counts": [
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1
+            ]
+          },
+          "profile_duration": "0.03",
+          "elapsed_milli": 30,
+          "description": "This is a unique identifier for an order"
+        },
+        "customer_id": {
+          "name": "customer_id",
+          "type": "integer",
+          "schema_type": "INTEGER",
+          "total": 99,
+          "samples": 99,
+          "samples_p": 1,
+          "non_nulls": 99,
+          "non_nulls_p": 1,
+          "nulls": 0,
+          "nulls_p": 0,
+          "valids": 99,
+          "valids_p": 1,
+          "invalids": 0,
+          "invalids_p": 0,
+          "zeros": 0,
+          "zeros_p": 0,
+          "negatives": 0,
+          "negatives_p": 0,
+          "positives": 99,
+          "positives_p": 1,
+          "distinct": 62,
+          "distinct_p": 0.6262626262626263,
+          "min": 1,
+          "max": 99,
+          "sum": 4777,
+          "avg": 48.25252525252525,
+          "stddev": 27.781341350472957,
+          "duplicates": 66,
+          "duplicates_p": 0.6666666666666666,
+          "non_duplicates": 33,
+          "non_duplicates_p": 0.3333333333333333,
+          "histogram": {
+            "labels": [
+              "1 _ 3",
+              "3 _ 5",
+              "5 _ 7",
+              "7 _ 9",
+              "9 _ 11",
+              "11 _ 13",
+              "13 _ 15",
+              "15 _ 17",
+              "17 _ 19",
+              "19 _ 21",
+              "21 _ 23",
+              "23 _ 25",
+              "25 _ 27",
+              "27 _ 29",
+              "29 _ 31",
+              "31 _ 33",
+              "33 _ 35",
+              "35 _ 37",
+              "37 _ 39",
+              "39 _ 41",
+              "41 _ 43",
+              "43 _ 45",
+              "45 _ 47",
+              "47 _ 49",
+              "49 _ 51",
+              "51 _ 53",
+              "53 _ 55",
+              "55 _ 57",
+              "57 _ 59",
+              "59 _ 61",
+              "61 _ 63",
+              "63 _ 65",
+              "65 _ 67",
+              "67 _ 69",
+              "69 _ 71",
+              "71 _ 73",
+              "73 _ 75",
+              "75 _ 77",
+              "77 _ 79",
+              "79 _ 81",
+              "81 _ 83",
+              "83 _ 85",
+              "85 _ 87",
+              "87 _ 89",
+              "89 _ 91",
+              "91 _ 93",
+              "93 _ 95",
+              "95 _ 97",
+              "97 _ 99",
+              "99 _ 101"
+            ],
+            "counts": [
+              3,
+              3,
+              1,
+              3,
+              1,
+              2,
+              1,
+              1,
+              1,
+              2,
+              4,
+              0,
+              4,
+              3,
+              2,
+              2,
+              2,
+              3,
+              1,
+              2,
+              3,
+              0,
+              2,
+              2,
+              2,
+              4,
+              7,
+              0,
+              2,
+              1,
+              0,
+              4,
+              3,
+              1,
+              4,
+              3,
+              0,
+              1,
+              0,
+              3,
+              0,
+              2,
+              3,
+              1,
+              3,
+              2,
+              3,
+              0,
+              0,
+              2
+            ],
+            "bin_edges": [
+              1,
+              3,
+              5,
+              7,
+              9,
+              11,
+              13,
+              15,
+              17,
+              19,
+              21,
+              23,
+              25,
+              27,
+              29,
+              31,
+              33,
+              35,
+              37,
+              39,
+              41,
+              43,
+              45,
+              47,
+              49,
+              51,
+              53,
+              55,
+              57,
+              59,
+              61,
+              63,
+              65,
+              67,
+              69,
+              71,
+              73,
+              75,
+              77,
+              79,
+              81,
+              83,
+              85,
+              87,
+              89,
+              91,
+              93,
+              95,
+              97,
+              99,
+              101
+            ]
+          },
+          "p5": 3,
+          "p25": 26,
+          "p50": 50,
+          "p75": 70,
+          "p95": 93,
+          "topk": {
+            "values": [
+              "54",
+              "3",
+              "22",
+              "51",
+              "66",
+              "71",
+              "1",
+              "8",
+              "25",
+              "26",
+              "27",
+              "30",
+              "35",
+              "42",
+              "46",
+              "47",
+              "50",
+              "53",
+              "57",
+              "63",
+              "64",
+              "69",
+              "70",
+              "79",
+              "84",
+              "85",
+              "90",
+              "94",
+              "99",
+              "2",
+              "6",
+              "7",
+              "9",
+              "11",
+              "12",
+              "13",
+              "16",
+              "18",
+              "19",
+              "20",
+              "21",
+              "28",
+              "31",
+              "32",
+              "33",
+              "34",
+              "36",
+              "38",
+              "39",
+              "40"
+            ],
+            "counts": [
+              5,
+              3,
+              3,
+              3,
+              3,
+              3,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1
+            ]
+          },
+          "profile_duration": "0.03",
+          "elapsed_milli": 29,
+          "description": "This is a unique identifier for a customer"
+        },
+        "order_date": {
+          "name": "order_date",
+          "type": "datetime",
+          "schema_type": "DATE",
+          "total": 99,
+          "samples": 99,
+          "samples_p": 1,
+          "non_nulls": 99,
+          "non_nulls_p": 1,
+          "nulls": 0,
+          "nulls_p": 0,
+          "valids": 99,
+          "valids_p": 1,
+          "invalids": 0,
+          "invalids_p": 0,
+          "distinct": 69,
+          "distinct_p": 0.696969696969697,
+          "min": "2023-03-14",
+          "max": "2023-06-20",
+          "duplicates": 53,
+          "duplicates_p": 0.5353535353535354,
+          "non_duplicates": 46,
+          "non_duplicates_p": 0.46464646464646464,
+          "histogram": {
+            "labels": [
+              "2023-03-01 - 2023-04-01",
+              "2023-04-01 - 2023-05-01",
+              "2023-05-01 - 2023-06-01",
+              "2023-06-01 - 2023-07-01"
+            ],
+            "counts": [
+              17,
+              28,
+              31,
+              23
+            ],
+            "bin_edges": [
+              "2023-03-01",
+              "2023-04-01",
+              "2023-05-01",
+              "2023-06-01",
+              "2023-07-01"
+            ]
+          },
+          "profile_duration": "0.02",
+          "elapsed_milli": 21,
+          "description": "Date (UTC) that the order was placed"
+        },
+        "status": {
+          "name": "status",
+          "type": "string",
+          "schema_type": "VARCHAR",
+          "total": 99,
+          "samples": 99,
+          "samples_p": 1,
+          "non_nulls": 99,
+          "non_nulls_p": 1,
+          "nulls": 0,
+          "nulls_p": 0,
+          "valids": 99,
+          "valids_p": 1,
+          "invalids": 0,
+          "invalids_p": 0,
+          "zero_length": 0,
+          "zero_length_p": 0,
+          "non_zero_length": 99,
+          "non_zero_length_p": 1,
+          "distinct": 5,
+          "distinct_p": 0.050505050505050504,
+          "min": 6,
+          "min_length": 6,
+          "max": 14,
+          "max_length": 14,
+          "avg": 8.404040404040405,
+          "avg_length": 8.404040404040405,
+          "stddev": 1.3844559228926328,
+          "stddev_length": 1.3844559228926328,
+          "duplicates": 99,
+          "duplicates_p": 1,
+          "non_duplicates": 0,
+          "non_duplicates_p": 0,
+          "topk": {
+            "values": [
+              "completed",
+              "shipped",
+              "placed",
+              "returned",
+              "return_pending"
+            ],
+            "counts": [
+              67,
+              13,
+              13,
+              4,
+              2
+            ]
+          },
+          "histogram": {
+            "labels": [
+              "6",
+              "7",
+              "8",
+              "9",
+              "10",
+              "11",
+              "12",
+              "13",
+              "14"
+            ],
+            "counts": [
+              13,
+              13,
+              4,
+              67,
+              0,
+              0,
+              0,
+              0,
+              2
+            ],
+            "bin_edges": [
+              6,
+              7,
+              8,
+              9,
+              10,
+              11,
+              12,
+              13,
+              14,
+              15
+            ]
+          },
+          "histogram_length": {
+            "labels": [
+              "6",
+              "7",
+              "8",
+              "9",
+              "10",
+              "11",
+              "12",
+              "13",
+              "14"
+            ],
+            "counts": [
+              13,
+              13,
+              4,
+              67,
+              0,
+              0,
+              0,
+              0,
+              2
+            ],
+            "bin_edges": [
+              6,
+              7,
+              8,
+              9,
+              10,
+              11,
+              12,
+              13,
+              14,
+              15
+            ]
+          },
+          "profile_duration": "0.03",
+          "elapsed_milli": 29,
+          "description": "Orders can be one of the following statuses:\n\n| status         | description                                                                                                            |\n|----------------|------------------------------------------------------------------------------------------------------------------------|\n| placed         | The order has been placed but has not yet left the warehouse                                                           |\n| shipped        | The order has ben shipped to the customer and is currently in transit                                                  |\n| completed      | The order has been received by the customer                                                                            |\n| return_pending | The customer has indicated that they would like to return the order, but it has not yet been received at the warehouse |\n| returned       | The order has been returned by the customer and received at the warehouse                                              |"
+        },
+        "credit_card_amount": {
+          "name": "credit_card_amount",
+          "type": "integer",
+          "schema_type": "BIGINT",
+          "total": 99,
+          "samples": 99,
+          "samples_p": 1,
+          "non_nulls": 99,
+          "non_nulls_p": 1,
+          "nulls": 0,
+          "nulls_p": 0,
+          "valids": 99,
+          "valids_p": 1,
+          "invalids": 0,
+          "invalids_p": 0,
+          "zeros": 50,
+          "zeros_p": 0.5050505050505051,
+          "negatives": 0,
+          "negatives_p": 0,
+          "positives": 49,
+          "positives_p": 0.494949494949495,
+          "distinct": 25,
+          "distinct_p": 0.25252525252525254,
+          "min": 0,
+          "max": 30,
+          "sum": 871,
+          "avg": 8.797979797979798,
+          "stddev": 10.959088854927677,
+          "duplicates": 91,
+          "duplicates_p": 0.9191919191919192,
+          "non_duplicates": 8,
+          "non_duplicates_p": 0.08080808080808081,
+          "histogram": {
+            "labels": [
+              "0",
+              "1",
+              "2",
+              "3",
+              "4",
+              "5",
+              "6",
+              "7",
+              "8",
+              "9",
+              "10",
+              "11",
+              "12",
+              "13",
+              "14",
+              "15",
+              "16",
+              "17",
+              "18",
+              "19",
+              "20",
+              "21",
+              "22",
+              "23",
+              "24",
+              "25",
+              "26",
+              "27",
+              "28",
+              "29",
+              "30"
+            ],
+            "counts": [
+              50,
+              2,
+              0,
+              2,
+              2,
+              2,
+              1,
+              0,
+              1,
+              0,
+              2,
+              0,
+              2,
+              2,
+              1,
+              2,
+              2,
+              1,
+              1,
+              4,
+              1,
+              0,
+              3,
+              3,
+              1,
+              0,
+              3,
+              2,
+              1,
+              5,
+              3
+            ],
+            "bin_edges": [
+              0,
+              1,
+              2,
+              3,
+              4,
+              5,
+              6,
+              7,
+              8,
+              9,
+              10,
+              11,
+              12,
+              13,
+              14,
+              15,
+              16,
+              17,
+              18,
+              19,
+              20,
+              21,
+              22,
+              23,
+              24,
+              25,
+              26,
+              27,
+              28,
+              29,
+              30,
+              31
+            ]
+          },
+          "p5": 0,
+          "p25": 0,
+          "p50": 0,
+          "p75": 19,
+          "p95": 29,
+          "topk": {
+            "values": [
+              "0",
+              "29",
+              "19",
+              "22",
+              "23",
+              "26",
+              "30",
+              "1",
+              "3",
+              "4",
+              "5",
+              "10",
+              "12",
+              "13",
+              "15",
+              "16",
+              "27",
+              "6",
+              "8",
+              "14",
+              "17",
+              "18",
+              "20",
+              "24",
+              "28"
+            ],
+            "counts": [
+              50,
+              5,
+              4,
+              3,
+              3,
+              3,
+              3,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1
+            ]
+          },
+          "profile_duration": "0.03",
+          "elapsed_milli": 33,
+          "description": "Amount of the order (AUD) paid for by credit card"
+        },
+        "coupon_amount": {
+          "name": "coupon_amount",
+          "type": "integer",
+          "schema_type": "BIGINT",
+          "total": 99,
+          "samples": 99,
+          "samples_p": 1,
+          "non_nulls": 99,
+          "non_nulls_p": 1,
+          "nulls": 0,
+          "nulls_p": 0,
+          "valids": 99,
+          "valids_p": 1,
+          "invalids": 0,
+          "invalids_p": 0,
+          "zeros": 86,
+          "zeros_p": 0.8686868686868687,
+          "negatives": 0,
+          "negatives_p": 0,
+          "positives": 13,
+          "positives_p": 0.13131313131313133,
+          "distinct": 12,
+          "distinct_p": 0.12121212121212122,
+          "min": 0,
+          "max": 26,
+          "sum": 185,
+          "avg": 1.8686868686868687,
+          "stddev": 5.955012405351228,
+          "duplicates": 89,
+          "duplicates_p": 0.898989898989899,
+          "non_duplicates": 10,
+          "non_duplicates_p": 0.10101010101010101,
+          "histogram": {
+            "labels": [
+              "0",
+              "1",
+              "2",
+              "3",
+              "4",
+              "5",
+              "6",
+              "7",
+              "8",
+              "9",
+              "10",
+              "11",
+              "12",
+              "13",
+              "14",
+              "15",
+              "16",
+              "17",
+              "18",
+              "19",
+              "20",
+              "21",
+              "22",
+              "23",
+              "24",
+              "25",
+              "26"
+            ],
+            "counts": [
+              86,
+              1,
+              3,
+              0,
+              0,
+              0,
+              0,
+              1,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              1,
+              1,
+              1,
+              0,
+              0,
+              0,
+              1,
+              1,
+              1,
+              1,
+              1
+            ],
+            "bin_edges": [
+              0,
+              1,
+              2,
+              3,
+              4,
+              5,
+              6,
+              7,
+              8,
+              9,
+              10,
+              11,
+              12,
+              13,
+              14,
+              15,
+              16,
+              17,
+              18,
+              19,
+              20,
+              21,
+              22,
+              23,
+              24,
+              25,
+              26,
+              27
+            ]
+          },
+          "p5": 0,
+          "p25": 0,
+          "p50": 0,
+          "p75": 0,
+          "p95": 20,
+          "topk": {
+            "values": [
+              "0",
+              "2",
+              "1",
+              "7",
+              "16",
+              "17",
+              "18",
+              "22",
+              "23",
+              "24",
+              "25",
+              "26"
+            ],
+            "counts": [
+              86,
+              3,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1
+            ]
+          },
+          "profile_duration": "0.05",
+          "elapsed_milli": 47,
+          "description": "Amount of the order (AUD) paid for by coupon"
+        },
+        "bank_transfer_amount": {
+          "name": "bank_transfer_amount",
+          "type": "integer",
+          "schema_type": "BIGINT",
+          "total": 99,
+          "samples": 99,
+          "samples_p": 1,
+          "non_nulls": 99,
+          "non_nulls_p": 1,
+          "nulls": 0,
+          "nulls_p": 0,
+          "valids": 99,
+          "valids_p": 1,
+          "invalids": 0,
+          "invalids_p": 0,
+          "zeros": 67,
+          "zeros_p": 0.6767676767676768,
+          "negatives": 0,
+          "negatives_p": 0,
+          "positives": 32,
+          "positives_p": 0.32323232323232326,
+          "distinct": 19,
+          "distinct_p": 0.1919191919191919,
+          "min": 0,
+          "max": 26,
+          "sum": 411,
+          "avg": 4.151515151515151,
+          "stddev": 7.420825132023677,
+          "duplicates": 89,
+          "duplicates_p": 0.898989898989899,
+          "non_duplicates": 10,
+          "non_duplicates_p": 0.10101010101010101,
+          "histogram": {
+            "labels": [
+              "0",
+              "1",
+              "2",
+              "3",
+              "4",
+              "5",
+              "6",
+              "7",
+              "8",
+              "9",
+              "10",
+              "11",
+              "12",
+              "13",
+              "14",
+              "15",
+              "16",
+              "17",
+              "18",
+              "19",
+              "20",
+              "21",
+              "22",
+              "23",
+              "24",
+              "25",
+              "26"
+            ],
+            "counts": [
+              67,
+              0,
+              3,
+              3,
+              1,
+              1,
+              0,
+              0,
+              3,
+              1,
+              1,
+              1,
+              1,
+              0,
+              2,
+              4,
+              1,
+              2,
+              0,
+              2,
+              1,
+              0,
+              1,
+              0,
+              0,
+              1,
+              3
+            ],
+            "bin_edges": [
+              0,
+              1,
+              2,
+              3,
+              4,
+              5,
+              6,
+              7,
+              8,
+              9,
+              10,
+              11,
+              12,
+              13,
+              14,
+              15,
+              16,
+              17,
+              18,
+              19,
+              20,
+              21,
+              22,
+              23,
+              24,
+              25,
+              26,
+              27
+            ]
+          },
+          "p5": 0,
+          "p25": 0,
+          "p50": 0,
+          "p75": 5,
+          "p95": 21,
+          "topk": {
+            "values": [
+              "0",
+              "15",
+              "2",
+              "3",
+              "8",
+              "26",
+              "14",
+              "17",
+              "19",
+              "4",
+              "5",
+              "9",
+              "10",
+              "11",
+              "12",
+              "16",
+              "20",
+              "22",
+              "25"
+            ],
+            "counts": [
+              67,
+              4,
+              3,
+              3,
+              3,
+              3,
+              2,
+              2,
+              2,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1
+            ]
+          },
+          "profile_duration": "0.05",
+          "elapsed_milli": 48,
+          "description": "Amount of the order (AUD) paid for by bank transfer"
+        },
+        "gift_card_amount": {
+          "name": "gift_card_amount",
+          "type": "integer",
+          "schema_type": "BIGINT",
+          "total": 99,
+          "samples": 99,
+          "samples_p": 1,
+          "non_nulls": 99,
+          "non_nulls_p": 1,
+          "nulls": 0,
+          "nulls_p": 0,
+          "valids": 99,
+          "valids_p": 1,
+          "invalids": 0,
+          "invalids_p": 0,
+          "zeros": 87,
+          "zeros_p": 0.8787878787878788,
+          "negatives": 0,
+          "negatives_p": 0,
+          "positives": 12,
+          "positives_p": 0.12121212121212122,
+          "distinct": 11,
+          "distinct_p": 0.1111111111111111,
+          "min": 0,
+          "max": 30,
+          "sum": 205,
+          "avg": 2.0707070707070705,
+          "stddev": 6.3923623515665176,
+          "duplicates": 91,
+          "duplicates_p": 0.9191919191919192,
+          "non_duplicates": 8,
+          "non_duplicates_p": 0.08080808080808081,
+          "histogram": {
+            "labels": [
+              "0",
+              "1",
+              "2",
+              "3",
+              "4",
+              "5",
+              "6",
+              "7",
+              "8",
+              "9",
+              "10",
+              "11",
+              "12",
+              "13",
+              "14",
+              "15",
+              "16",
+              "17",
+              "18",
+              "19",
+              "20",
+              "21",
+              "22",
+              "23",
+              "24",
+              "25",
+              "26",
+              "27",
+              "28",
+              "29",
+              "30"
+            ],
+            "counts": [
+              87,
+              0,
+              0,
+              1,
+              0,
+              0,
+              2,
+              0,
+              0,
+              0,
+              0,
+              1,
+              0,
+              0,
+              1,
+              0,
+              0,
+              1,
+              1,
+              0,
+              0,
+              0,
+              0,
+              2,
+              0,
+              0,
+              1,
+              0,
+              1,
+              0,
+              1
+            ],
+            "bin_edges": [
+              0,
+              1,
+              2,
+              3,
+              4,
+              5,
+              6,
+              7,
+              8,
+              9,
+              10,
+              11,
+              12,
+              13,
+              14,
+              15,
+              16,
+              17,
+              18,
+              19,
+              20,
+              21,
+              22,
+              23,
+              24,
+              25,
+              26,
+              27,
+              28,
+              29,
+              30,
+              31
+            ]
+          },
+          "p5": 0,
+          "p25": 0,
+          "p50": 0,
+          "p75": 0,
+          "p95": 21,
+          "topk": {
+            "values": [
+              "0",
+              "6",
+              "23",
+              "3",
+              "11",
+              "14",
+              "17",
+              "18",
+              "26",
+              "28",
+              "30"
+            ],
+            "counts": [
+              87,
+              2,
+              2,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1
+            ]
+          },
+          "profile_duration": "0.05",
+          "elapsed_milli": 51,
+          "description": "Amount of the order (AUD) paid for by gift card"
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "schema_type": "BIGINT",
+          "total": 99,
+          "samples": 99,
+          "samples_p": 1,
+          "non_nulls": 99,
+          "non_nulls_p": 1,
+          "nulls": 0,
+          "nulls_p": 0,
+          "valids": 99,
+          "valids_p": 1,
+          "invalids": 0,
+          "invalids_p": 0,
+          "zeros": 1,
+          "zeros_p": 0.010101010101010102,
+          "negatives": 0,
+          "negatives_p": 0,
+          "positives": 98,
+          "positives_p": 0.98989898989899,
+          "distinct": 32,
+          "distinct_p": 0.32323232323232326,
+          "min": 0,
+          "max": 58,
+          "sum": 1672,
+          "avg": 16.88888888888889,
+          "stddev": 10.736062525374601,
+          "duplicates": 91,
+          "duplicates_p": 0.9191919191919192,
+          "non_duplicates": 8,
+          "non_duplicates_p": 0.08080808080808081,
+          "histogram": {
+            "labels": [
+              "0 _ 2",
+              "2 _ 4",
+              "4 _ 6",
+              "6 _ 8",
+              "8 _ 10",
+              "10 _ 12",
+              "12 _ 14",
+              "14 _ 16",
+              "16 _ 18",
+              "18 _ 20",
+              "20 _ 22",
+              "22 _ 24",
+              "24 _ 26",
+              "26 _ 28",
+              "28 _ 30",
+              "30 _ 32",
+              "32 _ 34",
+              "34 _ 36",
+              "36 _ 38",
+              "38 _ 40",
+              "40 _ 42",
+              "42 _ 44",
+              "44 _ 46",
+              "46 _ 48",
+              "48 _ 50",
+              "50 _ 52",
+              "52 _ 54",
+              "54 _ 56",
+              "56 _ 58",
+              "58 _ 60"
+            ],
+            "counts": [
+              4,
+              11,
+              4,
+              3,
+              5,
+              4,
+              5,
+              8,
+              9,
+              7,
+              1,
+              11,
+              5,
+              9,
+              8,
+              3,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              1,
+              1
+            ],
+            "bin_edges": [
+              0,
+              2,
+              4,
+              6,
+              8,
+              10,
+              12,
+              14,
+              16,
+              18,
+              20,
+              22,
+              24,
+              26,
+              28,
+              30,
+              32,
+              34,
+              36,
+              38,
+              40,
+              42,
+              44,
+              46,
+              48,
+              50,
+              52,
+              54,
+              56,
+              58,
+              60
+            ]
+          },
+          "p5": 2,
+          "p25": 8,
+          "p50": 17,
+          "p75": 24,
+          "p95": 30,
+          "topk": {
+            "values": [
+              "23",
+              "26",
+              "3",
+              "17",
+              "19",
+              "29",
+              "2",
+              "15",
+              "8",
+              "22",
+              "1",
+              "10",
+              "12",
+              "14",
+              "16",
+              "24",
+              "30",
+              "4",
+              "5",
+              "6",
+              "13",
+              "25",
+              "27",
+              "28",
+              "0",
+              "7",
+              "9",
+              "11",
+              "18",
+              "20",
+              "56",
+              "58"
+            ],
+            "counts": [
+              7,
+              7,
+              6,
+              6,
+              6,
+              6,
+              5,
+              5,
+              4,
+              4,
+              3,
+              3,
+              3,
+              3,
+              3,
+              3,
+              3,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1
+            ]
+          },
+          "profile_duration": "0.06",
+          "elapsed_milli": 59,
+          "description": "Total amount (AUD) of the order"
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "string",
+          "schema_type": "VARCHAR",
+          "total": 99,
+          "samples": 99,
+          "samples_p": 1,
+          "non_nulls": 99,
+          "non_nulls_p": 1,
+          "nulls": 0,
+          "nulls_p": 0,
+          "valids": 99,
+          "valids_p": 1,
+          "invalids": 0,
+          "invalids_p": 0,
+          "zero_length": 0,
+          "zero_length_p": 0,
+          "non_zero_length": 99,
+          "non_zero_length_p": 1,
+          "distinct": 55,
+          "distinct_p": 0.5555555555555556,
+          "min": 3,
+          "min_length": 3,
+          "max": 9,
+          "max_length": 9,
+          "avg": 5.565656565656566,
+          "avg_length": 5.565656565656566,
+          "stddev": 1.526377705961887,
+          "stddev_length": 1.526377705961887,
+          "duplicates": 73,
+          "duplicates_p": 0.7373737373737373,
+          "non_duplicates": 26,
+          "non_duplicates_p": 0.26262626262626265,
+          "topk": {
+            "values": [
+              "Rose",
+              "Adam",
+              "Kathleen",
+              "Christina",
+              "Paul",
+              "Gerald",
+              "Sean",
+              "Howard",
+              "Michael",
+              "Gregory",
+              "Billy",
+              "David",
+              "Mary",
+              "Victor",
+              "Frank",
+              "Janet",
+              "Diana",
+              "Theresa",
+              "Aaron",
+              "Willie",
+              "Benjamin",
+              "Sara",
+              "Jennifer",
+              "Edward",
+              "Helen",
+              "Norma",
+              "Marie",
+              "Anne",
+              "Jack",
+              "Shawn",
+              "Martin",
+              "Maria",
+              "Louise",
+              "Anna",
+              "Jason",
+              "Thomas",
+              "Amanda",
+              "Lisa",
+              "Dennis",
+              "Phillip",
+              "Katherine",
+              "Jane",
+              "Sarah",
+              "Johnny",
+              "Frances",
+              "Amy",
+              "Harold",
+              "Virginia",
+              "Laura",
+              "Fred"
+            ],
+            "counts": [
+              5,
+              5,
+              4,
+              4,
+              4,
+              3,
+              3,
+              3,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1
+            ]
+          },
+          "histogram": {
+            "labels": [
+              "3",
+              "4",
+              "5",
+              "6",
+              "7",
+              "8",
+              "9"
+            ],
+            "counts": [
+              1,
+              30,
+              24,
+              20,
+              9,
+              10,
+              5
+            ],
+            "bin_edges": [
+              3,
+              4,
+              5,
+              6,
+              7,
+              8,
+              9,
+              10
+            ]
+          },
+          "histogram_length": {
+            "labels": [
+              "3",
+              "4",
+              "5",
+              "6",
+              "7",
+              "8",
+              "9"
+            ],
+            "counts": [
+              1,
+              30,
+              24,
+              20,
+              9,
+              10,
+              5
+            ],
+            "bin_edges": [
+              3,
+              4,
+              5,
+              6,
+              7,
+              8,
+              9,
+              10
+            ]
+          },
+          "profile_duration": "0.05",
+          "elapsed_milli": 53,
+          "description": "Customer's first name. PII."
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "string",
+          "schema_type": "VARCHAR",
+          "total": 99,
+          "samples": 99,
+          "samples_p": 1,
+          "non_nulls": 99,
+          "non_nulls_p": 1,
+          "nulls": 0,
+          "nulls_p": 0,
+          "valids": 99,
+          "valids_p": 1,
+          "invalids": 0,
+          "invalids_p": 0,
+          "zero_length": 0,
+          "zero_length_p": 0,
+          "non_zero_length": 99,
+          "non_zero_length_p": 1,
+          "distinct": 18,
+          "distinct_p": 0.18181818181818182,
+          "min": 2,
+          "min_length": 2,
+          "max": 2,
+          "max_length": 2,
+          "avg": 2,
+          "avg_length": 2,
+          "stddev": 0,
+          "stddev_length": 0,
+          "duplicates": 96,
+          "duplicates_p": 0.9696969696969697,
+          "non_duplicates": 3,
+          "non_duplicates_p": 0.030303030303030304,
+          "topk": {
+            "values": [
+              "R.",
+              "P.",
+              "M.",
+              "W.",
+              "H.",
+              "C.",
+              "G.",
+              "F.",
+              "S.",
+              "B.",
+              "T.",
+              "A.",
+              "O.",
+              "L.",
+              "J.",
+              "K.",
+              "D.",
+              "E."
+            ],
+            "counts": [
+              13,
+              11,
+              11,
+              11,
+              10,
+              9,
+              5,
+              5,
+              4,
+              4,
+              3,
+              3,
+              3,
+              2,
+              2,
+              1,
+              1,
+              1
+            ]
+          },
+          "histogram": {
+            "labels": [
+              "2"
+            ],
+            "counts": [
+              99
+            ],
+            "bin_edges": [
+              2,
+              3
+            ]
+          },
+          "histogram_length": {
+            "labels": [
+              "2"
+            ],
+            "counts": [
+              99
+            ],
+            "bin_edges": [
+              2,
+              3
+            ]
+          },
+          "profile_duration": "0.06",
+          "elapsed_milli": 59,
+          "description": "Customer's last name. PII."
+        },
+        "first_order": {
+          "name": "first_order",
+          "type": "datetime",
+          "schema_type": "DATE",
+          "total": 99,
+          "samples": 99,
+          "samples_p": 1,
+          "non_nulls": 99,
+          "non_nulls_p": 1,
+          "nulls": 0,
+          "nulls_p": 0,
+          "valids": 99,
+          "valids_p": 1,
+          "invalids": 0,
+          "invalids_p": 0,
+          "distinct": 46,
+          "distinct_p": 0.46464646464646464,
+          "min": "2023-03-14",
+          "max": "2023-06-18",
+          "duplicates": 80,
+          "duplicates_p": 0.8080808080808081,
+          "non_duplicates": 19,
+          "non_duplicates_p": 0.1919191919191919,
+          "histogram": {
+            "labels": [
+              "2023-03-01 - 2023-04-01",
+              "2023-04-01 - 2023-05-01",
+              "2023-05-01 - 2023-06-01",
+              "2023-06-01 - 2023-07-01"
+            ],
+            "counts": [
+              33,
+              31,
+              21,
+              14
+            ],
+            "bin_edges": [
+              "2023-03-01",
+              "2023-04-01",
+              "2023-05-01",
+              "2023-06-01",
+              "2023-07-01"
+            ]
+          },
+          "profile_duration": "0.06",
+          "elapsed_milli": 59,
+          "description": "Date (UTC) of a customer's first order"
+        },
+        "most_recent_order": {
+          "name": "most_recent_order",
+          "type": "datetime",
+          "schema_type": "DATE",
+          "total": 99,
+          "samples": 99,
+          "samples_p": 1,
+          "non_nulls": 99,
+          "non_nulls_p": 1,
+          "nulls": 0,
+          "nulls_p": 0,
+          "valids": 99,
+          "valids_p": 1,
+          "invalids": 0,
+          "invalids_p": 0,
+          "distinct": 52,
+          "distinct_p": 0.5252525252525253,
+          "min": "2023-03-22",
+          "max": "2023-06-20",
+          "duplicates": 74,
+          "duplicates_p": 0.7474747474747475,
+          "non_duplicates": 25,
+          "non_duplicates_p": 0.25252525252525254,
+          "histogram": {
+            "labels": [
+              "2023-03-01 - 2023-04-01",
+              "2023-04-01 - 2023-05-01",
+              "2023-05-01 - 2023-06-01",
+              "2023-06-01 - 2023-07-01"
+            ],
+            "counts": [
+              6,
+              18,
+              41,
+              34
+            ],
+            "bin_edges": [
+              "2023-03-01",
+              "2023-04-01",
+              "2023-05-01",
+              "2023-06-01",
+              "2023-07-01"
+            ]
+          },
+          "profile_duration": "0.06",
+          "elapsed_milli": 61,
+          "description": "Date (UTC) of a customer's most recent order"
+        },
+        "number_of_orders": {
+          "name": "number_of_orders",
+          "type": "integer",
+          "schema_type": "BIGINT",
+          "total": 99,
+          "samples": 99,
+          "samples_p": 1,
+          "non_nulls": 99,
+          "non_nulls_p": 1,
+          "nulls": 0,
+          "nulls_p": 0,
+          "valids": 99,
+          "valids_p": 1,
+          "invalids": 0,
+          "invalids_p": 0,
+          "zeros": 0,
+          "zeros_p": 0,
+          "negatives": 0,
+          "negatives_p": 0,
+          "positives": 99,
+          "positives_p": 1,
+          "distinct": 4,
+          "distinct_p": 0.04040404040404041,
+          "min": 1,
+          "max": 5,
+          "sum": 195,
+          "avg": 1.9696969696969697,
+          "stddev": 0.9736795920896912,
+          "duplicates": 99,
+          "duplicates_p": 1,
+          "non_duplicates": 0,
+          "non_duplicates_p": 0,
+          "histogram": {
+            "labels": [
+              "1",
+              "2",
+              "3",
+              "4",
+              "5"
+            ],
+            "counts": [
+              33,
+              46,
+              15,
+              0,
+              5
+            ],
+            "bin_edges": [
+              1,
+              2,
+              3,
+              4,
+              5,
+              6
+            ]
+          },
+          "p5": 1,
+          "p25": 1,
+          "p50": 2,
+          "p75": 2,
+          "p95": 4,
+          "topk": {
+            "values": [
+              "2",
+              "1",
+              "3",
+              "5"
+            ],
+            "counts": [
+              46,
+              33,
+              15,
+              5
+            ]
+          },
+          "profile_duration": "0.06",
+          "elapsed_milli": 64,
+          "description": "Count of the number of orders a customer has placed"
+        },
+        "customer_lifetime_value": {
+          "name": "customer_lifetime_value",
+          "type": "integer",
+          "schema_type": "BIGINT",
+          "total": 99,
+          "samples": 99,
+          "samples_p": 1,
+          "non_nulls": 99,
+          "non_nulls_p": 1,
+          "nulls": 0,
+          "nulls_p": 0,
+          "valids": 99,
+          "valids_p": 1,
+          "invalids": 0,
+          "invalids_p": 0,
+          "zeros": 0,
+          "zeros_p": 0,
+          "negatives": 0,
+          "negatives_p": 0,
+          "positives": 99,
+          "positives_p": 1,
+          "distinct": 35,
+          "distinct_p": 0.35353535353535354,
+          "min": 1,
+          "max": 99,
+          "sum": 3311,
+          "avg": 33.44444444444444,
+          "stddev": 20.596325322252156,
+          "duplicates": 91,
+          "duplicates_p": 0.9191919191919192,
+          "non_duplicates": 8,
+          "non_duplicates_p": 0.08080808080808081,
+          "histogram": {
+            "labels": [
+              "1 _ 3",
+              "3 _ 5",
+              "5 _ 7",
+              "7 _ 9",
+              "9 _ 11",
+              "11 _ 13",
+              "13 _ 15",
+              "15 _ 17",
+              "17 _ 19",
+              "19 _ 21",
+              "21 _ 23",
+              "23 _ 25",
+              "25 _ 27",
+              "27 _ 29",
+              "29 _ 31",
+              "31 _ 33",
+              "33 _ 35",
+              "35 _ 37",
+              "37 _ 39",
+              "39 _ 41",
+              "41 _ 43",
+              "43 _ 45",
+              "45 _ 47",
+              "47 _ 49",
+              "49 _ 51",
+              "51 _ 53",
+              "53 _ 55",
+              "55 _ 57",
+              "57 _ 59",
+              "59 _ 61",
+              "61 _ 63",
+              "63 _ 65",
+              "65 _ 67",
+              "67 _ 69",
+              "69 _ 71",
+              "71 _ 73",
+              "73 _ 75",
+              "75 _ 77",
+              "77 _ 79",
+              "79 _ 81",
+              "81 _ 83",
+              "83 _ 85",
+              "85 _ 87",
+              "87 _ 89",
+              "89 _ 91",
+              "91 _ 93",
+              "93 _ 95",
+              "95 _ 97",
+              "97 _ 99",
+              "99 _ 101"
+            ],
+            "counts": [
+              3,
+              6,
+              0,
+              4,
+              2,
+              1,
+              2,
+              3,
+              2,
+              0,
+              1,
+              8,
+              4,
+              8,
+              7,
+              2,
+              6,
+              4,
+              0,
+              5,
+              0,
+              7,
+              2,
+              2,
+              0,
+              3,
+              2,
+              0,
+              7,
+              0,
+              0,
+              2,
+              3,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              3
+            ],
+            "bin_edges": [
+              1,
+              3,
+              5,
+              7,
+              9,
+              11,
+              13,
+              15,
+              17,
+              19,
+              21,
+              23,
+              25,
+              27,
+              29,
+              31,
+              33,
+              35,
+              37,
+              39,
+              41,
+              43,
+              45,
+              47,
+              49,
+              51,
+              53,
+              55,
+              57,
+              59,
+              61,
+              63,
+              65,
+              67,
+              69,
+              71,
+              73,
+              75,
+              77,
+              79,
+              81,
+              83,
+              85,
+              87,
+              89,
+              91,
+              93,
+              95,
+              97,
+              99,
+              101
+            ]
+          },
+          "p5": 3,
+          "p25": 23,
+          "p50": 30,
+          "p75": 44,
+          "p95": 65,
+          "topk": {
+            "values": [
+              "27",
+              "57",
+              "3",
+              "39",
+              "44",
+              "8",
+              "23",
+              "24",
+              "26",
+              "30",
+              "33",
+              "36",
+              "29",
+              "52",
+              "65",
+              "99",
+              "2",
+              "10",
+              "14",
+              "15",
+              "32",
+              "34",
+              "43",
+              "45",
+              "47",
+              "54",
+              "64",
+              "1",
+              "4",
+              "12",
+              "16",
+              "17",
+              "18",
+              "22",
+              "28"
+            ],
+            "counts": [
+              7,
+              7,
+              5,
+              5,
+              5,
+              4,
+              4,
+              4,
+              4,
+              4,
+              4,
+              4,
+              3,
+              3,
+              3,
+              3,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1,
+              1
+            ]
+          },
+          "profile_duration": "0.07",
+          "elapsed_milli": 67
+        }
+      },
+      "profile_duration": "0.07",
+      "elapsed_milli": 68,
+      "description": "This table has basic information about orders, as well as some derived facts based on payments"
+    },
+    "raw_customers": {
+      "name": "raw_customers",
+      "col_count": 3,
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "schema_type": "INTEGER"
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "string",
+          "schema_type": "VARCHAR"
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "string",
+          "schema_type": "VARCHAR"
+        }
+      }
+    },
+    "raw_orders": {
+      "name": "raw_orders",
+      "col_count": 4,
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "schema_type": "INTEGER"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "schema_type": "INTEGER"
+        },
+        "order_date": {
+          "name": "order_date",
+          "type": "datetime",
+          "schema_type": "DATE"
+        },
+        "status": {
+          "name": "status",
+          "type": "string",
+          "schema_type": "VARCHAR"
+        }
+      }
+    },
+    "raw_payments": {
+      "name": "raw_payments",
+      "col_count": 4,
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "schema_type": "INTEGER"
+        },
+        "order_id": {
+          "name": "order_id",
+          "type": "integer",
+          "schema_type": "INTEGER"
+        },
+        "payment_method": {
+          "name": "payment_method",
+          "type": "string",
+          "schema_type": "VARCHAR"
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "schema_type": "INTEGER"
+        }
+      }
+    }
+  },
+  "metrics": [
+    {
+      "name": "expenses_daily",
+      "label": "Expenses (Daily)",
+      "description": "The total expenses of our jaffle business",
+      "grain": "day",
+      "dimensions": [],
+      "headers": [
+        "date_day",
+        "expenses"
+      ],
+      "data": [
+        [
+          "2023-05-21",
+          7
+        ],
+        [
+          "2023-05-22",
+          13
+        ],
+        [
+          "2023-05-23",
+          6
+        ],
+        [
+          "2023-05-24",
+          0
+        ],
+        [
+          "2023-05-25",
+          0
+        ],
+        [
+          "2023-05-26",
+          0
+        ],
+        [
+          "2023-05-27",
+          0
+        ],
+        [
+          "2023-05-28",
+          0
+        ],
+        [
+          "2023-05-29",
+          4
+        ],
+        [
+          "2023-05-30",
+          0
+        ],
+        [
+          "2023-05-31",
+          0
+        ],
+        [
+          "2023-06-01",
+          0
+        ],
+        [
+          "2023-06-02",
+          0
+        ],
+        [
+          "2023-06-03",
+          0
+        ],
+        [
+          "2023-06-04",
+          0
+        ],
+        [
+          "2023-06-05",
+          0
+        ],
+        [
+          "2023-06-06",
+          0
+        ],
+        [
+          "2023-06-07",
+          0
+        ],
+        [
+          "2023-06-08",
+          0
+        ],
+        [
+          "2023-06-09",
+          0
+        ],
+        [
+          "2023-06-10",
+          0
+        ],
+        [
+          "2023-06-11",
+          0
+        ],
+        [
+          "2023-06-12",
+          0
+        ],
+        [
+          "2023-06-13",
+          0
+        ],
+        [
+          "2023-06-14",
+          0
+        ],
+        [
+          "2023-06-15",
+          0
+        ],
+        [
+          "2023-06-16",
+          0
+        ],
+        [
+          "2023-06-17",
+          0
+        ],
+        [
+          "2023-06-18",
+          0
+        ],
+        [
+          "2023-06-19",
+          0
+        ],
+        [
+          "2023-06-20",
+          0
+        ]
+      ]
+    },
+    {
+      "name": "expenses_weekly",
+      "label": "Expenses (Weekly)",
+      "description": "The total expenses of our jaffle business",
+      "grain": "week",
+      "dimensions": [],
+      "headers": [
+        "date_week",
+        "expenses"
+      ],
+      "data": [
+        [
+          "2023-03-27",
+          23
+        ],
+        [
+          "2023-04-03",
+          15
+        ],
+        [
+          "2023-04-10",
+          39
+        ],
+        [
+          "2023-04-17",
+          25
+        ],
+        [
+          "2023-04-24",
+          20
+        ],
+        [
+          "2023-05-01",
+          23
+        ],
+        [
+          "2023-05-08",
+          33
+        ],
+        [
+          "2023-05-15",
+          23
+        ],
+        [
+          "2023-05-22",
+          19
+        ],
+        [
+          "2023-05-29",
+          4
+        ],
+        [
+          "2023-06-05",
+          0
+        ],
+        [
+          "2023-06-12",
+          0
+        ],
+        [
+          "2023-06-19",
+          0
+        ]
+      ]
+    },
+    {
+      "name": "expenses_monthly",
+      "label": "Expenses (Monthly)",
+      "description": "The total expenses of our jaffle business",
+      "grain": "month",
+      "dimensions": [],
+      "headers": [
+        "date_month",
+        "expenses"
+      ],
+      "data": [
+        [
+          "2022-06-01",
+          0
+        ],
+        [
+          "2022-07-01",
+          0
+        ],
+        [
+          "2022-08-01",
+          0
+        ],
+        [
+          "2022-09-01",
+          0
+        ],
+        [
+          "2022-10-01",
+          0
+        ],
+        [
+          "2022-11-01",
+          0
+        ],
+        [
+          "2022-12-01",
+          0
+        ],
+        [
+          "2023-01-01",
+          0
+        ],
+        [
+          "2023-02-01",
+          0
+        ],
+        [
+          "2023-03-01",
+          48
+        ],
+        [
+          "2023-04-01",
+          99
+        ],
+        [
+          "2023-05-01",
+          102
+        ],
+        [
+          "2023-06-01",
+          0
+        ]
+      ]
+    },
+    {
+      "name": "expenses_yearly",
+      "label": "Expenses (Yearly)",
+      "description": "The total expenses of our jaffle business",
+      "grain": "year",
+      "dimensions": [],
+      "headers": [
+        "date_year",
+        "expenses"
+      ],
+      "data": [
+        [
+          "2013-01-01",
+          0
+        ],
+        [
+          "2014-01-01",
+          0
+        ],
+        [
+          "2015-01-01",
+          0
+        ],
+        [
+          "2016-01-01",
+          0
+        ],
+        [
+          "2017-01-01",
+          0
+        ],
+        [
+          "2018-01-01",
+          0
+        ],
+        [
+          "2019-01-01",
+          0
+        ],
+        [
+          "2020-01-01",
+          0
+        ],
+        [
+          "2021-01-01",
+          0
+        ],
+        [
+          "2022-01-01",
+          0
+        ],
+        [
+          "2023-01-01",
+          249
+        ]
+      ]
+    },
+    {
+      "name": "average_order_amount_daily",
+      "label": "Average Order Amount (Daily)",
+      "description": "The average size of a jaffle order",
+      "grain": "day",
+      "dimensions": [],
+      "headers": [
+        "date_day",
+        "average_order_amount"
+      ],
+      "data": [
+        [
+          "2023-05-21",
+          28
+        ],
+        [
+          "2023-05-22",
+          19.333333333333332
+        ],
+        [
+          "2023-05-23",
+          15.5
+        ],
+        [
+          "2023-05-24",
+          null
+        ],
+        [
+          "2023-05-25",
+          29
+        ],
+        [
+          "2023-05-26",
+          null
+        ],
+        [
+          "2023-05-27",
+          3
+        ],
+        [
+          "2023-05-28",
+          30
+        ],
+        [
+          "2023-05-29",
+          19
+        ],
+        [
+          "2023-05-30",
+          null
+        ],
+        [
+          "2023-05-31",
+          2
+        ],
+        [
+          "2023-06-01",
+          19
+        ],
+        [
+          "2023-06-02",
+          null
+        ],
+        [
+          "2023-06-03",
+          14.5
+        ],
+        [
+          "2023-06-04",
+          4.5
+        ],
+        [
+          "2023-06-05",
+          null
+        ],
+        [
+          "2023-06-06",
+          21.666666666666668
+        ],
+        [
+          "2023-06-07",
+          42.5
+        ],
+        [
+          "2023-06-08",
+          22
+        ],
+        [
+          "2023-06-09",
+          null
+        ],
+        [
+          "2023-06-10",
+          2
+        ],
+        [
+          "2023-06-11",
+          19
+        ],
+        [
+          "2023-06-12",
+          null
+        ],
+        [
+          "2023-06-13",
+          17
+        ],
+        [
+          "2023-06-14",
+          16.5
+        ],
+        [
+          "2023-06-15",
+          24
+        ],
+        [
+          "2023-06-16",
+          null
+        ],
+        [
+          "2023-06-17",
+          17
+        ],
+        [
+          "2023-06-18",
+          12
+        ],
+        [
+          "2023-06-19",
+          null
+        ],
+        [
+          "2023-06-20",
+          24
+        ]
+      ]
+    },
+    {
+      "name": "average_order_amount_weekly",
+      "label": "Average Order Amount (Weekly)",
+      "description": "The average size of a jaffle order",
+      "grain": "week",
+      "dimensions": [],
+      "headers": [
+        "date_week",
+        "average_order_amount"
+      ],
+      "data": [
+        [
+          "2023-03-27",
+          13.666666666666666
+        ],
+        [
+          "2023-04-03",
+          15
+        ],
+        [
+          "2023-04-10",
+          23.857142857142858
+        ],
+        [
+          "2023-04-17",
+          16.571428571428573
+        ],
+        [
+          "2023-04-24",
+          12.857142857142858
+        ],
+        [
+          "2023-05-01",
+          17.333333333333332
+        ],
+        [
+          "2023-05-08",
+          15.4
+        ],
+        [
+          "2023-05-15",
+          19.4
+        ],
+        [
+          "2023-05-22",
+          18.875
+        ],
+        [
+          "2023-05-29",
+          11.88888888888889
+        ],
+        [
+          "2023-06-05",
+          24.125
+        ],
+        [
+          "2023-06-12",
+          16.428571428571427
+        ],
+        [
+          "2023-06-19",
+          24
+        ]
+      ]
+    },
+    {
+      "name": "average_order_amount_monthly",
+      "label": "Average Order Amount (Monthly)",
+      "description": "The average size of a jaffle order",
+      "grain": "month",
+      "dimensions": [],
+      "headers": [
+        "date_month",
+        "average_order_amount"
+      ],
+      "data": [
+        [
+          "2022-06-01",
+          null
+        ],
+        [
+          "2022-07-01",
+          null
+        ],
+        [
+          "2022-08-01",
+          null
+        ],
+        [
+          "2022-09-01",
+          null
+        ],
+        [
+          "2022-10-01",
+          null
+        ],
+        [
+          "2022-11-01",
+          null
+        ],
+        [
+          "2022-12-01",
+          null
+        ],
+        [
+          "2023-01-01",
+          null
+        ],
+        [
+          "2023-02-01",
+          null
+        ],
+        [
+          "2023-03-01",
+          14.764705882352942
+        ],
+        [
+          "2023-04-01",
+          17
+        ],
+        [
+          "2023-05-01",
+          17
+        ],
+        [
+          "2023-06-01",
+          18.17391304347826
+        ]
+      ]
+    },
+    {
+      "name": "revenue_daily",
+      "label": "Revenue (Daily)",
+      "description": "The total revenue of our jaffle business",
+      "grain": "day",
+      "dimensions": [],
+      "headers": [
+        "date_day",
+        "revenue"
+      ],
+      "data": [
+        [
+          "2023-05-21",
+          28
+        ],
+        [
+          "2023-05-22",
+          58
+        ],
+        [
+          "2023-05-23",
+          26
+        ],
+        [
+          "2023-05-24",
+          0
+        ],
+        [
+          "2023-05-25",
+          0
+        ],
+        [
+          "2023-05-26",
+          0
+        ],
+        [
+          "2023-05-27",
+          3
+        ],
+        [
+          "2023-05-28",
+          0
+        ],
+        [
+          "2023-05-29",
+          19
+        ],
+        [
+          "2023-05-30",
+          0
+        ],
+        [
+          "2023-05-31",
+          2
+        ],
+        [
+          "2023-06-01",
+          0
+        ],
+        [
+          "2023-06-02",
+          0
+        ],
+        [
+          "2023-06-03",
+          0
+        ],
+        [
+          "2023-06-04",
+          0
+        ],
+        [
+          "2023-06-05",
+          0
+        ],
+        [
+          "2023-06-06",
+          0
+        ],
+        [
+          "2023-06-07",
+          0
+        ],
+        [
+          "2023-06-08",
+          0
+        ],
+        [
+          "2023-06-09",
+          0
+        ],
+        [
+          "2023-06-10",
+          0
+        ],
+        [
+          "2023-06-11",
+          0
+        ],
+        [
+          "2023-06-12",
+          0
+        ],
+        [
+          "2023-06-13",
+          0
+        ],
+        [
+          "2023-06-14",
+          0
+        ],
+        [
+          "2023-06-15",
+          0
+        ],
+        [
+          "2023-06-16",
+          0
+        ],
+        [
+          "2023-06-17",
+          0
+        ],
+        [
+          "2023-06-18",
+          0
+        ],
+        [
+          "2023-06-19",
+          0
+        ],
+        [
+          "2023-06-20",
+          0
+        ]
+      ]
+    },
+    {
+      "name": "revenue_weekly",
+      "label": "Revenue (Weekly)",
+      "description": "The total revenue of our jaffle business",
+      "grain": "week",
+      "dimensions": [],
+      "headers": [
+        "date_week",
+        "revenue"
+      ],
+      "data": [
+        [
+          "2023-03-27",
+          107
+        ],
+        [
+          "2023-04-03",
+          67
+        ],
+        [
+          "2023-04-10",
+          167
+        ],
+        [
+          "2023-04-17",
+          116
+        ],
+        [
+          "2023-04-24",
+          90
+        ],
+        [
+          "2023-05-01",
+          104
+        ],
+        [
+          "2023-05-08",
+          139
+        ],
+        [
+          "2023-05-15",
+          97
+        ],
+        [
+          "2023-05-22",
+          87
+        ],
+        [
+          "2023-05-29",
+          21
+        ],
+        [
+          "2023-06-05",
+          0
+        ],
+        [
+          "2023-06-12",
+          0
+        ],
+        [
+          "2023-06-19",
+          0
+        ]
+      ]
+    },
+    {
+      "name": "revenue_monthly",
+      "label": "Revenue (Monthly)",
+      "description": "The total revenue of our jaffle business",
+      "grain": "month",
+      "dimensions": [],
+      "headers": [
+        "date_month",
+        "revenue"
+      ],
+      "data": [
+        [
+          "2022-06-01",
+          0
+        ],
+        [
+          "2022-07-01",
+          0
+        ],
+        [
+          "2022-08-01",
+          0
+        ],
+        [
+          "2022-09-01",
+          0
+        ],
+        [
+          "2022-10-01",
+          0
+        ],
+        [
+          "2022-11-01",
+          0
+        ],
+        [
+          "2022-12-01",
+          0
+        ],
+        [
+          "2023-01-01",
+          0
+        ],
+        [
+          "2023-02-01",
+          0
+        ],
+        [
+          "2023-03-01",
+          215
+        ],
+        [
+          "2023-04-01",
+          440
+        ],
+        [
+          "2023-05-01",
+          448
+        ],
+        [
+          "2023-06-01",
+          0
+        ]
+      ]
+    },
+    {
+      "name": "revenue_yearly",
+      "label": "Revenue (Yearly)",
+      "description": "The total revenue of our jaffle business",
+      "grain": "year",
+      "dimensions": [],
+      "headers": [
+        "date_year",
+        "revenue"
+      ],
+      "data": [
+        [
+          "2013-01-01",
+          0
+        ],
+        [
+          "2014-01-01",
+          0
+        ],
+        [
+          "2015-01-01",
+          0
+        ],
+        [
+          "2016-01-01",
+          0
+        ],
+        [
+          "2017-01-01",
+          0
+        ],
+        [
+          "2018-01-01",
+          0
+        ],
+        [
+          "2019-01-01",
+          0
+        ],
+        [
+          "2020-01-01",
+          0
+        ],
+        [
+          "2021-01-01",
+          0
+        ],
+        [
+          "2022-01-01",
+          0
+        ],
+        [
+          "2023-01-01",
+          1103
+        ]
+      ]
+    },
+    {
+      "name": "profit_daily",
+      "label": "Profit (Daily)",
+      "description": "The total money we get to take home from our jaffle business",
+      "grain": "day",
+      "dimensions": [],
+      "headers": [
+        "date_day",
+        "profit"
+      ],
+      "data": [
+        [
+          "2023-05-21",
+          21
+        ],
+        [
+          "2023-05-22",
+          45
+        ],
+        [
+          "2023-05-23",
+          20
+        ],
+        [
+          "2023-05-24",
+          0
+        ],
+        [
+          "2023-05-25",
+          0
+        ],
+        [
+          "2023-05-26",
+          0
+        ],
+        [
+          "2023-05-27",
+          3
+        ],
+        [
+          "2023-05-28",
+          0
+        ],
+        [
+          "2023-05-29",
+          15
+        ],
+        [
+          "2023-05-30",
+          0
+        ],
+        [
+          "2023-05-31",
+          2
+        ],
+        [
+          "2023-06-01",
+          0
+        ],
+        [
+          "2023-06-02",
+          0
+        ],
+        [
+          "2023-06-03",
+          0
+        ],
+        [
+          "2023-06-04",
+          0
+        ],
+        [
+          "2023-06-05",
+          0
+        ],
+        [
+          "2023-06-06",
+          0
+        ],
+        [
+          "2023-06-07",
+          0
+        ],
+        [
+          "2023-06-08",
+          0
+        ],
+        [
+          "2023-06-09",
+          0
+        ],
+        [
+          "2023-06-10",
+          0
+        ],
+        [
+          "2023-06-11",
+          0
+        ],
+        [
+          "2023-06-12",
+          0
+        ],
+        [
+          "2023-06-13",
+          0
+        ],
+        [
+          "2023-06-14",
+          0
+        ],
+        [
+          "2023-06-15",
+          0
+        ],
+        [
+          "2023-06-16",
+          0
+        ],
+        [
+          "2023-06-17",
+          0
+        ],
+        [
+          "2023-06-18",
+          0
+        ],
+        [
+          "2023-06-19",
+          0
+        ],
+        [
+          "2023-06-20",
+          0
+        ]
+      ]
+    },
+    {
+      "name": "profit_weekly",
+      "label": "Profit (Weekly)",
+      "description": "The total money we get to take home from our jaffle business",
+      "grain": "week",
+      "dimensions": [],
+      "headers": [
+        "date_week",
+        "profit"
+      ],
+      "data": [
+        [
+          "2023-03-27",
+          84
+        ],
+        [
+          "2023-04-03",
+          52
+        ],
+        [
+          "2023-04-10",
+          128
+        ],
+        [
+          "2023-04-17",
+          91
+        ],
+        [
+          "2023-04-24",
+          70
+        ],
+        [
+          "2023-05-01",
+          81
+        ],
+        [
+          "2023-05-08",
+          106
+        ],
+        [
+          "2023-05-15",
+          74
+        ],
+        [
+          "2023-05-22",
+          68
+        ],
+        [
+          "2023-05-29",
+          17
+        ],
+        [
+          "2023-06-05",
+          0
+        ],
+        [
+          "2023-06-12",
+          0
+        ],
+        [
+          "2023-06-19",
+          0
+        ]
+      ]
+    },
+    {
+      "name": "profit_monthly",
+      "label": "Profit (Monthly)",
+      "description": "The total money we get to take home from our jaffle business",
+      "grain": "month",
+      "dimensions": [],
+      "headers": [
+        "date_month",
+        "profit"
+      ],
+      "data": [
+        [
+          "2022-06-01",
+          0
+        ],
+        [
+          "2022-07-01",
+          0
+        ],
+        [
+          "2022-08-01",
+          0
+        ],
+        [
+          "2022-09-01",
+          0
+        ],
+        [
+          "2022-10-01",
+          0
+        ],
+        [
+          "2022-11-01",
+          0
+        ],
+        [
+          "2022-12-01",
+          0
+        ],
+        [
+          "2023-01-01",
+          0
+        ],
+        [
+          "2023-02-01",
+          0
+        ],
+        [
+          "2023-03-01",
+          167
+        ],
+        [
+          "2023-04-01",
+          341
+        ],
+        [
+          "2023-05-01",
+          346
+        ],
+        [
+          "2023-06-01",
+          0
+        ]
+      ]
+    },
+    {
+      "name": "profit_yearly",
+      "label": "Profit (Yearly)",
+      "description": "The total money we get to take home from our jaffle business",
+      "grain": "year",
+      "dimensions": [],
+      "headers": [
+        "date_year",
+        "profit"
+      ],
+      "data": [
+        [
+          "2013-01-01",
+          0
+        ],
+        [
+          "2014-01-01",
+          0
+        ],
+        [
+          "2015-01-01",
+          0
+        ],
+        [
+          "2016-01-01",
+          0
+        ],
+        [
+          "2017-01-01",
+          0
+        ],
+        [
+          "2018-01-01",
+          0
+        ],
+        [
+          "2019-01-01",
+          0
+        ],
+        [
+          "2020-01-01",
+          0
+        ],
+        [
+          "2021-01-01",
+          0
+        ],
+        [
+          "2022-01-01",
+          0
+        ],
+        [
+          "2023-01-01",
+          854
+        ]
+      ]
+    }
+  ],
+  "tests": [
+    {
+      "id": "test.jaffle_shop.not_null_stg_customers_customer_id.e2cfb1f9aa",
+      "name": "test.jaffle_shop.not_null_stg_customers_customer_id.e2cfb1f9aa",
+      "table": "stg_customers",
+      "column": "customer_id",
+      "status": "passed",
+      "tags": [],
+      "display_name": "not_null_stg_customers_customer_id",
+      "source": "dbt"
+    },
+    {
+      "id": "test.jaffle_shop.unique_stg_customers_customer_id.c7614daada",
+      "name": "test.jaffle_shop.unique_stg_customers_customer_id.c7614daada",
+      "table": "stg_customers",
+      "column": "customer_id",
+      "status": "passed",
+      "tags": [],
+      "display_name": "unique_stg_customers_customer_id",
+      "source": "dbt"
+    },
+    {
+      "id": "test.jaffle_shop.accepted_values_stg_orders_status__placed__shipped__completed__return_pending__returned.080fb20aad",
+      "name": "test.jaffle_shop.accepted_values_stg_orders_status__placed__shipped__completed__return_pending__returned.080fb20aad",
+      "table": "stg_orders",
+      "column": "status",
+      "status": "passed",
+      "tags": [],
+      "display_name": "accepted_values_stg_orders_status__placed__shipped__completed__return_pending__returned",
+      "source": "dbt"
+    },
+    {
+      "id": "test.jaffle_shop.not_null_stg_orders_order_id.81cfe2fe64",
+      "name": "test.jaffle_shop.not_null_stg_orders_order_id.81cfe2fe64",
+      "table": "stg_orders",
+      "column": "order_id",
+      "status": "passed",
+      "tags": [],
+      "display_name": "not_null_stg_orders_order_id",
+      "source": "dbt"
+    },
+    {
+      "id": "test.jaffle_shop.unique_stg_orders_order_id.e3b841c71a",
+      "name": "test.jaffle_shop.unique_stg_orders_order_id.e3b841c71a",
+      "table": "stg_orders",
+      "column": "order_id",
+      "status": "passed",
+      "tags": [],
+      "display_name": "unique_stg_orders_order_id",
+      "source": "dbt"
+    },
+    {
+      "id": "test.jaffle_shop.accepted_values_stg_payments_payment_method__credit_card__coupon__bank_transfer__gift_card.3c3820f278",
+      "name": "test.jaffle_shop.accepted_values_stg_payments_payment_method__credit_card__coupon__bank_transfer__gift_card.3c3820f278",
+      "table": "stg_payments",
+      "column": "payment_method",
+      "status": "passed",
+      "tags": [],
+      "display_name": "accepted_values_stg_payments_payment_method__credit_card__coupon__bank_transfer__gift_card",
+      "source": "dbt"
+    },
+    {
+      "id": "test.jaffle_shop.not_null_stg_payments_payment_id.c19cc50075",
+      "name": "test.jaffle_shop.not_null_stg_payments_payment_id.c19cc50075",
+      "table": "stg_payments",
+      "column": "payment_id",
+      "status": "passed",
+      "tags": [],
+      "display_name": "not_null_stg_payments_payment_id",
+      "source": "dbt"
+    },
+    {
+      "id": "test.jaffle_shop.unique_stg_payments_payment_id.3744510712",
+      "name": "test.jaffle_shop.unique_stg_payments_payment_id.3744510712",
+      "table": "stg_payments",
+      "column": "payment_id",
+      "status": "passed",
+      "tags": [],
+      "display_name": "unique_stg_payments_payment_id",
+      "source": "dbt"
+    },
+    {
+      "id": "test.jaffle_shop.not_null_int_customer_order_history_joined_customer_id.5eeb8cdf92",
+      "name": "test.jaffle_shop.not_null_int_customer_order_history_joined_customer_id.5eeb8cdf92",
+      "table": "int_customer_order_history_joined",
+      "column": "customer_id",
+      "status": "passed",
+      "tags": [],
+      "display_name": "not_null_int_customer_order_history_joined_customer_id",
+      "source": "dbt"
+    },
+    {
+      "id": "test.jaffle_shop.unique_int_customer_order_history_joined_customer_id.995635f7d9",
+      "name": "test.jaffle_shop.unique_int_customer_order_history_joined_customer_id.995635f7d9",
+      "table": "int_customer_order_history_joined",
+      "column": "customer_id",
+      "status": "passed",
+      "tags": [],
+      "display_name": "unique_int_customer_order_history_joined_customer_id",
+      "source": "dbt"
+    },
+    {
+      "id": "test.jaffle_shop.accepted_values_int_order_payments_pivoted_status__placed__shipped__completed__return_pending__returned.0ccdff53e8",
+      "name": "test.jaffle_shop.accepted_values_int_order_payments_pivoted_status__placed__shipped__completed__return_pending__returned.0ccdff53e8",
+      "table": "int_order_payments_pivoted",
+      "column": "status",
+      "status": "passed",
+      "tags": [],
+      "display_name": "accepted_values_int_order_payments_pivoted_status__placed__shipped__completed__return_pending__returned",
+      "source": "dbt"
+    },
+    {
+      "id": "test.jaffle_shop.not_null_int_order_payments_pivoted_amount.b7598e0e3b",
+      "name": "test.jaffle_shop.not_null_int_order_payments_pivoted_amount.b7598e0e3b",
+      "table": "int_order_payments_pivoted",
+      "column": "amount",
+      "status": "passed",
+      "tags": [],
+      "display_name": "not_null_int_order_payments_pivoted_amount",
+      "source": "dbt"
+    },
+    {
+      "id": "test.jaffle_shop.not_null_int_order_payments_pivoted_bank_transfer_amount.1a9e62933b",
+      "name": "test.jaffle_shop.not_null_int_order_payments_pivoted_bank_transfer_amount.1a9e62933b",
+      "table": "int_order_payments_pivoted",
+      "column": "bank_transfer_amount",
+      "status": "passed",
+      "tags": [],
+      "display_name": "not_null_int_order_payments_pivoted_bank_transfer_amount",
+      "source": "dbt"
+    },
+    {
+      "id": "test.jaffle_shop.not_null_int_order_payments_pivoted_coupon_amount.2532b538c2",
+      "name": "test.jaffle_shop.not_null_int_order_payments_pivoted_coupon_amount.2532b538c2",
+      "table": "int_order_payments_pivoted",
+      "column": "coupon_amount",
+      "status": "passed",
+      "tags": [],
+      "display_name": "not_null_int_order_payments_pivoted_coupon_amount",
+      "source": "dbt"
+    },
+    {
+      "id": "test.jaffle_shop.not_null_int_order_payments_pivoted_credit_card_amount.ae9c42d967",
+      "name": "test.jaffle_shop.not_null_int_order_payments_pivoted_credit_card_amount.ae9c42d967",
+      "table": "int_order_payments_pivoted",
+      "column": "credit_card_amount",
+      "status": "passed",
+      "tags": [],
+      "display_name": "not_null_int_order_payments_pivoted_credit_card_amount",
+      "source": "dbt"
+    },
+    {
+      "id": "test.jaffle_shop.not_null_int_order_payments_pivoted_customer_id.3db59c6de4",
+      "name": "test.jaffle_shop.not_null_int_order_payments_pivoted_customer_id.3db59c6de4",
+      "table": "int_order_payments_pivoted",
+      "column": "customer_id",
+      "status": "passed",
+      "tags": [],
+      "display_name": "not_null_int_order_payments_pivoted_customer_id",
+      "source": "dbt"
+    },
+    {
+      "id": "test.jaffle_shop.not_null_int_order_payments_pivoted_gift_card_amount.710d789cc0",
+      "name": "test.jaffle_shop.not_null_int_order_payments_pivoted_gift_card_amount.710d789cc0",
+      "table": "int_order_payments_pivoted",
+      "column": "gift_card_amount",
+      "status": "passed",
+      "tags": [],
+      "display_name": "not_null_int_order_payments_pivoted_gift_card_amount",
+      "source": "dbt"
+    },
+    {
+      "id": "test.jaffle_shop.not_null_int_order_payments_pivoted_order_id.787ba994a8",
+      "name": "test.jaffle_shop.not_null_int_order_payments_pivoted_order_id.787ba994a8",
+      "table": "int_order_payments_pivoted",
+      "column": "order_id",
+      "status": "passed",
+      "tags": [],
+      "display_name": "not_null_int_order_payments_pivoted_order_id",
+      "source": "dbt"
+    },
+    {
+      "id": "test.jaffle_shop.relationships_int_order_payments_pivoted_customer_id__customer_id__ref_int_customer_order_history_joined_.654a1aa35d",
+      "name": "test.jaffle_shop.relationships_int_order_payments_pivoted_customer_id__customer_id__ref_int_customer_order_history_joined_.654a1aa35d",
+      "table": "int_customer_order_history_joined",
+      "column": "customer_id",
+      "status": "passed",
+      "tags": [],
+      "display_name": "relationships_int_order_payments_pivoted_customer_id__customer_id__ref_int_customer_order_history_joined_",
+      "source": "dbt"
+    },
+    {
+      "id": "test.jaffle_shop.unique_int_order_payments_pivoted_order_id.34a0f3307d",
+      "name": "test.jaffle_shop.unique_int_order_payments_pivoted_order_id.34a0f3307d",
+      "table": "int_order_payments_pivoted",
+      "column": "order_id",
+      "status": "passed",
+      "tags": [],
+      "display_name": "unique_int_order_payments_pivoted_order_id",
+      "source": "dbt"
+    },
+    {
+      "id": "test.jaffle_shop.accepted_values_orders_status__placed__shipped__completed__return_pending__returned.be6b5b5ec3",
+      "name": "test.jaffle_shop.accepted_values_orders_status__placed__shipped__completed__return_pending__returned.be6b5b5ec3",
+      "table": "orders",
+      "column": "status",
+      "status": "passed",
+      "tags": [],
+      "display_name": "accepted_values_orders_status__placed__shipped__completed__return_pending__returned",
+      "source": "dbt"
+    },
+    {
+      "id": "test.jaffle_shop.not_null_orders_amount.106140f9fd",
+      "name": "test.jaffle_shop.not_null_orders_amount.106140f9fd",
+      "table": "orders",
+      "column": "amount",
+      "status": "passed",
+      "tags": [],
+      "display_name": "not_null_orders_amount",
+      "source": "dbt"
+    },
+    {
+      "id": "test.jaffle_shop.not_null_orders_bank_transfer_amount.7743500c49",
+      "name": "test.jaffle_shop.not_null_orders_bank_transfer_amount.7743500c49",
+      "table": "orders",
+      "column": "bank_transfer_amount",
+      "status": "passed",
+      "tags": [],
+      "display_name": "not_null_orders_bank_transfer_amount",
+      "source": "dbt"
+    },
+    {
+      "id": "test.jaffle_shop.not_null_orders_coupon_amount.ab90c90625",
+      "name": "test.jaffle_shop.not_null_orders_coupon_amount.ab90c90625",
+      "table": "orders",
+      "column": "coupon_amount",
+      "status": "passed",
+      "tags": [],
+      "display_name": "not_null_orders_coupon_amount",
+      "source": "dbt"
+    },
+    {
+      "id": "test.jaffle_shop.not_null_orders_credit_card_amount.d3ca593b59",
+      "name": "test.jaffle_shop.not_null_orders_credit_card_amount.d3ca593b59",
+      "table": "orders",
+      "column": "credit_card_amount",
+      "status": "passed",
+      "tags": [],
+      "display_name": "not_null_orders_credit_card_amount",
+      "source": "dbt"
+    },
+    {
+      "id": "test.jaffle_shop.not_null_orders_customer_id.c5f02694af",
+      "name": "test.jaffle_shop.not_null_orders_customer_id.c5f02694af",
+      "table": "orders",
+      "column": "customer_id",
+      "status": "passed",
+      "tags": [],
+      "display_name": "not_null_orders_customer_id",
+      "source": "dbt"
+    },
+    {
+      "id": "test.jaffle_shop.not_null_orders_gift_card_amount.413a0d2d7a",
+      "name": "test.jaffle_shop.not_null_orders_gift_card_amount.413a0d2d7a",
+      "table": "orders",
+      "column": "gift_card_amount",
+      "status": "passed",
+      "tags": [],
+      "display_name": "not_null_orders_gift_card_amount",
+      "source": "dbt"
+    },
+    {
+      "id": "test.jaffle_shop.not_null_orders_order_id.cf6c17daed",
+      "name": "test.jaffle_shop.not_null_orders_order_id.cf6c17daed",
+      "table": "orders",
+      "column": "order_id",
+      "status": "passed",
+      "tags": [],
+      "display_name": "not_null_orders_order_id",
+      "source": "dbt"
+    },
+    {
+      "id": "test.jaffle_shop.unique_orders_order_id.fed79b3a6e",
+      "name": "test.jaffle_shop.unique_orders_order_id.fed79b3a6e",
+      "table": "orders",
+      "column": "order_id",
+      "status": "passed",
+      "tags": [],
+      "display_name": "unique_orders_order_id",
+      "source": "dbt"
+    }
+  ],
+  "dbt": {
+    "manifest": {
+      "metadata": {
+        "dbt_schema_version": "https://schemas.getdbt.com/dbt/manifest/v9.json",
+        "dbt_version": "1.5.1",
+        "generated_at": "2023-06-20T06:00:40.952107Z",
+        "invocation_id": "a454c6bb-9f51-4874-8327-2f98c751a665",
+        "env": {},
+        "project_id": "06e5b98c2db46f8a72cc4f66410e9b3b",
+        "user_id": "a95e4c35-f5d4-4c37-9d87-9a331e4f18fd",
+        "send_anonymous_usage_stats": true,
+        "adapter_type": "duckdb"
+      },
+      "nodes": {
+        "model.jaffle_shop.int_order_payments_pivoted": {
+          "database": "jaffle_shop",
+          "schema": "main",
+          "name": "int_order_payments_pivoted",
+          "resource_type": "model",
+          "package_name": "jaffle_shop",
+          "path": "int_order_payments_pivoted.sql",
+          "original_file_path": "models/int_order_payments_pivoted.sql",
+          "unique_id": "model.jaffle_shop.int_order_payments_pivoted",
+          "fqn": [
+            "jaffle_shop",
+            "int_order_payments_pivoted"
+          ],
+          "alias": "int_order_payments_pivoted",
+          "checksum": {
+            "name": "sha256",
+            "checksum": "a6b3504e09200d63863bf0a4291e009271059d72174aa3742ef5dcef0d00f6ef"
+          },
+          "config": {
+            "enabled": true,
+            "tags": [],
+            "meta": {},
+            "materialized": "table",
+            "persist_docs": {},
+            "quoting": {},
+            "column_types": {},
+            "on_schema_change": "ignore",
+            "grants": {},
+            "packages": [],
+            "docs": {
+              "show": true
+            },
+            "contract": {
+              "enforced": false
+            },
+            "post-hook": [],
+            "pre-hook": []
+          },
+          "tags": [],
+          "description": "This table has basic information about orders, as well as some derived facts based on payments",
+          "columns": {
+            "order_id": {
+              "name": "order_id",
+              "description": "This is a unique identifier for an order",
+              "meta": {},
+              "constraints": [],
+              "tags": []
+            },
+            "customer_id": {
+              "name": "customer_id",
+              "description": "Foreign key to the customers table",
+              "meta": {},
+              "constraints": [],
+              "tags": []
+            },
+            "order_date": {
+              "name": "order_date",
+              "description": "Date (UTC) that the order was placed",
+              "meta": {},
+              "constraints": [],
+              "tags": []
+            },
+            "status": {
+              "name": "status",
+              "description": "Orders can be one of the following statuses:\n\n| status         | description                                                                                                            |\n|----------------|------------------------------------------------------------------------------------------------------------------------|\n| placed         | The order has been placed but has not yet left the warehouse                                                           |\n| shipped        | The order has ben shipped to the customer and is currently in transit                                                  |\n| completed      | The order has been received by the customer                                                                            |\n| return_pending | The customer has indicated that they would like to return the order, but it has not yet been received at the warehouse |\n| returned       | The order has been returned by the customer and received at the warehouse                                              |",
+              "meta": {},
+              "constraints": [],
+              "tags": []
+            },
+            "amount": {
+              "name": "amount",
+              "description": "Total amount (AUD) of the order",
+              "meta": {},
+              "constraints": [],
+              "tags": []
+            },
+            "credit_card_amount": {
+              "name": "credit_card_amount",
+              "description": "Amount of the order (AUD) paid for by credit card",
+              "meta": {},
+              "constraints": [],
+              "tags": []
+            },
+            "coupon_amount": {
+              "name": "coupon_amount",
+              "description": "Amount of the order (AUD) paid for by coupon",
+              "meta": {},
+              "constraints": [],
+              "tags": []
+            },
+            "bank_transfer_amount": {
+              "name": "bank_transfer_amount",
+              "description": "Amount of the order (AUD) paid for by bank transfer",
+              "meta": {},
+              "constraints": [],
+              "tags": []
+            },
+            "gift_card_amount": {
+              "name": "gift_card_amount",
+              "description": "Amount of the order (AUD) paid for by gift card",
+              "meta": {},
+              "constraints": [],
+              "tags": []
+            }
+          },
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "patch_path": "jaffle_shop://models/schema.yml",
+          "build_path": "target/run/jaffle_shop/models/int_order_payments_pivoted.sql",
+          "deferred": false,
+          "unrendered_config": {
+            "materialized": "table"
+          },
+          "created_at": 1687240841.349011,
+          "relation_name": "\"jaffle_shop\".\"main\".\"int_order_payments_pivoted\"",
+          "raw_code": "{% set payment_methods = ['credit_card', 'coupon', 'bank_transfer', 'gift_card'] %}\n\nwith orders as (\n\n    select * from {{ ref('stg_orders') }}\n\n),\n\npayments as (\n\n    select * from {{ ref('stg_payments') }}\n\n),\n\norder_payments as (\n\n    select\n        order_id,\n\n        {% for payment_method in payment_methods -%}\n        sum(case when payment_method = '{{ payment_method }}' then amount else 0 end)::bigint as {{ payment_method }}_amount,\n        {% endfor -%}\n\n        sum(amount)::bigint as total_amount\n\n    from payments\n\n    group by order_id\n\n),\n\nfinal as (\n\n    select\n        orders.order_id,\n        orders.customer_id,\n        orders.order_date,\n        orders.status,\n\n        {% for payment_method in payment_methods -%}\n\n        order_payments.{{ payment_method }}_amount,\n\n        {% endfor -%}\n\n        order_payments.total_amount as amount\n\n    from orders\n\n\n    left join order_payments\n        on orders.order_id = order_payments.order_id\n\n)\n\nselect * from final",
+          "language": "sql",
+          "refs": [
+            {
+              "name": "stg_orders"
+            },
+            {
+              "name": "stg_payments"
+            }
+          ],
+          "sources": [],
+          "metrics": [],
+          "depends_on": {
+            "macros": [],
+            "nodes": [
+              "model.jaffle_shop.stg_orders",
+              "model.jaffle_shop.stg_payments"
+            ]
+          },
+          "compiled_path": "target/compiled/jaffle_shop/models/int_order_payments_pivoted.sql",
+          "compiled": true,
+          "compiled_code": "\n\nwith orders as (\n\n    select * from \"jaffle_shop\".\"main\".\"stg_orders\"\n\n),\n\npayments as (\n\n    select * from \"jaffle_shop\".\"main\".\"stg_payments\"\n\n),\n\norder_payments as (\n\n    select\n        order_id,\n\n        sum(case when payment_method = 'credit_card' then amount else 0 end)::bigint as credit_card_amount,\n        sum(case when payment_method = 'coupon' then amount else 0 end)::bigint as coupon_amount,\n        sum(case when payment_method = 'bank_transfer' then amount else 0 end)::bigint as bank_transfer_amount,\n        sum(case when payment_method = 'gift_card' then amount else 0 end)::bigint as gift_card_amount,\n        sum(amount)::bigint as total_amount\n\n    from payments\n\n    group by order_id\n\n),\n\nfinal as (\n\n    select\n        orders.order_id,\n        orders.customer_id,\n        orders.order_date,\n        orders.status,\n\n        order_payments.credit_card_amount,\n\n        order_payments.coupon_amount,\n\n        order_payments.bank_transfer_amount,\n\n        order_payments.gift_card_amount,\n\n        order_payments.total_amount as amount\n\n    from orders\n\n\n    left join order_payments\n        on orders.order_id = order_payments.order_id\n\n)\n\nselect * from final",
+          "extra_ctes_injected": true,
+          "extra_ctes": [],
+          "contract": {
+            "enforced": false
+          },
+          "access": "protected",
+          "constraints": []
+        },
+        "model.jaffle_shop.int_customer_order_history_joined": {
+          "database": "jaffle_shop",
+          "schema": "main",
+          "name": "int_customer_order_history_joined",
+          "resource_type": "model",
+          "package_name": "jaffle_shop",
+          "path": "int_customer_order_history_joined.sql",
+          "original_file_path": "models/int_customer_order_history_joined.sql",
+          "unique_id": "model.jaffle_shop.int_customer_order_history_joined",
+          "fqn": [
+            "jaffle_shop",
+            "int_customer_order_history_joined"
+          ],
+          "alias": "int_customer_order_history_joined",
+          "checksum": {
+            "name": "sha256",
+            "checksum": "d3b742d16b8ba5a1e9b7952a58fab257dd83524960d5adff6d2466a51855e41f"
+          },
+          "config": {
+            "enabled": true,
+            "tags": [],
+            "meta": {},
+            "materialized": "table",
+            "persist_docs": {},
+            "quoting": {},
+            "column_types": {},
+            "on_schema_change": "ignore",
+            "grants": {},
+            "packages": [],
+            "docs": {
+              "show": true
+            },
+            "contract": {
+              "enforced": false
+            },
+            "post-hook": [],
+            "pre-hook": []
+          },
+          "tags": [],
+          "description": "This table has basic information about a customer, as well as some derived facts based on a customer's orders",
+          "columns": {
+            "customer_id": {
+              "name": "customer_id",
+              "description": "This is a unique identifier for a customer",
+              "meta": {},
+              "constraints": [],
+              "tags": []
+            },
+            "first_name": {
+              "name": "first_name",
+              "description": "Customer's first name. PII.",
+              "meta": {},
+              "constraints": [],
+              "tags": []
+            },
+            "last_name": {
+              "name": "last_name",
+              "description": "Customer's last name. PII.",
+              "meta": {},
+              "constraints": [],
+              "tags": []
+            },
+            "first_order": {
+              "name": "first_order",
+              "description": "Date (UTC) of a customer's first order",
+              "meta": {},
+              "constraints": [],
+              "tags": []
+            },
+            "most_recent_order": {
+              "name": "most_recent_order",
+              "description": "Date (UTC) of a customer's most recent order",
+              "meta": {},
+              "constraints": [],
+              "tags": []
+            },
+            "number_of_orders": {
+              "name": "number_of_orders",
+              "description": "Count of the number of orders a customer has placed",
+              "meta": {},
+              "constraints": [],
+              "tags": []
+            },
+            "total_order_amount": {
+              "name": "total_order_amount",
+              "description": "Total value (AUD) of a customer's orders",
+              "meta": {},
+              "constraints": [],
+              "tags": []
+            }
+          },
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "patch_path": "jaffle_shop://models/schema.yml",
+          "build_path": "target/run/jaffle_shop/models/int_customer_order_history_joined.sql",
+          "deferred": false,
+          "unrendered_config": {
+            "materialized": "table"
+          },
+          "created_at": 1687240841.346936,
+          "relation_name": "\"jaffle_shop\".\"main\".\"int_customer_order_history_joined\"",
+          "raw_code": "with customers as (\n\n    select * from {{ ref('stg_customers') }}\n\n),\n\norders as (\n\n    select * from {{ ref('stg_orders') }}\n\n),\n\npayments as (\n\n    select * from {{ ref('stg_payments') }}\n\n),\n\ncustomer_orders as (\n\n        select\n        customer_id,\n\n        min(order_date) as first_order,\n        max(order_date) as most_recent_order,\n        count(order_id) as number_of_orders\n    from orders\n\n    group by customer_id\n\n),\n\ncustomer_payments as (\n\n    select\n        orders.customer_id,\n        sum(amount)::bigint as total_amount\n\n    from payments\n\n    left join orders on\n         payments.order_id = orders.order_id\n\n    group by orders.customer_id\n\n),\n\nfinal as (\n\n    select\n        customers.customer_id,\n        customers.first_name,\n        customers.last_name,\n        customer_orders.first_order,\n        customer_orders.most_recent_order,\n        customer_orders.number_of_orders,\n        customer_payments.total_amount as customer_lifetime_value\n\n    from customers\n\n    left join customer_orders\n        on customers.customer_id = customer_orders.customer_id\n\n    left join customer_payments\n        on  customers.customer_id = customer_payments.customer_id\n\n)\n\nselect * from final",
+          "language": "sql",
+          "refs": [
+            {
+              "name": "stg_customers"
+            },
+            {
+              "name": "stg_orders"
+            },
+            {
+              "name": "stg_payments"
+            }
+          ],
+          "sources": [],
+          "metrics": [],
+          "depends_on": {
+            "macros": [],
+            "nodes": [
+              "model.jaffle_shop.stg_customers",
+              "model.jaffle_shop.stg_orders",
+              "model.jaffle_shop.stg_payments"
+            ]
+          },
+          "compiled_path": "target/compiled/jaffle_shop/models/int_customer_order_history_joined.sql",
+          "compiled": true,
+          "compiled_code": "with customers as (\n\n    select * from \"jaffle_shop\".\"main\".\"stg_customers\"\n\n),\n\norders as (\n\n    select * from \"jaffle_shop\".\"main\".\"stg_orders\"\n\n),\n\npayments as (\n\n    select * from \"jaffle_shop\".\"main\".\"stg_payments\"\n\n),\n\ncustomer_orders as (\n\n        select\n        customer_id,\n\n        min(order_date) as first_order,\n        max(order_date) as most_recent_order,\n        count(order_id) as number_of_orders\n    from orders\n\n    group by customer_id\n\n),\n\ncustomer_payments as (\n\n    select\n        orders.customer_id,\n        sum(amount)::bigint as total_amount\n\n    from payments\n\n    left join orders on\n         payments.order_id = orders.order_id\n\n    group by orders.customer_id\n\n),\n\nfinal as (\n\n    select\n        customers.customer_id,\n        customers.first_name,\n        customers.last_name,\n        customer_orders.first_order,\n        customer_orders.most_recent_order,\n        customer_orders.number_of_orders,\n        customer_payments.total_amount as customer_lifetime_value\n\n    from customers\n\n    left join customer_orders\n        on customers.customer_id = customer_orders.customer_id\n\n    left join customer_payments\n        on  customers.customer_id = customer_payments.customer_id\n\n)\n\nselect * from final",
+          "extra_ctes_injected": true,
+          "extra_ctes": [],
+          "contract": {
+            "enforced": false
+          },
+          "access": "protected",
+          "constraints": []
+        },
+        "model.jaffle_shop.stg_customers": {
+          "database": "jaffle_shop",
+          "schema": "main",
+          "name": "stg_customers",
+          "resource_type": "model",
+          "package_name": "jaffle_shop",
+          "path": "staging/stg_customers.sql",
+          "original_file_path": "models/staging/stg_customers.sql",
+          "unique_id": "model.jaffle_shop.stg_customers",
+          "fqn": [
+            "jaffle_shop",
+            "staging",
+            "stg_customers"
+          ],
+          "alias": "stg_customers",
+          "checksum": {
+            "name": "sha256",
+            "checksum": "80e3223cd54387e11fa16cd0f4cbe15f8ff74dcd9900b93856b9e39416178c9d"
+          },
+          "config": {
+            "enabled": true,
+            "tags": [
+              "piperider"
+            ],
+            "meta": {},
+            "materialized": "view",
+            "persist_docs": {},
+            "quoting": {},
+            "column_types": {},
+            "on_schema_change": "ignore",
+            "grants": {},
+            "packages": [],
+            "docs": {
+              "show": true
+            },
+            "contract": {
+              "enforced": false
+            },
+            "post-hook": [],
+            "pre-hook": []
+          },
+          "tags": [
+            "piperider"
+          ],
+          "description": "",
+          "columns": {
+            "customer_id": {
+              "name": "customer_id",
+              "description": "",
+              "meta": {},
+              "constraints": [],
+              "tags": []
+            }
+          },
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "patch_path": "jaffle_shop://models/staging/schema.yml",
+          "build_path": "target/run/jaffle_shop/models/staging/stg_customers.sql",
+          "deferred": false,
+          "unrendered_config": {
+            "materialized": "view",
+            "tags": "piperider"
+          },
+          "created_at": 1687240841.401644,
+          "relation_name": "\"jaffle_shop\".\"main\".\"stg_customers\"",
+          "raw_code": "with source as (\n\n    {#-\n    Normally we would select from the table here, but we are using seeds to load\n    our data in this project\n    #}\n    select * from {{ ref('raw_customers') }}\n\n),\n\nrenamed as (\n\n    select\n        id as customer_id,\n        first_name,\n        last_name\n\n    from source\n\n)\n\nselect * from renamed",
+          "language": "sql",
+          "refs": [
+            {
+              "name": "raw_customers"
+            }
+          ],
+          "sources": [],
+          "metrics": [],
+          "depends_on": {
+            "macros": [],
+            "nodes": [
+              "seed.jaffle_shop.raw_customers"
+            ]
+          },
+          "compiled_path": "target/compiled/jaffle_shop/models/staging/stg_customers.sql",
+          "compiled": true,
+          "compiled_code": "with source as (\n    select * from \"jaffle_shop\".\"main\".\"raw_customers\"\n\n),\n\nrenamed as (\n\n    select\n        id as customer_id,\n        first_name,\n        last_name\n\n    from source\n\n)\n\nselect * from renamed",
+          "extra_ctes_injected": true,
+          "extra_ctes": [],
+          "contract": {
+            "enforced": false
+          },
+          "access": "protected",
+          "constraints": []
+        },
+        "model.jaffle_shop.stg_payments": {
+          "database": "jaffle_shop",
+          "schema": "main",
+          "name": "stg_payments",
+          "resource_type": "model",
+          "package_name": "jaffle_shop",
+          "path": "staging/stg_payments.sql",
+          "original_file_path": "models/staging/stg_payments.sql",
+          "unique_id": "model.jaffle_shop.stg_payments",
+          "fqn": [
+            "jaffle_shop",
+            "staging",
+            "stg_payments"
+          ],
+          "alias": "stg_payments",
+          "checksum": {
+            "name": "sha256",
+            "checksum": "9c1ee3bfb10e07c2dfc325d55925da0e521887136d9051768cb8acf09dc86bda"
+          },
+          "config": {
+            "enabled": true,
+            "tags": [
+              "piperider"
+            ],
+            "meta": {},
+            "materialized": "view",
+            "persist_docs": {},
+            "quoting": {},
+            "column_types": {},
+            "on_schema_change": "ignore",
+            "grants": {},
+            "packages": [],
+            "docs": {
+              "show": true
+            },
+            "contract": {
+              "enforced": false
+            },
+            "post-hook": [],
+            "pre-hook": []
+          },
+          "tags": [
+            "piperider"
+          ],
+          "description": "",
+          "columns": {
+            "payment_id": {
+              "name": "payment_id",
+              "description": "",
+              "meta": {},
+              "constraints": [],
+              "tags": []
+            },
+            "payment_method": {
+              "name": "payment_method",
+              "description": "",
+              "meta": {},
+              "constraints": [],
+              "tags": []
+            }
+          },
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "patch_path": "jaffle_shop://models/staging/schema.yml",
+          "build_path": "target/run/jaffle_shop/models/staging/stg_payments.sql",
+          "deferred": false,
+          "unrendered_config": {
+            "materialized": "view",
+            "tags": "piperider"
+          },
+          "created_at": 1687240841.402996,
+          "relation_name": "\"jaffle_shop\".\"main\".\"stg_payments\"",
+          "raw_code": "with source as (\n    \n    {#-\n    Normally we would select from the table here, but we are using seeds to load\n    our data in this project\n    #}\n    select * from {{ ref('raw_payments') }}\n\n),\n\nrenamed as (\n\n    select\n        id as payment_id,\n        order_id,\n        payment_method,\n\n        -- `amount` is currently stored in cents, so we convert it to dollars\n        amount / 100 as amount\n\n    from source\n\n)\n\nselect * from renamed",
+          "language": "sql",
+          "refs": [
+            {
+              "name": "raw_payments"
+            }
+          ],
+          "sources": [],
+          "metrics": [],
+          "depends_on": {
+            "macros": [],
+            "nodes": [
+              "seed.jaffle_shop.raw_payments"
+            ]
+          },
+          "compiled_path": "target/compiled/jaffle_shop/models/staging/stg_payments.sql",
+          "compiled": true,
+          "compiled_code": "with source as (\n    select * from \"jaffle_shop\".\"main\".\"raw_payments\"\n\n),\n\nrenamed as (\n\n    select\n        id as payment_id,\n        order_id,\n        payment_method,\n\n        -- `amount` is currently stored in cents, so we convert it to dollars\n        amount / 100 as amount\n\n    from source\n\n)\n\nselect * from renamed",
+          "extra_ctes_injected": true,
+          "extra_ctes": [],
+          "contract": {
+            "enforced": false
+          },
+          "access": "protected",
+          "constraints": []
+        },
+        "model.jaffle_shop.stg_orders": {
+          "database": "jaffle_shop",
+          "schema": "main",
+          "name": "stg_orders",
+          "resource_type": "model",
+          "package_name": "jaffle_shop",
+          "path": "staging/stg_orders.sql",
+          "original_file_path": "models/staging/stg_orders.sql",
+          "unique_id": "model.jaffle_shop.stg_orders",
+          "fqn": [
+            "jaffle_shop",
+            "staging",
+            "stg_orders"
+          ],
+          "alias": "stg_orders",
+          "checksum": {
+            "name": "sha256",
+            "checksum": "0bc34d953a33548e7476302e43e2d1a3e97a91506ef644ce93406ac57844c767"
+          },
+          "config": {
+            "enabled": true,
+            "tags": [
+              "piperider"
+            ],
+            "meta": {},
+            "materialized": "view",
+            "persist_docs": {},
+            "quoting": {},
+            "column_types": {},
+            "on_schema_change": "ignore",
+            "grants": {},
+            "packages": [],
+            "docs": {
+              "show": true
+            },
+            "contract": {
+              "enforced": false
+            },
+            "post-hook": [],
+            "pre-hook": []
+          },
+          "tags": [
+            "piperider"
+          ],
+          "description": "",
+          "columns": {
+            "order_id": {
+              "name": "order_id",
+              "description": "",
+              "meta": {},
+              "constraints": [],
+              "tags": []
+            },
+            "status": {
+              "name": "status",
+              "description": "",
+              "meta": {},
+              "constraints": [],
+              "tags": []
+            }
+          },
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "patch_path": "jaffle_shop://models/staging/schema.yml",
+          "build_path": "target/run/jaffle_shop/models/staging/stg_orders.sql",
+          "deferred": false,
+          "unrendered_config": {
+            "materialized": "view",
+            "tags": "piperider"
+          },
+          "created_at": 1687240841.402252,
+          "relation_name": "\"jaffle_shop\".\"main\".\"stg_orders\"",
+          "raw_code": "with source as (\n\n    {#-\n    Normally we would select from the table here, but we are using seeds to load\n    our data in this project\n    #}\n    select * from {{ ref('raw_orders') }}\n\n),\n\nrenamed as (\n\n    select\n        id as order_id,\n        user_id as customer_id,\n        order_date,\n        status\n\n    from source\n\n),\n\n-- Shift the order_date by the number of days since 2018-04-09 (the max order_date in the raw data)\nshift_date as (\n    \n    select\n        order_id,\n        customer_id,\n        (order_date + datediff('day', date '2018-04-09', CURRENT_DATE)::int) as order_date,\n        status        \n\n    from renamed\n)\n\nselect * from shift_date",
+          "language": "sql",
+          "refs": [
+            {
+              "name": "raw_orders"
+            }
+          ],
+          "sources": [],
+          "metrics": [],
+          "depends_on": {
+            "macros": [],
+            "nodes": [
+              "seed.jaffle_shop.raw_orders"
+            ]
+          },
+          "compiled_path": "target/compiled/jaffle_shop/models/staging/stg_orders.sql",
+          "compiled": true,
+          "compiled_code": "with source as (\n    select * from \"jaffle_shop\".\"main\".\"raw_orders\"\n\n),\n\nrenamed as (\n\n    select\n        id as order_id,\n        user_id as customer_id,\n        order_date,\n        status\n\n    from source\n\n),\n\n-- Shift the order_date by the number of days since 2018-04-09 (the max order_date in the raw data)\nshift_date as (\n    \n    select\n        order_id,\n        customer_id,\n        (order_date + datediff('day', date '2018-04-09', CURRENT_DATE)::int) as order_date,\n        status        \n\n    from renamed\n)\n\nselect * from shift_date",
+          "extra_ctes_injected": true,
+          "extra_ctes": [],
+          "contract": {
+            "enforced": false
+          },
+          "access": "protected",
+          "constraints": []
+        },
+        "model.jaffle_shop.orders": {
+          "database": "jaffle_shop",
+          "schema": "main",
+          "name": "orders",
+          "resource_type": "model",
+          "package_name": "jaffle_shop",
+          "path": "marts/orders.sql",
+          "original_file_path": "models/marts/orders.sql",
+          "unique_id": "model.jaffle_shop.orders",
+          "fqn": [
+            "jaffle_shop",
+            "marts",
+            "orders"
+          ],
+          "alias": "orders",
+          "checksum": {
+            "name": "sha256",
+            "checksum": "72daa5bd3383a814f0315bff00159d5fb30f62b5f8d0955934cf041c605052a1"
+          },
+          "config": {
+            "enabled": true,
+            "tags": [
+              "piperider"
+            ],
+            "meta": {},
+            "materialized": "table",
+            "persist_docs": {},
+            "quoting": {},
+            "column_types": {},
+            "on_schema_change": "ignore",
+            "grants": {},
+            "packages": [],
+            "docs": {
+              "show": true
+            },
+            "contract": {
+              "enforced": false
+            },
+            "post-hook": [],
+            "pre-hook": []
+          },
+          "tags": [
+            "piperider"
+          ],
+          "description": "This table has basic information about orders, as well as some derived facts based on payments",
+          "columns": {
+            "order_id": {
+              "name": "order_id",
+              "description": "This is a unique identifier for an order",
+              "meta": {},
+              "constraints": [],
+              "tags": []
+            },
+            "customer_id": {
+              "name": "customer_id",
+              "description": "This is a unique identifier for a customer",
+              "meta": {},
+              "constraints": [],
+              "tags": []
+            },
+            "order_date": {
+              "name": "order_date",
+              "description": "Date (UTC) that the order was placed",
+              "meta": {},
+              "constraints": [],
+              "tags": []
+            },
+            "status": {
+              "name": "status",
+              "description": "Orders can be one of the following statuses:\n\n| status         | description                                                                                                            |\n|----------------|------------------------------------------------------------------------------------------------------------------------|\n| placed         | The order has been placed but has not yet left the warehouse                                                           |\n| shipped        | The order has ben shipped to the customer and is currently in transit                                                  |\n| completed      | The order has been received by the customer                                                                            |\n| return_pending | The customer has indicated that they would like to return the order, but it has not yet been received at the warehouse |\n| returned       | The order has been returned by the customer and received at the warehouse                                              |",
+              "meta": {},
+              "constraints": [],
+              "tags": []
+            },
+            "amount": {
+              "name": "amount",
+              "description": "Total amount (AUD) of the order",
+              "meta": {},
+              "constraints": [],
+              "tags": []
+            },
+            "credit_card_amount": {
+              "name": "credit_card_amount",
+              "description": "Amount of the order (AUD) paid for by credit card",
+              "meta": {},
+              "constraints": [],
+              "tags": []
+            },
+            "coupon_amount": {
+              "name": "coupon_amount",
+              "description": "Amount of the order (AUD) paid for by coupon",
+              "meta": {},
+              "constraints": [],
+              "tags": []
+            },
+            "bank_transfer_amount": {
+              "name": "bank_transfer_amount",
+              "description": "Amount of the order (AUD) paid for by bank transfer",
+              "meta": {},
+              "constraints": [],
+              "tags": []
+            },
+            "gift_card_amount": {
+              "name": "gift_card_amount",
+              "description": "Amount of the order (AUD) paid for by gift card",
+              "meta": {},
+              "constraints": [],
+              "tags": []
+            },
+            "first_name": {
+              "name": "first_name",
+              "description": "Customer's first name. PII.",
+              "meta": {},
+              "constraints": [],
+              "tags": []
+            },
+            "last_name": {
+              "name": "last_name",
+              "description": "Customer's last name. PII.",
+              "meta": {},
+              "constraints": [],
+              "tags": []
+            },
+            "first_order": {
+              "name": "first_order",
+              "description": "Date (UTC) of a customer's first order",
+              "meta": {},
+              "constraints": [],
+              "tags": []
+            },
+            "most_recent_order": {
+              "name": "most_recent_order",
+              "description": "Date (UTC) of a customer's most recent order",
+              "meta": {},
+              "constraints": [],
+              "tags": []
+            },
+            "number_of_orders": {
+              "name": "number_of_orders",
+              "description": "Count of the number of orders a customer has placed",
+              "meta": {},
+              "constraints": [],
+              "tags": []
+            },
+            "total_order_amount": {
+              "name": "total_order_amount",
+              "description": "Total value (AUD) of a customer's orders",
+              "meta": {},
+              "constraints": [],
+              "tags": []
+            }
+          },
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "patch_path": "jaffle_shop://models/marts/orders.yml",
+          "build_path": "target/run/jaffle_shop/models/marts/orders.sql",
+          "deferred": false,
+          "unrendered_config": {
+            "materialized": "table",
+            "tags": "piperider"
+          },
+          "created_at": 1687240841.425799,
+          "relation_name": "\"jaffle_shop\".\"main\".\"orders\"",
+          "raw_code": "with orders as (\n\n    select * from {{ ref('int_order_payments_pivoted') }}\n\n)\n,\ncustomers as (\n\n    select * from {{ ref('int_customer_order_history_joined') }}\n\n)\n,\nfinal as (\n\n    select \n        *\n    from orders \n    left join customers using (customer_id)\n\n)\n\nselect * from final",
+          "language": "sql",
+          "refs": [
+            {
+              "name": "int_order_payments_pivoted"
+            },
+            {
+              "name": "int_customer_order_history_joined"
+            }
+          ],
+          "sources": [],
+          "metrics": [],
+          "depends_on": {
+            "macros": [],
+            "nodes": [
+              "model.jaffle_shop.int_order_payments_pivoted",
+              "model.jaffle_shop.int_customer_order_history_joined"
+            ]
+          },
+          "compiled_path": "target/compiled/jaffle_shop/models/marts/orders.sql",
+          "compiled": true,
+          "compiled_code": "with orders as (\n\n    select * from \"jaffle_shop\".\"main\".\"int_order_payments_pivoted\"\n\n)\n,\ncustomers as (\n\n    select * from \"jaffle_shop\".\"main\".\"int_customer_order_history_joined\"\n\n)\n,\nfinal as (\n\n    select \n        *\n    from orders \n    left join customers using (customer_id)\n\n)\n\nselect * from final",
+          "extra_ctes_injected": true,
+          "extra_ctes": [],
+          "contract": {
+            "enforced": false
+          },
+          "access": "protected",
+          "constraints": []
+        },
+        "seed.jaffle_shop.raw_customers": {
+          "database": "jaffle_shop",
+          "schema": "main",
+          "name": "raw_customers",
+          "resource_type": "seed",
+          "package_name": "jaffle_shop",
+          "path": "raw_customers.csv",
+          "original_file_path": "seeds/raw_customers.csv",
+          "unique_id": "seed.jaffle_shop.raw_customers",
+          "fqn": [
+            "jaffle_shop",
+            "raw_customers"
+          ],
+          "alias": "raw_customers",
+          "checksum": {
+            "name": "sha256",
+            "checksum": "357d173dda65a741ad97d6683502286cc2655bb396ab5f4dfad12b8c39bd2a63"
+          },
+          "config": {
+            "enabled": true,
+            "tags": [],
+            "meta": {},
+            "materialized": "seed",
+            "persist_docs": {},
+            "quoting": {},
+            "column_types": {},
+            "on_schema_change": "ignore",
+            "grants": {},
+            "packages": [],
+            "docs": {
+              "show": true
+            },
+            "contract": {
+              "enforced": false
+            },
+            "post-hook": [],
+            "pre-hook": []
+          },
+          "tags": [],
+          "description": "",
+          "columns": {},
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "build_path": "target/run/jaffle_shop/seeds/raw_customers.csv",
+          "deferred": false,
+          "unrendered_config": {},
+          "created_at": 1687240841.331158,
+          "relation_name": "\"jaffle_shop\".\"main\".\"raw_customers\"",
+          "raw_code": "",
+          "root_path": "/Users/popcorny/Documents/infuseai/repo/jaffle_shop",
+          "depends_on": {
+            "macros": []
+          }
+        },
+        "seed.jaffle_shop.raw_orders": {
+          "database": "jaffle_shop",
+          "schema": "main",
+          "name": "raw_orders",
+          "resource_type": "seed",
+          "package_name": "jaffle_shop",
+          "path": "raw_orders.csv",
+          "original_file_path": "seeds/raw_orders.csv",
+          "unique_id": "seed.jaffle_shop.raw_orders",
+          "fqn": [
+            "jaffle_shop",
+            "raw_orders"
+          ],
+          "alias": "raw_orders",
+          "checksum": {
+            "name": "sha256",
+            "checksum": "ddecd7adf70a07a88b9c302aec2a03fce615b925c2c06f2d5ef99a5c97b41250"
+          },
+          "config": {
+            "enabled": true,
+            "tags": [],
+            "meta": {},
+            "materialized": "seed",
+            "persist_docs": {},
+            "quoting": {},
+            "column_types": {},
+            "on_schema_change": "ignore",
+            "grants": {},
+            "packages": [],
+            "docs": {
+              "show": true
+            },
+            "contract": {
+              "enforced": false
+            },
+            "post-hook": [],
+            "pre-hook": []
+          },
+          "tags": [],
+          "description": "",
+          "columns": {},
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "build_path": "target/run/jaffle_shop/seeds/raw_orders.csv",
+          "deferred": false,
+          "unrendered_config": {},
+          "created_at": 1687240841.3325849,
+          "relation_name": "\"jaffle_shop\".\"main\".\"raw_orders\"",
+          "raw_code": "",
+          "root_path": "/Users/popcorny/Documents/infuseai/repo/jaffle_shop",
+          "depends_on": {
+            "macros": []
+          }
+        },
+        "seed.jaffle_shop.raw_payments": {
+          "database": "jaffle_shop",
+          "schema": "main",
+          "name": "raw_payments",
+          "resource_type": "seed",
+          "package_name": "jaffle_shop",
+          "path": "raw_payments.csv",
+          "original_file_path": "seeds/raw_payments.csv",
+          "unique_id": "seed.jaffle_shop.raw_payments",
+          "fqn": [
+            "jaffle_shop",
+            "raw_payments"
+          ],
+          "alias": "raw_payments",
+          "checksum": {
+            "name": "sha256",
+            "checksum": "6de0626a8db9c1750eefd1b2e17fac4c2a4b9f778eb50532d8b377b90de395e6"
+          },
+          "config": {
+            "enabled": true,
+            "tags": [],
+            "meta": {},
+            "materialized": "seed",
+            "persist_docs": {},
+            "quoting": {},
+            "column_types": {},
+            "on_schema_change": "ignore",
+            "grants": {},
+            "packages": [],
+            "docs": {
+              "show": true
+            },
+            "contract": {
+              "enforced": false
+            },
+            "post-hook": [],
+            "pre-hook": []
+          },
+          "tags": [],
+          "description": "",
+          "columns": {},
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "build_path": "target/run/jaffle_shop/seeds/raw_payments.csv",
+          "deferred": false,
+          "unrendered_config": {},
+          "created_at": 1687240841.334035,
+          "relation_name": "\"jaffle_shop\".\"main\".\"raw_payments\"",
+          "raw_code": "",
+          "root_path": "/Users/popcorny/Documents/infuseai/repo/jaffle_shop",
+          "depends_on": {
+            "macros": []
+          }
+        },
+        "test.jaffle_shop.unique_int_customer_order_history_joined_customer_id.995635f7d9": {
+          "test_metadata": {
+            "name": "unique",
+            "kwargs": {
+              "column_name": "customer_id",
+              "model": "{{ get_where_subquery(ref('int_customer_order_history_joined')) }}"
+            }
+          },
+          "database": "jaffle_shop",
+          "schema": "main_dbt_test__audit",
+          "name": "unique_int_customer_order_history_joined_customer_id",
+          "resource_type": "test",
+          "package_name": "jaffle_shop",
+          "path": "unique_int_customer_order_history_joined_customer_id.sql",
+          "original_file_path": "models/schema.yml",
+          "unique_id": "test.jaffle_shop.unique_int_customer_order_history_joined_customer_id.995635f7d9",
+          "fqn": [
+            "jaffle_shop",
+            "unique_int_customer_order_history_joined_customer_id"
+          ],
+          "alias": "unique_int_customer_order_history_joined_customer_id",
+          "checksum": {
+            "name": "none",
+            "checksum": ""
+          },
+          "config": {
+            "enabled": true,
+            "schema": "dbt_test__audit",
+            "tags": [],
+            "meta": {},
+            "materialized": "test",
+            "severity": "ERROR",
+            "fail_calc": "count(*)",
+            "warn_if": "!= 0",
+            "error_if": "!= 0"
+          },
+          "tags": [],
+          "description": "",
+          "columns": {},
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "build_path": "target/run/jaffle_shop/models/schema.yml/unique_int_customer_order_history_joined_customer_id.sql",
+          "deferred": false,
+          "unrendered_config": {},
+          "created_at": 1687240841.3536818,
+          "raw_code": "{{ test_unique(**_dbt_generic_test_kwargs) }}",
+          "language": "sql",
+          "refs": [
+            {
+              "name": "int_customer_order_history_joined"
+            }
+          ],
+          "sources": [],
+          "metrics": [],
+          "depends_on": {
+            "macros": [
+              "macro.dbt.test_unique",
+              "macro.dbt.get_where_subquery",
+              "macro.dbt.should_store_failures",
+              "macro.dbt.statement"
+            ],
+            "nodes": [
+              "model.jaffle_shop.int_customer_order_history_joined"
+            ]
+          },
+          "compiled_path": "target/compiled/jaffle_shop/models/schema.yml/unique_int_customer_order_history_joined_customer_id.sql",
+          "compiled": true,
+          "compiled_code": "\n    \n    \n\nselect\n    customer_id as unique_field,\n    count(*) as n_records\n\nfrom \"jaffle_shop\".\"main\".\"int_customer_order_history_joined\"\nwhere customer_id is not null\ngroup by customer_id\nhaving count(*) > 1\n\n\n",
+          "extra_ctes_injected": true,
+          "extra_ctes": [],
+          "contract": {
+            "enforced": false
+          },
+          "column_name": "customer_id",
+          "file_key_name": "models.int_customer_order_history_joined",
+          "attached_node": "model.jaffle_shop.int_customer_order_history_joined"
+        },
+        "test.jaffle_shop.not_null_int_customer_order_history_joined_customer_id.5eeb8cdf92": {
+          "test_metadata": {
+            "name": "not_null",
+            "kwargs": {
+              "column_name": "customer_id",
+              "model": "{{ get_where_subquery(ref('int_customer_order_history_joined')) }}"
+            }
+          },
+          "database": "jaffle_shop",
+          "schema": "main_dbt_test__audit",
+          "name": "not_null_int_customer_order_history_joined_customer_id",
+          "resource_type": "test",
+          "package_name": "jaffle_shop",
+          "path": "not_null_int_customer_order_history_joined_customer_id.sql",
+          "original_file_path": "models/schema.yml",
+          "unique_id": "test.jaffle_shop.not_null_int_customer_order_history_joined_customer_id.5eeb8cdf92",
+          "fqn": [
+            "jaffle_shop",
+            "not_null_int_customer_order_history_joined_customer_id"
+          ],
+          "alias": "not_null_int_customer_order_history_joined_customer_id",
+          "checksum": {
+            "name": "none",
+            "checksum": ""
+          },
+          "config": {
+            "enabled": true,
+            "schema": "dbt_test__audit",
+            "tags": [],
+            "meta": {},
+            "materialized": "test",
+            "severity": "ERROR",
+            "fail_calc": "count(*)",
+            "warn_if": "!= 0",
+            "error_if": "!= 0"
+          },
+          "tags": [],
+          "description": "",
+          "columns": {},
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "build_path": "target/run/jaffle_shop/models/schema.yml/not_null_int_customer_order_history_joined_customer_id.sql",
+          "deferred": false,
+          "unrendered_config": {},
+          "created_at": 1687240841.354979,
+          "raw_code": "{{ test_not_null(**_dbt_generic_test_kwargs) }}",
+          "language": "sql",
+          "refs": [
+            {
+              "name": "int_customer_order_history_joined"
+            }
+          ],
+          "sources": [],
+          "metrics": [],
+          "depends_on": {
+            "macros": [
+              "macro.dbt.test_not_null",
+              "macro.dbt.get_where_subquery",
+              "macro.dbt.should_store_failures",
+              "macro.dbt.statement"
+            ],
+            "nodes": [
+              "model.jaffle_shop.int_customer_order_history_joined"
+            ]
+          },
+          "compiled_path": "target/compiled/jaffle_shop/models/schema.yml/not_null_int_customer_order_history_joined_customer_id.sql",
+          "compiled": true,
+          "compiled_code": "\n    \n    \n\n\n\nselect customer_id\nfrom \"jaffle_shop\".\"main\".\"int_customer_order_history_joined\"\nwhere customer_id is null\n\n\n",
+          "extra_ctes_injected": true,
+          "extra_ctes": [],
+          "contract": {
+            "enforced": false
+          },
+          "column_name": "customer_id",
+          "file_key_name": "models.int_customer_order_history_joined",
+          "attached_node": "model.jaffle_shop.int_customer_order_history_joined"
+        },
+        "test.jaffle_shop.unique_int_order_payments_pivoted_order_id.34a0f3307d": {
+          "test_metadata": {
+            "name": "unique",
+            "kwargs": {
+              "column_name": "order_id",
+              "model": "{{ get_where_subquery(ref('int_order_payments_pivoted')) }}"
+            }
+          },
+          "database": "jaffle_shop",
+          "schema": "main_dbt_test__audit",
+          "name": "unique_int_order_payments_pivoted_order_id",
+          "resource_type": "test",
+          "package_name": "jaffle_shop",
+          "path": "unique_int_order_payments_pivoted_order_id.sql",
+          "original_file_path": "models/schema.yml",
+          "unique_id": "test.jaffle_shop.unique_int_order_payments_pivoted_order_id.34a0f3307d",
+          "fqn": [
+            "jaffle_shop",
+            "unique_int_order_payments_pivoted_order_id"
+          ],
+          "alias": "unique_int_order_payments_pivoted_order_id",
+          "checksum": {
+            "name": "none",
+            "checksum": ""
+          },
+          "config": {
+            "enabled": true,
+            "schema": "dbt_test__audit",
+            "tags": [],
+            "meta": {},
+            "materialized": "test",
+            "severity": "ERROR",
+            "fail_calc": "count(*)",
+            "warn_if": "!= 0",
+            "error_if": "!= 0"
+          },
+          "tags": [],
+          "description": "",
+          "columns": {},
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "build_path": "target/run/jaffle_shop/models/schema.yml/unique_int_order_payments_pivoted_order_id.sql",
+          "deferred": false,
+          "unrendered_config": {},
+          "created_at": 1687240841.356172,
+          "raw_code": "{{ test_unique(**_dbt_generic_test_kwargs) }}",
+          "language": "sql",
+          "refs": [
+            {
+              "name": "int_order_payments_pivoted"
+            }
+          ],
+          "sources": [],
+          "metrics": [],
+          "depends_on": {
+            "macros": [
+              "macro.dbt.test_unique",
+              "macro.dbt.get_where_subquery",
+              "macro.dbt.should_store_failures",
+              "macro.dbt.statement"
+            ],
+            "nodes": [
+              "model.jaffle_shop.int_order_payments_pivoted"
+            ]
+          },
+          "compiled_path": "target/compiled/jaffle_shop/models/schema.yml/unique_int_order_payments_pivoted_order_id.sql",
+          "compiled": true,
+          "compiled_code": "\n    \n    \n\nselect\n    order_id as unique_field,\n    count(*) as n_records\n\nfrom \"jaffle_shop\".\"main\".\"int_order_payments_pivoted\"\nwhere order_id is not null\ngroup by order_id\nhaving count(*) > 1\n\n\n",
+          "extra_ctes_injected": true,
+          "extra_ctes": [],
+          "contract": {
+            "enforced": false
+          },
+          "column_name": "order_id",
+          "file_key_name": "models.int_order_payments_pivoted",
+          "attached_node": "model.jaffle_shop.int_order_payments_pivoted"
+        },
+        "test.jaffle_shop.not_null_int_order_payments_pivoted_order_id.787ba994a8": {
+          "test_metadata": {
+            "name": "not_null",
+            "kwargs": {
+              "column_name": "order_id",
+              "model": "{{ get_where_subquery(ref('int_order_payments_pivoted')) }}"
+            }
+          },
+          "database": "jaffle_shop",
+          "schema": "main_dbt_test__audit",
+          "name": "not_null_int_order_payments_pivoted_order_id",
+          "resource_type": "test",
+          "package_name": "jaffle_shop",
+          "path": "not_null_int_order_payments_pivoted_order_id.sql",
+          "original_file_path": "models/schema.yml",
+          "unique_id": "test.jaffle_shop.not_null_int_order_payments_pivoted_order_id.787ba994a8",
+          "fqn": [
+            "jaffle_shop",
+            "not_null_int_order_payments_pivoted_order_id"
+          ],
+          "alias": "not_null_int_order_payments_pivoted_order_id",
+          "checksum": {
+            "name": "none",
+            "checksum": ""
+          },
+          "config": {
+            "enabled": true,
+            "schema": "dbt_test__audit",
+            "tags": [],
+            "meta": {},
+            "materialized": "test",
+            "severity": "ERROR",
+            "fail_calc": "count(*)",
+            "warn_if": "!= 0",
+            "error_if": "!= 0"
+          },
+          "tags": [],
+          "description": "",
+          "columns": {},
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "build_path": "target/run/jaffle_shop/models/schema.yml/not_null_int_order_payments_pivoted_order_id.sql",
+          "deferred": false,
+          "unrendered_config": {},
+          "created_at": 1687240841.35748,
+          "raw_code": "{{ test_not_null(**_dbt_generic_test_kwargs) }}",
+          "language": "sql",
+          "refs": [
+            {
+              "name": "int_order_payments_pivoted"
+            }
+          ],
+          "sources": [],
+          "metrics": [],
+          "depends_on": {
+            "macros": [
+              "macro.dbt.test_not_null",
+              "macro.dbt.get_where_subquery",
+              "macro.dbt.should_store_failures",
+              "macro.dbt.statement"
+            ],
+            "nodes": [
+              "model.jaffle_shop.int_order_payments_pivoted"
+            ]
+          },
+          "compiled_path": "target/compiled/jaffle_shop/models/schema.yml/not_null_int_order_payments_pivoted_order_id.sql",
+          "compiled": true,
+          "compiled_code": "\n    \n    \n\n\n\nselect order_id\nfrom \"jaffle_shop\".\"main\".\"int_order_payments_pivoted\"\nwhere order_id is null\n\n\n",
+          "extra_ctes_injected": true,
+          "extra_ctes": [],
+          "contract": {
+            "enforced": false
+          },
+          "column_name": "order_id",
+          "file_key_name": "models.int_order_payments_pivoted",
+          "attached_node": "model.jaffle_shop.int_order_payments_pivoted"
+        },
+        "test.jaffle_shop.not_null_int_order_payments_pivoted_customer_id.3db59c6de4": {
+          "test_metadata": {
+            "name": "not_null",
+            "kwargs": {
+              "column_name": "customer_id",
+              "model": "{{ get_where_subquery(ref('int_order_payments_pivoted')) }}"
+            }
+          },
+          "database": "jaffle_shop",
+          "schema": "main_dbt_test__audit",
+          "name": "not_null_int_order_payments_pivoted_customer_id",
+          "resource_type": "test",
+          "package_name": "jaffle_shop",
+          "path": "not_null_int_order_payments_pivoted_customer_id.sql",
+          "original_file_path": "models/schema.yml",
+          "unique_id": "test.jaffle_shop.not_null_int_order_payments_pivoted_customer_id.3db59c6de4",
+          "fqn": [
+            "jaffle_shop",
+            "not_null_int_order_payments_pivoted_customer_id"
+          ],
+          "alias": "not_null_int_order_payments_pivoted_customer_id",
+          "checksum": {
+            "name": "none",
+            "checksum": ""
+          },
+          "config": {
+            "enabled": true,
+            "schema": "dbt_test__audit",
+            "tags": [],
+            "meta": {},
+            "materialized": "test",
+            "severity": "ERROR",
+            "fail_calc": "count(*)",
+            "warn_if": "!= 0",
+            "error_if": "!= 0"
+          },
+          "tags": [],
+          "description": "",
+          "columns": {},
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "build_path": "target/run/jaffle_shop/models/schema.yml/not_null_int_order_payments_pivoted_customer_id.sql",
+          "deferred": false,
+          "unrendered_config": {},
+          "created_at": 1687240841.358758,
+          "raw_code": "{{ test_not_null(**_dbt_generic_test_kwargs) }}",
+          "language": "sql",
+          "refs": [
+            {
+              "name": "int_order_payments_pivoted"
+            }
+          ],
+          "sources": [],
+          "metrics": [],
+          "depends_on": {
+            "macros": [
+              "macro.dbt.test_not_null",
+              "macro.dbt.get_where_subquery",
+              "macro.dbt.should_store_failures",
+              "macro.dbt.statement"
+            ],
+            "nodes": [
+              "model.jaffle_shop.int_order_payments_pivoted"
+            ]
+          },
+          "compiled_path": "target/compiled/jaffle_shop/models/schema.yml/not_null_int_order_payments_pivoted_customer_id.sql",
+          "compiled": true,
+          "compiled_code": "\n    \n    \n\n\n\nselect customer_id\nfrom \"jaffle_shop\".\"main\".\"int_order_payments_pivoted\"\nwhere customer_id is null\n\n\n",
+          "extra_ctes_injected": true,
+          "extra_ctes": [],
+          "contract": {
+            "enforced": false
+          },
+          "column_name": "customer_id",
+          "file_key_name": "models.int_order_payments_pivoted",
+          "attached_node": "model.jaffle_shop.int_order_payments_pivoted"
+        },
+        "test.jaffle_shop.relationships_int_order_payments_pivoted_customer_id__customer_id__ref_int_customer_order_history_joined_.654a1aa35d": {
+          "test_metadata": {
+            "name": "relationships",
+            "kwargs": {
+              "to": "ref('int_customer_order_history_joined')",
+              "field": "customer_id",
+              "column_name": "customer_id",
+              "model": "{{ get_where_subquery(ref('int_order_payments_pivoted')) }}"
+            }
+          },
+          "database": "jaffle_shop",
+          "schema": "main_dbt_test__audit",
+          "name": "relationships_int_order_payments_pivoted_customer_id__customer_id__ref_int_customer_order_history_joined_",
+          "resource_type": "test",
+          "package_name": "jaffle_shop",
+          "path": "relationships_int_order_paymen_0a5fcb40aa1fc18dbd520bbf52b44924.sql",
+          "original_file_path": "models/schema.yml",
+          "unique_id": "test.jaffle_shop.relationships_int_order_payments_pivoted_customer_id__customer_id__ref_int_customer_order_history_joined_.654a1aa35d",
+          "fqn": [
+            "jaffle_shop",
+            "relationships_int_order_payments_pivoted_customer_id__customer_id__ref_int_customer_order_history_joined_"
+          ],
+          "alias": "relationships_int_order_paymen_0a5fcb40aa1fc18dbd520bbf52b44924",
+          "checksum": {
+            "name": "none",
+            "checksum": ""
+          },
+          "config": {
+            "enabled": true,
+            "alias": "relationships_int_order_paymen_0a5fcb40aa1fc18dbd520bbf52b44924",
+            "schema": "dbt_test__audit",
+            "tags": [],
+            "meta": {},
+            "materialized": "test",
+            "severity": "ERROR",
+            "fail_calc": "count(*)",
+            "warn_if": "!= 0",
+            "error_if": "!= 0"
+          },
+          "tags": [],
+          "description": "",
+          "columns": {},
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "build_path": "target/run/jaffle_shop/models/schema.yml/relationships_int_order_paymen_0a5fcb40aa1fc18dbd520bbf52b44924.sql",
+          "deferred": false,
+          "unrendered_config": {
+            "alias": "relationships_int_order_paymen_0a5fcb40aa1fc18dbd520bbf52b44924"
+          },
+          "created_at": 1687240841.359948,
+          "raw_code": "{{ test_relationships(**_dbt_generic_test_kwargs) }}{{ config(alias=\"relationships_int_order_paymen_0a5fcb40aa1fc18dbd520bbf52b44924\") }}",
+          "language": "sql",
+          "refs": [
+            {
+              "name": "int_customer_order_history_joined"
+            },
+            {
+              "name": "int_order_payments_pivoted"
+            }
+          ],
+          "sources": [],
+          "metrics": [],
+          "depends_on": {
+            "macros": [
+              "macro.dbt.test_relationships",
+              "macro.dbt.get_where_subquery",
+              "macro.dbt.should_store_failures",
+              "macro.dbt.statement"
+            ],
+            "nodes": [
+              "model.jaffle_shop.int_customer_order_history_joined",
+              "model.jaffle_shop.int_order_payments_pivoted"
+            ]
+          },
+          "compiled_path": "target/compiled/jaffle_shop/models/schema.yml/relationships_int_order_paymen_0a5fcb40aa1fc18dbd520bbf52b44924.sql",
+          "compiled": true,
+          "compiled_code": "\n    \n    \n\nwith child as (\n    select customer_id as from_field\n    from \"jaffle_shop\".\"main\".\"int_order_payments_pivoted\"\n    where customer_id is not null\n),\n\nparent as (\n    select customer_id as to_field\n    from \"jaffle_shop\".\"main\".\"int_customer_order_history_joined\"\n)\n\nselect\n    from_field\n\nfrom child\nleft join parent\n    on child.from_field = parent.to_field\n\nwhere parent.to_field is null\n\n\n",
+          "extra_ctes_injected": true,
+          "extra_ctes": [],
+          "contract": {
+            "enforced": false
+          },
+          "column_name": "customer_id",
+          "file_key_name": "models.int_order_payments_pivoted",
+          "attached_node": "model.jaffle_shop.int_order_payments_pivoted"
+        },
+        "test.jaffle_shop.accepted_values_int_order_payments_pivoted_status__placed__shipped__completed__return_pending__returned.0ccdff53e8": {
+          "test_metadata": {
+            "name": "accepted_values",
+            "kwargs": {
+              "values": [
+                "placed",
+                "shipped",
+                "completed",
+                "return_pending",
+                "returned"
+              ],
+              "column_name": "status",
+              "model": "{{ get_where_subquery(ref('int_order_payments_pivoted')) }}"
+            }
+          },
+          "database": "jaffle_shop",
+          "schema": "main_dbt_test__audit",
+          "name": "accepted_values_int_order_payments_pivoted_status__placed__shipped__completed__return_pending__returned",
+          "resource_type": "test",
+          "package_name": "jaffle_shop",
+          "path": "accepted_values_int_order_paym_9fe2727f303988bdfad8f1fd2813d0f2.sql",
+          "original_file_path": "models/schema.yml",
+          "unique_id": "test.jaffle_shop.accepted_values_int_order_payments_pivoted_status__placed__shipped__completed__return_pending__returned.0ccdff53e8",
+          "fqn": [
+            "jaffle_shop",
+            "accepted_values_int_order_payments_pivoted_status__placed__shipped__completed__return_pending__returned"
+          ],
+          "alias": "accepted_values_int_order_paym_9fe2727f303988bdfad8f1fd2813d0f2",
+          "checksum": {
+            "name": "none",
+            "checksum": ""
+          },
+          "config": {
+            "enabled": true,
+            "alias": "accepted_values_int_order_paym_9fe2727f303988bdfad8f1fd2813d0f2",
+            "schema": "dbt_test__audit",
+            "tags": [],
+            "meta": {},
+            "materialized": "test",
+            "severity": "ERROR",
+            "fail_calc": "count(*)",
+            "warn_if": "!= 0",
+            "error_if": "!= 0"
+          },
+          "tags": [],
+          "description": "",
+          "columns": {},
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "build_path": "target/run/jaffle_shop/models/schema.yml/accepted_values_int_order_paym_9fe2727f303988bdfad8f1fd2813d0f2.sql",
+          "deferred": false,
+          "unrendered_config": {
+            "alias": "accepted_values_int_order_paym_9fe2727f303988bdfad8f1fd2813d0f2"
+          },
+          "created_at": 1687240841.367187,
+          "raw_code": "{{ test_accepted_values(**_dbt_generic_test_kwargs) }}{{ config(alias=\"accepted_values_int_order_paym_9fe2727f303988bdfad8f1fd2813d0f2\") }}",
+          "language": "sql",
+          "refs": [
+            {
+              "name": "int_order_payments_pivoted"
+            }
+          ],
+          "sources": [],
+          "metrics": [],
+          "depends_on": {
+            "macros": [
+              "macro.dbt.test_accepted_values",
+              "macro.dbt.get_where_subquery",
+              "macro.dbt.should_store_failures",
+              "macro.dbt.statement"
+            ],
+            "nodes": [
+              "model.jaffle_shop.int_order_payments_pivoted"
+            ]
+          },
+          "compiled_path": "target/compiled/jaffle_shop/models/schema.yml/accepted_values_int_order_paym_9fe2727f303988bdfad8f1fd2813d0f2.sql",
+          "compiled": true,
+          "compiled_code": "\n    \n    \n\nwith all_values as (\n\n    select\n        status as value_field,\n        count(*) as n_records\n\n    from \"jaffle_shop\".\"main\".\"int_order_payments_pivoted\"\n    group by status\n\n)\n\nselect *\nfrom all_values\nwhere value_field not in (\n    'placed','shipped','completed','return_pending','returned'\n)\n\n\n",
+          "extra_ctes_injected": true,
+          "extra_ctes": [],
+          "contract": {
+            "enforced": false
+          },
+          "column_name": "status",
+          "file_key_name": "models.int_order_payments_pivoted",
+          "attached_node": "model.jaffle_shop.int_order_payments_pivoted"
+        },
+        "test.jaffle_shop.not_null_int_order_payments_pivoted_amount.b7598e0e3b": {
+          "test_metadata": {
+            "name": "not_null",
+            "kwargs": {
+              "column_name": "amount",
+              "model": "{{ get_where_subquery(ref('int_order_payments_pivoted')) }}"
+            }
+          },
+          "database": "jaffle_shop",
+          "schema": "main_dbt_test__audit",
+          "name": "not_null_int_order_payments_pivoted_amount",
+          "resource_type": "test",
+          "package_name": "jaffle_shop",
+          "path": "not_null_int_order_payments_pivoted_amount.sql",
+          "original_file_path": "models/schema.yml",
+          "unique_id": "test.jaffle_shop.not_null_int_order_payments_pivoted_amount.b7598e0e3b",
+          "fqn": [
+            "jaffle_shop",
+            "not_null_int_order_payments_pivoted_amount"
+          ],
+          "alias": "not_null_int_order_payments_pivoted_amount",
+          "checksum": {
+            "name": "none",
+            "checksum": ""
+          },
+          "config": {
+            "enabled": true,
+            "schema": "dbt_test__audit",
+            "tags": [],
+            "meta": {},
+            "materialized": "test",
+            "severity": "ERROR",
+            "fail_calc": "count(*)",
+            "warn_if": "!= 0",
+            "error_if": "!= 0"
+          },
+          "tags": [],
+          "description": "",
+          "columns": {},
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "build_path": "target/run/jaffle_shop/models/schema.yml/not_null_int_order_payments_pivoted_amount.sql",
+          "deferred": false,
+          "unrendered_config": {},
+          "created_at": 1687240841.39545,
+          "raw_code": "{{ test_not_null(**_dbt_generic_test_kwargs) }}",
+          "language": "sql",
+          "refs": [
+            {
+              "name": "int_order_payments_pivoted"
+            }
+          ],
+          "sources": [],
+          "metrics": [],
+          "depends_on": {
+            "macros": [
+              "macro.dbt.test_not_null",
+              "macro.dbt.get_where_subquery",
+              "macro.dbt.should_store_failures",
+              "macro.dbt.statement"
+            ],
+            "nodes": [
+              "model.jaffle_shop.int_order_payments_pivoted"
+            ]
+          },
+          "compiled_path": "target/compiled/jaffle_shop/models/schema.yml/not_null_int_order_payments_pivoted_amount.sql",
+          "compiled": true,
+          "compiled_code": "\n    \n    \n\n\n\nselect amount\nfrom \"jaffle_shop\".\"main\".\"int_order_payments_pivoted\"\nwhere amount is null\n\n\n",
+          "extra_ctes_injected": true,
+          "extra_ctes": [],
+          "contract": {
+            "enforced": false
+          },
+          "column_name": "amount",
+          "file_key_name": "models.int_order_payments_pivoted",
+          "attached_node": "model.jaffle_shop.int_order_payments_pivoted"
+        },
+        "test.jaffle_shop.not_null_int_order_payments_pivoted_credit_card_amount.ae9c42d967": {
+          "test_metadata": {
+            "name": "not_null",
+            "kwargs": {
+              "column_name": "credit_card_amount",
+              "model": "{{ get_where_subquery(ref('int_order_payments_pivoted')) }}"
+            }
+          },
+          "database": "jaffle_shop",
+          "schema": "main_dbt_test__audit",
+          "name": "not_null_int_order_payments_pivoted_credit_card_amount",
+          "resource_type": "test",
+          "package_name": "jaffle_shop",
+          "path": "not_null_int_order_payments_pivoted_credit_card_amount.sql",
+          "original_file_path": "models/schema.yml",
+          "unique_id": "test.jaffle_shop.not_null_int_order_payments_pivoted_credit_card_amount.ae9c42d967",
+          "fqn": [
+            "jaffle_shop",
+            "not_null_int_order_payments_pivoted_credit_card_amount"
+          ],
+          "alias": "not_null_int_order_payments_pivoted_credit_card_amount",
+          "checksum": {
+            "name": "none",
+            "checksum": ""
+          },
+          "config": {
+            "enabled": true,
+            "schema": "dbt_test__audit",
+            "tags": [],
+            "meta": {},
+            "materialized": "test",
+            "severity": "ERROR",
+            "fail_calc": "count(*)",
+            "warn_if": "!= 0",
+            "error_if": "!= 0"
+          },
+          "tags": [],
+          "description": "",
+          "columns": {},
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "build_path": "target/run/jaffle_shop/models/schema.yml/not_null_int_order_payments_pivoted_credit_card_amount.sql",
+          "deferred": false,
+          "unrendered_config": {},
+          "created_at": 1687240841.39661,
+          "raw_code": "{{ test_not_null(**_dbt_generic_test_kwargs) }}",
+          "language": "sql",
+          "refs": [
+            {
+              "name": "int_order_payments_pivoted"
+            }
+          ],
+          "sources": [],
+          "metrics": [],
+          "depends_on": {
+            "macros": [
+              "macro.dbt.test_not_null",
+              "macro.dbt.get_where_subquery",
+              "macro.dbt.should_store_failures",
+              "macro.dbt.statement"
+            ],
+            "nodes": [
+              "model.jaffle_shop.int_order_payments_pivoted"
+            ]
+          },
+          "compiled_path": "target/compiled/jaffle_shop/models/schema.yml/not_null_int_order_payments_pivoted_credit_card_amount.sql",
+          "compiled": true,
+          "compiled_code": "\n    \n    \n\n\n\nselect credit_card_amount\nfrom \"jaffle_shop\".\"main\".\"int_order_payments_pivoted\"\nwhere credit_card_amount is null\n\n\n",
+          "extra_ctes_injected": true,
+          "extra_ctes": [],
+          "contract": {
+            "enforced": false
+          },
+          "column_name": "credit_card_amount",
+          "file_key_name": "models.int_order_payments_pivoted",
+          "attached_node": "model.jaffle_shop.int_order_payments_pivoted"
+        },
+        "test.jaffle_shop.not_null_int_order_payments_pivoted_coupon_amount.2532b538c2": {
+          "test_metadata": {
+            "name": "not_null",
+            "kwargs": {
+              "column_name": "coupon_amount",
+              "model": "{{ get_where_subquery(ref('int_order_payments_pivoted')) }}"
+            }
+          },
+          "database": "jaffle_shop",
+          "schema": "main_dbt_test__audit",
+          "name": "not_null_int_order_payments_pivoted_coupon_amount",
+          "resource_type": "test",
+          "package_name": "jaffle_shop",
+          "path": "not_null_int_order_payments_pivoted_coupon_amount.sql",
+          "original_file_path": "models/schema.yml",
+          "unique_id": "test.jaffle_shop.not_null_int_order_payments_pivoted_coupon_amount.2532b538c2",
+          "fqn": [
+            "jaffle_shop",
+            "not_null_int_order_payments_pivoted_coupon_amount"
+          ],
+          "alias": "not_null_int_order_payments_pivoted_coupon_amount",
+          "checksum": {
+            "name": "none",
+            "checksum": ""
+          },
+          "config": {
+            "enabled": true,
+            "schema": "dbt_test__audit",
+            "tags": [],
+            "meta": {},
+            "materialized": "test",
+            "severity": "ERROR",
+            "fail_calc": "count(*)",
+            "warn_if": "!= 0",
+            "error_if": "!= 0"
+          },
+          "tags": [],
+          "description": "",
+          "columns": {},
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "build_path": "target/run/jaffle_shop/models/schema.yml/not_null_int_order_payments_pivoted_coupon_amount.sql",
+          "deferred": false,
+          "unrendered_config": {},
+          "created_at": 1687240841.3977668,
+          "raw_code": "{{ test_not_null(**_dbt_generic_test_kwargs) }}",
+          "language": "sql",
+          "refs": [
+            {
+              "name": "int_order_payments_pivoted"
+            }
+          ],
+          "sources": [],
+          "metrics": [],
+          "depends_on": {
+            "macros": [
+              "macro.dbt.test_not_null",
+              "macro.dbt.get_where_subquery",
+              "macro.dbt.should_store_failures",
+              "macro.dbt.statement"
+            ],
+            "nodes": [
+              "model.jaffle_shop.int_order_payments_pivoted"
+            ]
+          },
+          "compiled_path": "target/compiled/jaffle_shop/models/schema.yml/not_null_int_order_payments_pivoted_coupon_amount.sql",
+          "compiled": true,
+          "compiled_code": "\n    \n    \n\n\n\nselect coupon_amount\nfrom \"jaffle_shop\".\"main\".\"int_order_payments_pivoted\"\nwhere coupon_amount is null\n\n\n",
+          "extra_ctes_injected": true,
+          "extra_ctes": [],
+          "contract": {
+            "enforced": false
+          },
+          "column_name": "coupon_amount",
+          "file_key_name": "models.int_order_payments_pivoted",
+          "attached_node": "model.jaffle_shop.int_order_payments_pivoted"
+        },
+        "test.jaffle_shop.not_null_int_order_payments_pivoted_bank_transfer_amount.1a9e62933b": {
+          "test_metadata": {
+            "name": "not_null",
+            "kwargs": {
+              "column_name": "bank_transfer_amount",
+              "model": "{{ get_where_subquery(ref('int_order_payments_pivoted')) }}"
+            }
+          },
+          "database": "jaffle_shop",
+          "schema": "main_dbt_test__audit",
+          "name": "not_null_int_order_payments_pivoted_bank_transfer_amount",
+          "resource_type": "test",
+          "package_name": "jaffle_shop",
+          "path": "not_null_int_order_payments_pivoted_bank_transfer_amount.sql",
+          "original_file_path": "models/schema.yml",
+          "unique_id": "test.jaffle_shop.not_null_int_order_payments_pivoted_bank_transfer_amount.1a9e62933b",
+          "fqn": [
+            "jaffle_shop",
+            "not_null_int_order_payments_pivoted_bank_transfer_amount"
+          ],
+          "alias": "not_null_int_order_payments_pivoted_bank_transfer_amount",
+          "checksum": {
+            "name": "none",
+            "checksum": ""
+          },
+          "config": {
+            "enabled": true,
+            "schema": "dbt_test__audit",
+            "tags": [],
+            "meta": {},
+            "materialized": "test",
+            "severity": "ERROR",
+            "fail_calc": "count(*)",
+            "warn_if": "!= 0",
+            "error_if": "!= 0"
+          },
+          "tags": [],
+          "description": "",
+          "columns": {},
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "build_path": "target/run/jaffle_shop/models/schema.yml/not_null_int_order_payments_pivoted_bank_transfer_amount.sql",
+          "deferred": false,
+          "unrendered_config": {},
+          "created_at": 1687240841.399023,
+          "raw_code": "{{ test_not_null(**_dbt_generic_test_kwargs) }}",
+          "language": "sql",
+          "refs": [
+            {
+              "name": "int_order_payments_pivoted"
+            }
+          ],
+          "sources": [],
+          "metrics": [],
+          "depends_on": {
+            "macros": [
+              "macro.dbt.test_not_null",
+              "macro.dbt.get_where_subquery",
+              "macro.dbt.should_store_failures",
+              "macro.dbt.statement"
+            ],
+            "nodes": [
+              "model.jaffle_shop.int_order_payments_pivoted"
+            ]
+          },
+          "compiled_path": "target/compiled/jaffle_shop/models/schema.yml/not_null_int_order_payments_pivoted_bank_transfer_amount.sql",
+          "compiled": true,
+          "compiled_code": "\n    \n    \n\n\n\nselect bank_transfer_amount\nfrom \"jaffle_shop\".\"main\".\"int_order_payments_pivoted\"\nwhere bank_transfer_amount is null\n\n\n",
+          "extra_ctes_injected": true,
+          "extra_ctes": [],
+          "contract": {
+            "enforced": false
+          },
+          "column_name": "bank_transfer_amount",
+          "file_key_name": "models.int_order_payments_pivoted",
+          "attached_node": "model.jaffle_shop.int_order_payments_pivoted"
+        },
+        "test.jaffle_shop.not_null_int_order_payments_pivoted_gift_card_amount.710d789cc0": {
+          "test_metadata": {
+            "name": "not_null",
+            "kwargs": {
+              "column_name": "gift_card_amount",
+              "model": "{{ get_where_subquery(ref('int_order_payments_pivoted')) }}"
+            }
+          },
+          "database": "jaffle_shop",
+          "schema": "main_dbt_test__audit",
+          "name": "not_null_int_order_payments_pivoted_gift_card_amount",
+          "resource_type": "test",
+          "package_name": "jaffle_shop",
+          "path": "not_null_int_order_payments_pivoted_gift_card_amount.sql",
+          "original_file_path": "models/schema.yml",
+          "unique_id": "test.jaffle_shop.not_null_int_order_payments_pivoted_gift_card_amount.710d789cc0",
+          "fqn": [
+            "jaffle_shop",
+            "not_null_int_order_payments_pivoted_gift_card_amount"
+          ],
+          "alias": "not_null_int_order_payments_pivoted_gift_card_amount",
+          "checksum": {
+            "name": "none",
+            "checksum": ""
+          },
+          "config": {
+            "enabled": true,
+            "schema": "dbt_test__audit",
+            "tags": [],
+            "meta": {},
+            "materialized": "test",
+            "severity": "ERROR",
+            "fail_calc": "count(*)",
+            "warn_if": "!= 0",
+            "error_if": "!= 0"
+          },
+          "tags": [],
+          "description": "",
+          "columns": {},
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "build_path": "target/run/jaffle_shop/models/schema.yml/not_null_int_order_payments_pivoted_gift_card_amount.sql",
+          "deferred": false,
+          "unrendered_config": {},
+          "created_at": 1687240841.40022,
+          "raw_code": "{{ test_not_null(**_dbt_generic_test_kwargs) }}",
+          "language": "sql",
+          "refs": [
+            {
+              "name": "int_order_payments_pivoted"
+            }
+          ],
+          "sources": [],
+          "metrics": [],
+          "depends_on": {
+            "macros": [
+              "macro.dbt.test_not_null",
+              "macro.dbt.get_where_subquery",
+              "macro.dbt.should_store_failures",
+              "macro.dbt.statement"
+            ],
+            "nodes": [
+              "model.jaffle_shop.int_order_payments_pivoted"
+            ]
+          },
+          "compiled_path": "target/compiled/jaffle_shop/models/schema.yml/not_null_int_order_payments_pivoted_gift_card_amount.sql",
+          "compiled": true,
+          "compiled_code": "\n    \n    \n\n\n\nselect gift_card_amount\nfrom \"jaffle_shop\".\"main\".\"int_order_payments_pivoted\"\nwhere gift_card_amount is null\n\n\n",
+          "extra_ctes_injected": true,
+          "extra_ctes": [],
+          "contract": {
+            "enforced": false
+          },
+          "column_name": "gift_card_amount",
+          "file_key_name": "models.int_order_payments_pivoted",
+          "attached_node": "model.jaffle_shop.int_order_payments_pivoted"
+        },
+        "test.jaffle_shop.unique_stg_customers_customer_id.c7614daada": {
+          "test_metadata": {
+            "name": "unique",
+            "kwargs": {
+              "column_name": "customer_id",
+              "model": "{{ get_where_subquery(ref('stg_customers')) }}"
+            }
+          },
+          "database": "jaffle_shop",
+          "schema": "main_dbt_test__audit",
+          "name": "unique_stg_customers_customer_id",
+          "resource_type": "test",
+          "package_name": "jaffle_shop",
+          "path": "unique_stg_customers_customer_id.sql",
+          "original_file_path": "models/staging/schema.yml",
+          "unique_id": "test.jaffle_shop.unique_stg_customers_customer_id.c7614daada",
+          "fqn": [
+            "jaffle_shop",
+            "staging",
+            "unique_stg_customers_customer_id"
+          ],
+          "alias": "unique_stg_customers_customer_id",
+          "checksum": {
+            "name": "none",
+            "checksum": ""
+          },
+          "config": {
+            "enabled": true,
+            "schema": "dbt_test__audit",
+            "tags": [],
+            "meta": {},
+            "materialized": "test",
+            "severity": "ERROR",
+            "fail_calc": "count(*)",
+            "warn_if": "!= 0",
+            "error_if": "!= 0"
+          },
+          "tags": [],
+          "description": "",
+          "columns": {},
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "build_path": "target/run/jaffle_shop/models/staging/schema.yml/unique_stg_customers_customer_id.sql",
+          "deferred": false,
+          "unrendered_config": {},
+          "created_at": 1687240841.4034078,
+          "raw_code": "{{ test_unique(**_dbt_generic_test_kwargs) }}",
+          "language": "sql",
+          "refs": [
+            {
+              "name": "stg_customers"
+            }
+          ],
+          "sources": [],
+          "metrics": [],
+          "depends_on": {
+            "macros": [
+              "macro.dbt.test_unique",
+              "macro.dbt.get_where_subquery",
+              "macro.dbt.should_store_failures",
+              "macro.dbt.statement"
+            ],
+            "nodes": [
+              "model.jaffle_shop.stg_customers"
+            ]
+          },
+          "compiled_path": "target/compiled/jaffle_shop/models/staging/schema.yml/unique_stg_customers_customer_id.sql",
+          "compiled": true,
+          "compiled_code": "\n    \n    \n\nselect\n    customer_id as unique_field,\n    count(*) as n_records\n\nfrom \"jaffle_shop\".\"main\".\"stg_customers\"\nwhere customer_id is not null\ngroup by customer_id\nhaving count(*) > 1\n\n\n",
+          "extra_ctes_injected": true,
+          "extra_ctes": [],
+          "contract": {
+            "enforced": false
+          },
+          "column_name": "customer_id",
+          "file_key_name": "models.stg_customers",
+          "attached_node": "model.jaffle_shop.stg_customers"
+        },
+        "test.jaffle_shop.not_null_stg_customers_customer_id.e2cfb1f9aa": {
+          "test_metadata": {
+            "name": "not_null",
+            "kwargs": {
+              "column_name": "customer_id",
+              "model": "{{ get_where_subquery(ref('stg_customers')) }}"
+            }
+          },
+          "database": "jaffle_shop",
+          "schema": "main_dbt_test__audit",
+          "name": "not_null_stg_customers_customer_id",
+          "resource_type": "test",
+          "package_name": "jaffle_shop",
+          "path": "not_null_stg_customers_customer_id.sql",
+          "original_file_path": "models/staging/schema.yml",
+          "unique_id": "test.jaffle_shop.not_null_stg_customers_customer_id.e2cfb1f9aa",
+          "fqn": [
+            "jaffle_shop",
+            "staging",
+            "not_null_stg_customers_customer_id"
+          ],
+          "alias": "not_null_stg_customers_customer_id",
+          "checksum": {
+            "name": "none",
+            "checksum": ""
+          },
+          "config": {
+            "enabled": true,
+            "schema": "dbt_test__audit",
+            "tags": [],
+            "meta": {},
+            "materialized": "test",
+            "severity": "ERROR",
+            "fail_calc": "count(*)",
+            "warn_if": "!= 0",
+            "error_if": "!= 0"
+          },
+          "tags": [],
+          "description": "",
+          "columns": {},
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "build_path": "target/run/jaffle_shop/models/staging/schema.yml/not_null_stg_customers_customer_id.sql",
+          "deferred": false,
+          "unrendered_config": {},
+          "created_at": 1687240841.404595,
+          "raw_code": "{{ test_not_null(**_dbt_generic_test_kwargs) }}",
+          "language": "sql",
+          "refs": [
+            {
+              "name": "stg_customers"
+            }
+          ],
+          "sources": [],
+          "metrics": [],
+          "depends_on": {
+            "macros": [
+              "macro.dbt.test_not_null",
+              "macro.dbt.get_where_subquery",
+              "macro.dbt.should_store_failures",
+              "macro.dbt.statement"
+            ],
+            "nodes": [
+              "model.jaffle_shop.stg_customers"
+            ]
+          },
+          "compiled_path": "target/compiled/jaffle_shop/models/staging/schema.yml/not_null_stg_customers_customer_id.sql",
+          "compiled": true,
+          "compiled_code": "\n    \n    \n\n\n\nselect customer_id\nfrom \"jaffle_shop\".\"main\".\"stg_customers\"\nwhere customer_id is null\n\n\n",
+          "extra_ctes_injected": true,
+          "extra_ctes": [],
+          "contract": {
+            "enforced": false
+          },
+          "column_name": "customer_id",
+          "file_key_name": "models.stg_customers",
+          "attached_node": "model.jaffle_shop.stg_customers"
+        },
+        "test.jaffle_shop.unique_stg_orders_order_id.e3b841c71a": {
+          "test_metadata": {
+            "name": "unique",
+            "kwargs": {
+              "column_name": "order_id",
+              "model": "{{ get_where_subquery(ref('stg_orders')) }}"
+            }
+          },
+          "database": "jaffle_shop",
+          "schema": "main_dbt_test__audit",
+          "name": "unique_stg_orders_order_id",
+          "resource_type": "test",
+          "package_name": "jaffle_shop",
+          "path": "unique_stg_orders_order_id.sql",
+          "original_file_path": "models/staging/schema.yml",
+          "unique_id": "test.jaffle_shop.unique_stg_orders_order_id.e3b841c71a",
+          "fqn": [
+            "jaffle_shop",
+            "staging",
+            "unique_stg_orders_order_id"
+          ],
+          "alias": "unique_stg_orders_order_id",
+          "checksum": {
+            "name": "none",
+            "checksum": ""
+          },
+          "config": {
+            "enabled": true,
+            "schema": "dbt_test__audit",
+            "tags": [],
+            "meta": {},
+            "materialized": "test",
+            "severity": "ERROR",
+            "fail_calc": "count(*)",
+            "warn_if": "!= 0",
+            "error_if": "!= 0"
+          },
+          "tags": [],
+          "description": "",
+          "columns": {},
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "build_path": "target/run/jaffle_shop/models/staging/schema.yml/unique_stg_orders_order_id.sql",
+          "deferred": false,
+          "unrendered_config": {},
+          "created_at": 1687240841.405817,
+          "raw_code": "{{ test_unique(**_dbt_generic_test_kwargs) }}",
+          "language": "sql",
+          "refs": [
+            {
+              "name": "stg_orders"
+            }
+          ],
+          "sources": [],
+          "metrics": [],
+          "depends_on": {
+            "macros": [
+              "macro.dbt.test_unique",
+              "macro.dbt.get_where_subquery",
+              "macro.dbt.should_store_failures",
+              "macro.dbt.statement"
+            ],
+            "nodes": [
+              "model.jaffle_shop.stg_orders"
+            ]
+          },
+          "compiled_path": "target/compiled/jaffle_shop/models/staging/schema.yml/unique_stg_orders_order_id.sql",
+          "compiled": true,
+          "compiled_code": "\n    \n    \n\nselect\n    order_id as unique_field,\n    count(*) as n_records\n\nfrom \"jaffle_shop\".\"main\".\"stg_orders\"\nwhere order_id is not null\ngroup by order_id\nhaving count(*) > 1\n\n\n",
+          "extra_ctes_injected": true,
+          "extra_ctes": [],
+          "contract": {
+            "enforced": false
+          },
+          "column_name": "order_id",
+          "file_key_name": "models.stg_orders",
+          "attached_node": "model.jaffle_shop.stg_orders"
+        },
+        "test.jaffle_shop.not_null_stg_orders_order_id.81cfe2fe64": {
+          "test_metadata": {
+            "name": "not_null",
+            "kwargs": {
+              "column_name": "order_id",
+              "model": "{{ get_where_subquery(ref('stg_orders')) }}"
+            }
+          },
+          "database": "jaffle_shop",
+          "schema": "main_dbt_test__audit",
+          "name": "not_null_stg_orders_order_id",
+          "resource_type": "test",
+          "package_name": "jaffle_shop",
+          "path": "not_null_stg_orders_order_id.sql",
+          "original_file_path": "models/staging/schema.yml",
+          "unique_id": "test.jaffle_shop.not_null_stg_orders_order_id.81cfe2fe64",
+          "fqn": [
+            "jaffle_shop",
+            "staging",
+            "not_null_stg_orders_order_id"
+          ],
+          "alias": "not_null_stg_orders_order_id",
+          "checksum": {
+            "name": "none",
+            "checksum": ""
+          },
+          "config": {
+            "enabled": true,
+            "schema": "dbt_test__audit",
+            "tags": [],
+            "meta": {},
+            "materialized": "test",
+            "severity": "ERROR",
+            "fail_calc": "count(*)",
+            "warn_if": "!= 0",
+            "error_if": "!= 0"
+          },
+          "tags": [],
+          "description": "",
+          "columns": {},
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "build_path": "target/run/jaffle_shop/models/staging/schema.yml/not_null_stg_orders_order_id.sql",
+          "deferred": false,
+          "unrendered_config": {},
+          "created_at": 1687240841.407118,
+          "raw_code": "{{ test_not_null(**_dbt_generic_test_kwargs) }}",
+          "language": "sql",
+          "refs": [
+            {
+              "name": "stg_orders"
+            }
+          ],
+          "sources": [],
+          "metrics": [],
+          "depends_on": {
+            "macros": [
+              "macro.dbt.test_not_null",
+              "macro.dbt.get_where_subquery",
+              "macro.dbt.should_store_failures",
+              "macro.dbt.statement"
+            ],
+            "nodes": [
+              "model.jaffle_shop.stg_orders"
+            ]
+          },
+          "compiled_path": "target/compiled/jaffle_shop/models/staging/schema.yml/not_null_stg_orders_order_id.sql",
+          "compiled": true,
+          "compiled_code": "\n    \n    \n\n\n\nselect order_id\nfrom \"jaffle_shop\".\"main\".\"stg_orders\"\nwhere order_id is null\n\n\n",
+          "extra_ctes_injected": true,
+          "extra_ctes": [],
+          "contract": {
+            "enforced": false
+          },
+          "column_name": "order_id",
+          "file_key_name": "models.stg_orders",
+          "attached_node": "model.jaffle_shop.stg_orders"
+        },
+        "test.jaffle_shop.accepted_values_stg_orders_status__placed__shipped__completed__return_pending__returned.080fb20aad": {
+          "test_metadata": {
+            "name": "accepted_values",
+            "kwargs": {
+              "values": [
+                "placed",
+                "shipped",
+                "completed",
+                "return_pending",
+                "returned"
+              ],
+              "column_name": "status",
+              "model": "{{ get_where_subquery(ref('stg_orders')) }}"
+            }
+          },
+          "database": "jaffle_shop",
+          "schema": "main_dbt_test__audit",
+          "name": "accepted_values_stg_orders_status__placed__shipped__completed__return_pending__returned",
+          "resource_type": "test",
+          "package_name": "jaffle_shop",
+          "path": "accepted_values_stg_orders_4f514bf94b77b7ea437830eec4421c58.sql",
+          "original_file_path": "models/staging/schema.yml",
+          "unique_id": "test.jaffle_shop.accepted_values_stg_orders_status__placed__shipped__completed__return_pending__returned.080fb20aad",
+          "fqn": [
+            "jaffle_shop",
+            "staging",
+            "accepted_values_stg_orders_status__placed__shipped__completed__return_pending__returned"
+          ],
+          "alias": "accepted_values_stg_orders_4f514bf94b77b7ea437830eec4421c58",
+          "checksum": {
+            "name": "none",
+            "checksum": ""
+          },
+          "config": {
+            "enabled": true,
+            "alias": "accepted_values_stg_orders_4f514bf94b77b7ea437830eec4421c58",
+            "schema": "dbt_test__audit",
+            "tags": [],
+            "meta": {},
+            "materialized": "test",
+            "severity": "ERROR",
+            "fail_calc": "count(*)",
+            "warn_if": "!= 0",
+            "error_if": "!= 0"
+          },
+          "tags": [],
+          "description": "",
+          "columns": {},
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "build_path": "target/run/jaffle_shop/models/staging/schema.yml/accepted_values_stg_orders_4f514bf94b77b7ea437830eec4421c58.sql",
+          "deferred": false,
+          "unrendered_config": {
+            "alias": "accepted_values_stg_orders_4f514bf94b77b7ea437830eec4421c58"
+          },
+          "created_at": 1687240841.4084558,
+          "raw_code": "{{ test_accepted_values(**_dbt_generic_test_kwargs) }}{{ config(alias=\"accepted_values_stg_orders_4f514bf94b77b7ea437830eec4421c58\") }}",
+          "language": "sql",
+          "refs": [
+            {
+              "name": "stg_orders"
+            }
+          ],
+          "sources": [],
+          "metrics": [],
+          "depends_on": {
+            "macros": [
+              "macro.dbt.test_accepted_values",
+              "macro.dbt.get_where_subquery",
+              "macro.dbt.should_store_failures",
+              "macro.dbt.statement"
+            ],
+            "nodes": [
+              "model.jaffle_shop.stg_orders"
+            ]
+          },
+          "compiled_path": "target/compiled/jaffle_shop/models/staging/schema.yml/accepted_values_stg_orders_4f514bf94b77b7ea437830eec4421c58.sql",
+          "compiled": true,
+          "compiled_code": "\n    \n    \n\nwith all_values as (\n\n    select\n        status as value_field,\n        count(*) as n_records\n\n    from \"jaffle_shop\".\"main\".\"stg_orders\"\n    group by status\n\n)\n\nselect *\nfrom all_values\nwhere value_field not in (\n    'placed','shipped','completed','return_pending','returned'\n)\n\n\n",
+          "extra_ctes_injected": true,
+          "extra_ctes": [],
+          "contract": {
+            "enforced": false
+          },
+          "column_name": "status",
+          "file_key_name": "models.stg_orders",
+          "attached_node": "model.jaffle_shop.stg_orders"
+        },
+        "test.jaffle_shop.unique_stg_payments_payment_id.3744510712": {
+          "test_metadata": {
+            "name": "unique",
+            "kwargs": {
+              "column_name": "payment_id",
+              "model": "{{ get_where_subquery(ref('stg_payments')) }}"
+            }
+          },
+          "database": "jaffle_shop",
+          "schema": "main_dbt_test__audit",
+          "name": "unique_stg_payments_payment_id",
+          "resource_type": "test",
+          "package_name": "jaffle_shop",
+          "path": "unique_stg_payments_payment_id.sql",
+          "original_file_path": "models/staging/schema.yml",
+          "unique_id": "test.jaffle_shop.unique_stg_payments_payment_id.3744510712",
+          "fqn": [
+            "jaffle_shop",
+            "staging",
+            "unique_stg_payments_payment_id"
+          ],
+          "alias": "unique_stg_payments_payment_id",
+          "checksum": {
+            "name": "none",
+            "checksum": ""
+          },
+          "config": {
+            "enabled": true,
+            "schema": "dbt_test__audit",
+            "tags": [],
+            "meta": {},
+            "materialized": "test",
+            "severity": "ERROR",
+            "fail_calc": "count(*)",
+            "warn_if": "!= 0",
+            "error_if": "!= 0"
+          },
+          "tags": [],
+          "description": "",
+          "columns": {},
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "build_path": "target/run/jaffle_shop/models/staging/schema.yml/unique_stg_payments_payment_id.sql",
+          "deferred": false,
+          "unrendered_config": {},
+          "created_at": 1687240841.413034,
+          "raw_code": "{{ test_unique(**_dbt_generic_test_kwargs) }}",
+          "language": "sql",
+          "refs": [
+            {
+              "name": "stg_payments"
+            }
+          ],
+          "sources": [],
+          "metrics": [],
+          "depends_on": {
+            "macros": [
+              "macro.dbt.test_unique",
+              "macro.dbt.get_where_subquery",
+              "macro.dbt.should_store_failures",
+              "macro.dbt.statement"
+            ],
+            "nodes": [
+              "model.jaffle_shop.stg_payments"
+            ]
+          },
+          "compiled_path": "target/compiled/jaffle_shop/models/staging/schema.yml/unique_stg_payments_payment_id.sql",
+          "compiled": true,
+          "compiled_code": "\n    \n    \n\nselect\n    payment_id as unique_field,\n    count(*) as n_records\n\nfrom \"jaffle_shop\".\"main\".\"stg_payments\"\nwhere payment_id is not null\ngroup by payment_id\nhaving count(*) > 1\n\n\n",
+          "extra_ctes_injected": true,
+          "extra_ctes": [],
+          "contract": {
+            "enforced": false
+          },
+          "column_name": "payment_id",
+          "file_key_name": "models.stg_payments",
+          "attached_node": "model.jaffle_shop.stg_payments"
+        },
+        "test.jaffle_shop.not_null_stg_payments_payment_id.c19cc50075": {
+          "test_metadata": {
+            "name": "not_null",
+            "kwargs": {
+              "column_name": "payment_id",
+              "model": "{{ get_where_subquery(ref('stg_payments')) }}"
+            }
+          },
+          "database": "jaffle_shop",
+          "schema": "main_dbt_test__audit",
+          "name": "not_null_stg_payments_payment_id",
+          "resource_type": "test",
+          "package_name": "jaffle_shop",
+          "path": "not_null_stg_payments_payment_id.sql",
+          "original_file_path": "models/staging/schema.yml",
+          "unique_id": "test.jaffle_shop.not_null_stg_payments_payment_id.c19cc50075",
+          "fqn": [
+            "jaffle_shop",
+            "staging",
+            "not_null_stg_payments_payment_id"
+          ],
+          "alias": "not_null_stg_payments_payment_id",
+          "checksum": {
+            "name": "none",
+            "checksum": ""
+          },
+          "config": {
+            "enabled": true,
+            "schema": "dbt_test__audit",
+            "tags": [],
+            "meta": {},
+            "materialized": "test",
+            "severity": "ERROR",
+            "fail_calc": "count(*)",
+            "warn_if": "!= 0",
+            "error_if": "!= 0"
+          },
+          "tags": [],
+          "description": "",
+          "columns": {},
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "build_path": "target/run/jaffle_shop/models/staging/schema.yml/not_null_stg_payments_payment_id.sql",
+          "deferred": false,
+          "unrendered_config": {},
+          "created_at": 1687240841.4142258,
+          "raw_code": "{{ test_not_null(**_dbt_generic_test_kwargs) }}",
+          "language": "sql",
+          "refs": [
+            {
+              "name": "stg_payments"
+            }
+          ],
+          "sources": [],
+          "metrics": [],
+          "depends_on": {
+            "macros": [
+              "macro.dbt.test_not_null",
+              "macro.dbt.get_where_subquery",
+              "macro.dbt.should_store_failures",
+              "macro.dbt.statement"
+            ],
+            "nodes": [
+              "model.jaffle_shop.stg_payments"
+            ]
+          },
+          "compiled_path": "target/compiled/jaffle_shop/models/staging/schema.yml/not_null_stg_payments_payment_id.sql",
+          "compiled": true,
+          "compiled_code": "\n    \n    \n\n\n\nselect payment_id\nfrom \"jaffle_shop\".\"main\".\"stg_payments\"\nwhere payment_id is null\n\n\n",
+          "extra_ctes_injected": true,
+          "extra_ctes": [],
+          "contract": {
+            "enforced": false
+          },
+          "column_name": "payment_id",
+          "file_key_name": "models.stg_payments",
+          "attached_node": "model.jaffle_shop.stg_payments"
+        },
+        "test.jaffle_shop.accepted_values_stg_payments_payment_method__credit_card__coupon__bank_transfer__gift_card.3c3820f278": {
+          "test_metadata": {
+            "name": "accepted_values",
+            "kwargs": {
+              "values": [
+                "credit_card",
+                "coupon",
+                "bank_transfer",
+                "gift_card"
+              ],
+              "column_name": "payment_method",
+              "model": "{{ get_where_subquery(ref('stg_payments')) }}"
+            }
+          },
+          "database": "jaffle_shop",
+          "schema": "main_dbt_test__audit",
+          "name": "accepted_values_stg_payments_payment_method__credit_card__coupon__bank_transfer__gift_card",
+          "resource_type": "test",
+          "package_name": "jaffle_shop",
+          "path": "accepted_values_stg_payments_c7909fb19b1f0177c2bf99c7912f06ef.sql",
+          "original_file_path": "models/staging/schema.yml",
+          "unique_id": "test.jaffle_shop.accepted_values_stg_payments_payment_method__credit_card__coupon__bank_transfer__gift_card.3c3820f278",
+          "fqn": [
+            "jaffle_shop",
+            "staging",
+            "accepted_values_stg_payments_payment_method__credit_card__coupon__bank_transfer__gift_card"
+          ],
+          "alias": "accepted_values_stg_payments_c7909fb19b1f0177c2bf99c7912f06ef",
+          "checksum": {
+            "name": "none",
+            "checksum": ""
+          },
+          "config": {
+            "enabled": true,
+            "alias": "accepted_values_stg_payments_c7909fb19b1f0177c2bf99c7912f06ef",
+            "schema": "dbt_test__audit",
+            "tags": [],
+            "meta": {},
+            "materialized": "test",
+            "severity": "ERROR",
+            "fail_calc": "count(*)",
+            "warn_if": "!= 0",
+            "error_if": "!= 0"
+          },
+          "tags": [],
+          "description": "",
+          "columns": {},
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "build_path": "target/run/jaffle_shop/models/staging/schema.yml/accepted_values_stg_payments_c7909fb19b1f0177c2bf99c7912f06ef.sql",
+          "deferred": false,
+          "unrendered_config": {
+            "alias": "accepted_values_stg_payments_c7909fb19b1f0177c2bf99c7912f06ef"
+          },
+          "created_at": 1687240841.415622,
+          "raw_code": "{{ test_accepted_values(**_dbt_generic_test_kwargs) }}{{ config(alias=\"accepted_values_stg_payments_c7909fb19b1f0177c2bf99c7912f06ef\") }}",
+          "language": "sql",
+          "refs": [
+            {
+              "name": "stg_payments"
+            }
+          ],
+          "sources": [],
+          "metrics": [],
+          "depends_on": {
+            "macros": [
+              "macro.dbt.test_accepted_values",
+              "macro.dbt.get_where_subquery",
+              "macro.dbt.should_store_failures",
+              "macro.dbt.statement"
+            ],
+            "nodes": [
+              "model.jaffle_shop.stg_payments"
+            ]
+          },
+          "compiled_path": "target/compiled/jaffle_shop/models/staging/schema.yml/accepted_values_stg_payments_c7909fb19b1f0177c2bf99c7912f06ef.sql",
+          "compiled": true,
+          "compiled_code": "\n    \n    \n\nwith all_values as (\n\n    select\n        payment_method as value_field,\n        count(*) as n_records\n\n    from \"jaffle_shop\".\"main\".\"stg_payments\"\n    group by payment_method\n\n)\n\nselect *\nfrom all_values\nwhere value_field not in (\n    'credit_card','coupon','bank_transfer','gift_card'\n)\n\n\n",
+          "extra_ctes_injected": true,
+          "extra_ctes": [],
+          "contract": {
+            "enforced": false
+          },
+          "column_name": "payment_method",
+          "file_key_name": "models.stg_payments",
+          "attached_node": "model.jaffle_shop.stg_payments"
+        },
+        "test.jaffle_shop.unique_orders_order_id.fed79b3a6e": {
+          "test_metadata": {
+            "name": "unique",
+            "kwargs": {
+              "column_name": "order_id",
+              "model": "{{ get_where_subquery(ref('orders')) }}"
+            }
+          },
+          "database": "jaffle_shop",
+          "schema": "main_dbt_test__audit",
+          "name": "unique_orders_order_id",
+          "resource_type": "test",
+          "package_name": "jaffle_shop",
+          "path": "unique_orders_order_id.sql",
+          "original_file_path": "models/marts/orders.yml",
+          "unique_id": "test.jaffle_shop.unique_orders_order_id.fed79b3a6e",
+          "fqn": [
+            "jaffle_shop",
+            "marts",
+            "unique_orders_order_id"
+          ],
+          "alias": "unique_orders_order_id",
+          "checksum": {
+            "name": "none",
+            "checksum": ""
+          },
+          "config": {
+            "enabled": true,
+            "schema": "dbt_test__audit",
+            "tags": [],
+            "meta": {},
+            "materialized": "test",
+            "severity": "ERROR",
+            "fail_calc": "count(*)",
+            "warn_if": "!= 0",
+            "error_if": "!= 0"
+          },
+          "tags": [],
+          "description": "",
+          "columns": {},
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "build_path": "target/run/jaffle_shop/models/marts/orders.yml/unique_orders_order_id.sql",
+          "deferred": false,
+          "unrendered_config": {},
+          "created_at": 1687240841.4262972,
+          "raw_code": "{{ test_unique(**_dbt_generic_test_kwargs) }}",
+          "language": "sql",
+          "refs": [
+            {
+              "name": "orders"
+            }
+          ],
+          "sources": [],
+          "metrics": [],
+          "depends_on": {
+            "macros": [
+              "macro.dbt.test_unique",
+              "macro.dbt.get_where_subquery",
+              "macro.dbt.should_store_failures",
+              "macro.dbt.statement"
+            ],
+            "nodes": [
+              "model.jaffle_shop.orders"
+            ]
+          },
+          "compiled_path": "target/compiled/jaffle_shop/models/marts/orders.yml/unique_orders_order_id.sql",
+          "compiled": true,
+          "compiled_code": "\n    \n    \n\nselect\n    order_id as unique_field,\n    count(*) as n_records\n\nfrom \"jaffle_shop\".\"main\".\"orders\"\nwhere order_id is not null\ngroup by order_id\nhaving count(*) > 1\n\n\n",
+          "extra_ctes_injected": true,
+          "extra_ctes": [],
+          "contract": {
+            "enforced": false
+          },
+          "column_name": "order_id",
+          "file_key_name": "models.orders",
+          "attached_node": "model.jaffle_shop.orders"
+        },
+        "test.jaffle_shop.not_null_orders_order_id.cf6c17daed": {
+          "test_metadata": {
+            "name": "not_null",
+            "kwargs": {
+              "column_name": "order_id",
+              "model": "{{ get_where_subquery(ref('orders')) }}"
+            }
+          },
+          "database": "jaffle_shop",
+          "schema": "main_dbt_test__audit",
+          "name": "not_null_orders_order_id",
+          "resource_type": "test",
+          "package_name": "jaffle_shop",
+          "path": "not_null_orders_order_id.sql",
+          "original_file_path": "models/marts/orders.yml",
+          "unique_id": "test.jaffle_shop.not_null_orders_order_id.cf6c17daed",
+          "fqn": [
+            "jaffle_shop",
+            "marts",
+            "not_null_orders_order_id"
+          ],
+          "alias": "not_null_orders_order_id",
+          "checksum": {
+            "name": "none",
+            "checksum": ""
+          },
+          "config": {
+            "enabled": true,
+            "schema": "dbt_test__audit",
+            "tags": [],
+            "meta": {},
+            "materialized": "test",
+            "severity": "ERROR",
+            "fail_calc": "count(*)",
+            "warn_if": "!= 0",
+            "error_if": "!= 0"
+          },
+          "tags": [],
+          "description": "",
+          "columns": {},
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "build_path": "target/run/jaffle_shop/models/marts/orders.yml/not_null_orders_order_id.sql",
+          "deferred": false,
+          "unrendered_config": {},
+          "created_at": 1687240841.42753,
+          "raw_code": "{{ test_not_null(**_dbt_generic_test_kwargs) }}",
+          "language": "sql",
+          "refs": [
+            {
+              "name": "orders"
+            }
+          ],
+          "sources": [],
+          "metrics": [],
+          "depends_on": {
+            "macros": [
+              "macro.dbt.test_not_null",
+              "macro.dbt.get_where_subquery",
+              "macro.dbt.should_store_failures",
+              "macro.dbt.statement"
+            ],
+            "nodes": [
+              "model.jaffle_shop.orders"
+            ]
+          },
+          "compiled_path": "target/compiled/jaffle_shop/models/marts/orders.yml/not_null_orders_order_id.sql",
+          "compiled": true,
+          "compiled_code": "\n    \n    \n\n\n\nselect order_id\nfrom \"jaffle_shop\".\"main\".\"orders\"\nwhere order_id is null\n\n\n",
+          "extra_ctes_injected": true,
+          "extra_ctes": [],
+          "contract": {
+            "enforced": false
+          },
+          "column_name": "order_id",
+          "file_key_name": "models.orders",
+          "attached_node": "model.jaffle_shop.orders"
+        },
+        "test.jaffle_shop.not_null_orders_customer_id.c5f02694af": {
+          "test_metadata": {
+            "name": "not_null",
+            "kwargs": {
+              "column_name": "customer_id",
+              "model": "{{ get_where_subquery(ref('orders')) }}"
+            }
+          },
+          "database": "jaffle_shop",
+          "schema": "main_dbt_test__audit",
+          "name": "not_null_orders_customer_id",
+          "resource_type": "test",
+          "package_name": "jaffle_shop",
+          "path": "not_null_orders_customer_id.sql",
+          "original_file_path": "models/marts/orders.yml",
+          "unique_id": "test.jaffle_shop.not_null_orders_customer_id.c5f02694af",
+          "fqn": [
+            "jaffle_shop",
+            "marts",
+            "not_null_orders_customer_id"
+          ],
+          "alias": "not_null_orders_customer_id",
+          "checksum": {
+            "name": "none",
+            "checksum": ""
+          },
+          "config": {
+            "enabled": true,
+            "schema": "dbt_test__audit",
+            "tags": [],
+            "meta": {},
+            "materialized": "test",
+            "severity": "ERROR",
+            "fail_calc": "count(*)",
+            "warn_if": "!= 0",
+            "error_if": "!= 0"
+          },
+          "tags": [],
+          "description": "",
+          "columns": {},
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "build_path": "target/run/jaffle_shop/models/marts/orders.yml/not_null_orders_customer_id.sql",
+          "deferred": false,
+          "unrendered_config": {},
+          "created_at": 1687240841.428805,
+          "raw_code": "{{ test_not_null(**_dbt_generic_test_kwargs) }}",
+          "language": "sql",
+          "refs": [
+            {
+              "name": "orders"
+            }
+          ],
+          "sources": [],
+          "metrics": [],
+          "depends_on": {
+            "macros": [
+              "macro.dbt.test_not_null",
+              "macro.dbt.get_where_subquery",
+              "macro.dbt.should_store_failures",
+              "macro.dbt.statement"
+            ],
+            "nodes": [
+              "model.jaffle_shop.orders"
+            ]
+          },
+          "compiled_path": "target/compiled/jaffle_shop/models/marts/orders.yml/not_null_orders_customer_id.sql",
+          "compiled": true,
+          "compiled_code": "\n    \n    \n\n\n\nselect customer_id\nfrom \"jaffle_shop\".\"main\".\"orders\"\nwhere customer_id is null\n\n\n",
+          "extra_ctes_injected": true,
+          "extra_ctes": [],
+          "contract": {
+            "enforced": false
+          },
+          "column_name": "customer_id",
+          "file_key_name": "models.orders",
+          "attached_node": "model.jaffle_shop.orders"
+        },
+        "test.jaffle_shop.accepted_values_orders_status__placed__shipped__completed__return_pending__returned.be6b5b5ec3": {
+          "test_metadata": {
+            "name": "accepted_values",
+            "kwargs": {
+              "values": [
+                "placed",
+                "shipped",
+                "completed",
+                "return_pending",
+                "returned"
+              ],
+              "column_name": "status",
+              "model": "{{ get_where_subquery(ref('orders')) }}"
+            }
+          },
+          "database": "jaffle_shop",
+          "schema": "main_dbt_test__audit",
+          "name": "accepted_values_orders_status__placed__shipped__completed__return_pending__returned",
+          "resource_type": "test",
+          "package_name": "jaffle_shop",
+          "path": "accepted_values_orders_1ce6ab157c285f7cd2ac656013faf758.sql",
+          "original_file_path": "models/marts/orders.yml",
+          "unique_id": "test.jaffle_shop.accepted_values_orders_status__placed__shipped__completed__return_pending__returned.be6b5b5ec3",
+          "fqn": [
+            "jaffle_shop",
+            "marts",
+            "accepted_values_orders_status__placed__shipped__completed__return_pending__returned"
+          ],
+          "alias": "accepted_values_orders_1ce6ab157c285f7cd2ac656013faf758",
+          "checksum": {
+            "name": "none",
+            "checksum": ""
+          },
+          "config": {
+            "enabled": true,
+            "alias": "accepted_values_orders_1ce6ab157c285f7cd2ac656013faf758",
+            "schema": "dbt_test__audit",
+            "tags": [],
+            "meta": {},
+            "materialized": "test",
+            "severity": "ERROR",
+            "fail_calc": "count(*)",
+            "warn_if": "!= 0",
+            "error_if": "!= 0"
+          },
+          "tags": [],
+          "description": "",
+          "columns": {},
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "build_path": "target/run/jaffle_shop/models/marts/orders.yml/accepted_values_orders_1ce6ab157c285f7cd2ac656013faf758.sql",
+          "deferred": false,
+          "unrendered_config": {
+            "alias": "accepted_values_orders_1ce6ab157c285f7cd2ac656013faf758"
+          },
+          "created_at": 1687240841.430048,
+          "raw_code": "{{ test_accepted_values(**_dbt_generic_test_kwargs) }}{{ config(alias=\"accepted_values_orders_1ce6ab157c285f7cd2ac656013faf758\") }}",
+          "language": "sql",
+          "refs": [
+            {
+              "name": "orders"
+            }
+          ],
+          "sources": [],
+          "metrics": [],
+          "depends_on": {
+            "macros": [
+              "macro.dbt.test_accepted_values",
+              "macro.dbt.get_where_subquery",
+              "macro.dbt.should_store_failures",
+              "macro.dbt.statement"
+            ],
+            "nodes": [
+              "model.jaffle_shop.orders"
+            ]
+          },
+          "compiled_path": "target/compiled/jaffle_shop/models/marts/orders.yml/accepted_values_orders_1ce6ab157c285f7cd2ac656013faf758.sql",
+          "compiled": true,
+          "compiled_code": "\n    \n    \n\nwith all_values as (\n\n    select\n        status as value_field,\n        count(*) as n_records\n\n    from \"jaffle_shop\".\"main\".\"orders\"\n    group by status\n\n)\n\nselect *\nfrom all_values\nwhere value_field not in (\n    'placed','shipped','completed','return_pending','returned'\n)\n\n\n",
+          "extra_ctes_injected": true,
+          "extra_ctes": [],
+          "contract": {
+            "enforced": false
+          },
+          "column_name": "status",
+          "file_key_name": "models.orders",
+          "attached_node": "model.jaffle_shop.orders"
+        },
+        "test.jaffle_shop.not_null_orders_amount.106140f9fd": {
+          "test_metadata": {
+            "name": "not_null",
+            "kwargs": {
+              "column_name": "amount",
+              "model": "{{ get_where_subquery(ref('orders')) }}"
+            }
+          },
+          "database": "jaffle_shop",
+          "schema": "main_dbt_test__audit",
+          "name": "not_null_orders_amount",
+          "resource_type": "test",
+          "package_name": "jaffle_shop",
+          "path": "not_null_orders_amount.sql",
+          "original_file_path": "models/marts/orders.yml",
+          "unique_id": "test.jaffle_shop.not_null_orders_amount.106140f9fd",
+          "fqn": [
+            "jaffle_shop",
+            "marts",
+            "not_null_orders_amount"
+          ],
+          "alias": "not_null_orders_amount",
+          "checksum": {
+            "name": "none",
+            "checksum": ""
+          },
+          "config": {
+            "enabled": true,
+            "schema": "dbt_test__audit",
+            "tags": [],
+            "meta": {},
+            "materialized": "test",
+            "severity": "ERROR",
+            "fail_calc": "count(*)",
+            "warn_if": "!= 0",
+            "error_if": "!= 0"
+          },
+          "tags": [],
+          "description": "",
+          "columns": {},
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "build_path": "target/run/jaffle_shop/models/marts/orders.yml/not_null_orders_amount.sql",
+          "deferred": false,
+          "unrendered_config": {},
+          "created_at": 1687240841.433779,
+          "raw_code": "{{ test_not_null(**_dbt_generic_test_kwargs) }}",
+          "language": "sql",
+          "refs": [
+            {
+              "name": "orders"
+            }
+          ],
+          "sources": [],
+          "metrics": [],
+          "depends_on": {
+            "macros": [
+              "macro.dbt.test_not_null",
+              "macro.dbt.get_where_subquery",
+              "macro.dbt.should_store_failures",
+              "macro.dbt.statement"
+            ],
+            "nodes": [
+              "model.jaffle_shop.orders"
+            ]
+          },
+          "compiled_path": "target/compiled/jaffle_shop/models/marts/orders.yml/not_null_orders_amount.sql",
+          "compiled": true,
+          "compiled_code": "\n    \n    \n\n\n\nselect amount\nfrom \"jaffle_shop\".\"main\".\"orders\"\nwhere amount is null\n\n\n",
+          "extra_ctes_injected": true,
+          "extra_ctes": [],
+          "contract": {
+            "enforced": false
+          },
+          "column_name": "amount",
+          "file_key_name": "models.orders",
+          "attached_node": "model.jaffle_shop.orders"
+        },
+        "test.jaffle_shop.not_null_orders_credit_card_amount.d3ca593b59": {
+          "test_metadata": {
+            "name": "not_null",
+            "kwargs": {
+              "column_name": "credit_card_amount",
+              "model": "{{ get_where_subquery(ref('orders')) }}"
+            }
+          },
+          "database": "jaffle_shop",
+          "schema": "main_dbt_test__audit",
+          "name": "not_null_orders_credit_card_amount",
+          "resource_type": "test",
+          "package_name": "jaffle_shop",
+          "path": "not_null_orders_credit_card_amount.sql",
+          "original_file_path": "models/marts/orders.yml",
+          "unique_id": "test.jaffle_shop.not_null_orders_credit_card_amount.d3ca593b59",
+          "fqn": [
+            "jaffle_shop",
+            "marts",
+            "not_null_orders_credit_card_amount"
+          ],
+          "alias": "not_null_orders_credit_card_amount",
+          "checksum": {
+            "name": "none",
+            "checksum": ""
+          },
+          "config": {
+            "enabled": true,
+            "schema": "dbt_test__audit",
+            "tags": [],
+            "meta": {},
+            "materialized": "test",
+            "severity": "ERROR",
+            "fail_calc": "count(*)",
+            "warn_if": "!= 0",
+            "error_if": "!= 0"
+          },
+          "tags": [],
+          "description": "",
+          "columns": {},
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "build_path": "target/run/jaffle_shop/models/marts/orders.yml/not_null_orders_credit_card_amount.sql",
+          "deferred": false,
+          "unrendered_config": {},
+          "created_at": 1687240841.434981,
+          "raw_code": "{{ test_not_null(**_dbt_generic_test_kwargs) }}",
+          "language": "sql",
+          "refs": [
+            {
+              "name": "orders"
+            }
+          ],
+          "sources": [],
+          "metrics": [],
+          "depends_on": {
+            "macros": [
+              "macro.dbt.test_not_null",
+              "macro.dbt.get_where_subquery",
+              "macro.dbt.should_store_failures",
+              "macro.dbt.statement"
+            ],
+            "nodes": [
+              "model.jaffle_shop.orders"
+            ]
+          },
+          "compiled_path": "target/compiled/jaffle_shop/models/marts/orders.yml/not_null_orders_credit_card_amount.sql",
+          "compiled": true,
+          "compiled_code": "\n    \n    \n\n\n\nselect credit_card_amount\nfrom \"jaffle_shop\".\"main\".\"orders\"\nwhere credit_card_amount is null\n\n\n",
+          "extra_ctes_injected": true,
+          "extra_ctes": [],
+          "contract": {
+            "enforced": false
+          },
+          "column_name": "credit_card_amount",
+          "file_key_name": "models.orders",
+          "attached_node": "model.jaffle_shop.orders"
+        },
+        "test.jaffle_shop.not_null_orders_coupon_amount.ab90c90625": {
+          "test_metadata": {
+            "name": "not_null",
+            "kwargs": {
+              "column_name": "coupon_amount",
+              "model": "{{ get_where_subquery(ref('orders')) }}"
+            }
+          },
+          "database": "jaffle_shop",
+          "schema": "main_dbt_test__audit",
+          "name": "not_null_orders_coupon_amount",
+          "resource_type": "test",
+          "package_name": "jaffle_shop",
+          "path": "not_null_orders_coupon_amount.sql",
+          "original_file_path": "models/marts/orders.yml",
+          "unique_id": "test.jaffle_shop.not_null_orders_coupon_amount.ab90c90625",
+          "fqn": [
+            "jaffle_shop",
+            "marts",
+            "not_null_orders_coupon_amount"
+          ],
+          "alias": "not_null_orders_coupon_amount",
+          "checksum": {
+            "name": "none",
+            "checksum": ""
+          },
+          "config": {
+            "enabled": true,
+            "schema": "dbt_test__audit",
+            "tags": [],
+            "meta": {},
+            "materialized": "test",
+            "severity": "ERROR",
+            "fail_calc": "count(*)",
+            "warn_if": "!= 0",
+            "error_if": "!= 0"
+          },
+          "tags": [],
+          "description": "",
+          "columns": {},
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "build_path": "target/run/jaffle_shop/models/marts/orders.yml/not_null_orders_coupon_amount.sql",
+          "deferred": false,
+          "unrendered_config": {},
+          "created_at": 1687240841.436532,
+          "raw_code": "{{ test_not_null(**_dbt_generic_test_kwargs) }}",
+          "language": "sql",
+          "refs": [
+            {
+              "name": "orders"
+            }
+          ],
+          "sources": [],
+          "metrics": [],
+          "depends_on": {
+            "macros": [
+              "macro.dbt.test_not_null",
+              "macro.dbt.get_where_subquery",
+              "macro.dbt.should_store_failures",
+              "macro.dbt.statement"
+            ],
+            "nodes": [
+              "model.jaffle_shop.orders"
+            ]
+          },
+          "compiled_path": "target/compiled/jaffle_shop/models/marts/orders.yml/not_null_orders_coupon_amount.sql",
+          "compiled": true,
+          "compiled_code": "\n    \n    \n\n\n\nselect coupon_amount\nfrom \"jaffle_shop\".\"main\".\"orders\"\nwhere coupon_amount is null\n\n\n",
+          "extra_ctes_injected": true,
+          "extra_ctes": [],
+          "contract": {
+            "enforced": false
+          },
+          "column_name": "coupon_amount",
+          "file_key_name": "models.orders",
+          "attached_node": "model.jaffle_shop.orders"
+        },
+        "test.jaffle_shop.not_null_orders_bank_transfer_amount.7743500c49": {
+          "test_metadata": {
+            "name": "not_null",
+            "kwargs": {
+              "column_name": "bank_transfer_amount",
+              "model": "{{ get_where_subquery(ref('orders')) }}"
+            }
+          },
+          "database": "jaffle_shop",
+          "schema": "main_dbt_test__audit",
+          "name": "not_null_orders_bank_transfer_amount",
+          "resource_type": "test",
+          "package_name": "jaffle_shop",
+          "path": "not_null_orders_bank_transfer_amount.sql",
+          "original_file_path": "models/marts/orders.yml",
+          "unique_id": "test.jaffle_shop.not_null_orders_bank_transfer_amount.7743500c49",
+          "fqn": [
+            "jaffle_shop",
+            "marts",
+            "not_null_orders_bank_transfer_amount"
+          ],
+          "alias": "not_null_orders_bank_transfer_amount",
+          "checksum": {
+            "name": "none",
+            "checksum": ""
+          },
+          "config": {
+            "enabled": true,
+            "schema": "dbt_test__audit",
+            "tags": [],
+            "meta": {},
+            "materialized": "test",
+            "severity": "ERROR",
+            "fail_calc": "count(*)",
+            "warn_if": "!= 0",
+            "error_if": "!= 0"
+          },
+          "tags": [],
+          "description": "",
+          "columns": {},
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "build_path": "target/run/jaffle_shop/models/marts/orders.yml/not_null_orders_bank_transfer_amount.sql",
+          "deferred": false,
+          "unrendered_config": {},
+          "created_at": 1687240841.4376929,
+          "raw_code": "{{ test_not_null(**_dbt_generic_test_kwargs) }}",
+          "language": "sql",
+          "refs": [
+            {
+              "name": "orders"
+            }
+          ],
+          "sources": [],
+          "metrics": [],
+          "depends_on": {
+            "macros": [
+              "macro.dbt.test_not_null",
+              "macro.dbt.get_where_subquery",
+              "macro.dbt.should_store_failures",
+              "macro.dbt.statement"
+            ],
+            "nodes": [
+              "model.jaffle_shop.orders"
+            ]
+          },
+          "compiled_path": "target/compiled/jaffle_shop/models/marts/orders.yml/not_null_orders_bank_transfer_amount.sql",
+          "compiled": true,
+          "compiled_code": "\n    \n    \n\n\n\nselect bank_transfer_amount\nfrom \"jaffle_shop\".\"main\".\"orders\"\nwhere bank_transfer_amount is null\n\n\n",
+          "extra_ctes_injected": true,
+          "extra_ctes": [],
+          "contract": {
+            "enforced": false
+          },
+          "column_name": "bank_transfer_amount",
+          "file_key_name": "models.orders",
+          "attached_node": "model.jaffle_shop.orders"
+        },
+        "test.jaffle_shop.not_null_orders_gift_card_amount.413a0d2d7a": {
+          "test_metadata": {
+            "name": "not_null",
+            "kwargs": {
+              "column_name": "gift_card_amount",
+              "model": "{{ get_where_subquery(ref('orders')) }}"
+            }
+          },
+          "database": "jaffle_shop",
+          "schema": "main_dbt_test__audit",
+          "name": "not_null_orders_gift_card_amount",
+          "resource_type": "test",
+          "package_name": "jaffle_shop",
+          "path": "not_null_orders_gift_card_amount.sql",
+          "original_file_path": "models/marts/orders.yml",
+          "unique_id": "test.jaffle_shop.not_null_orders_gift_card_amount.413a0d2d7a",
+          "fqn": [
+            "jaffle_shop",
+            "marts",
+            "not_null_orders_gift_card_amount"
+          ],
+          "alias": "not_null_orders_gift_card_amount",
+          "checksum": {
+            "name": "none",
+            "checksum": ""
+          },
+          "config": {
+            "enabled": true,
+            "schema": "dbt_test__audit",
+            "tags": [],
+            "meta": {},
+            "materialized": "test",
+            "severity": "ERROR",
+            "fail_calc": "count(*)",
+            "warn_if": "!= 0",
+            "error_if": "!= 0"
+          },
+          "tags": [],
+          "description": "",
+          "columns": {},
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "build_path": "target/run/jaffle_shop/models/marts/orders.yml/not_null_orders_gift_card_amount.sql",
+          "deferred": false,
+          "unrendered_config": {},
+          "created_at": 1687240841.438865,
+          "raw_code": "{{ test_not_null(**_dbt_generic_test_kwargs) }}",
+          "language": "sql",
+          "refs": [
+            {
+              "name": "orders"
+            }
+          ],
+          "sources": [],
+          "metrics": [],
+          "depends_on": {
+            "macros": [
+              "macro.dbt.test_not_null",
+              "macro.dbt.get_where_subquery",
+              "macro.dbt.should_store_failures",
+              "macro.dbt.statement"
+            ],
+            "nodes": [
+              "model.jaffle_shop.orders"
+            ]
+          },
+          "compiled_path": "target/compiled/jaffle_shop/models/marts/orders.yml/not_null_orders_gift_card_amount.sql",
+          "compiled": true,
+          "compiled_code": "\n    \n    \n\n\n\nselect gift_card_amount\nfrom \"jaffle_shop\".\"main\".\"orders\"\nwhere gift_card_amount is null\n\n\n",
+          "extra_ctes_injected": true,
+          "extra_ctes": [],
+          "contract": {
+            "enforced": false
+          },
+          "column_name": "gift_card_amount",
+          "file_key_name": "models.orders",
+          "attached_node": "model.jaffle_shop.orders"
+        }
+      },
+      "sources": {},
+      "macros": {
+        "macro.dbt_duckdb.duckdb__get_binding_char": {
+          "name": "duckdb__get_binding_char",
+          "resource_type": "macro",
+          "package_name": "dbt_duckdb",
+          "path": "macros/seed.sql",
+          "original_file_path": "macros/seed.sql",
+          "unique_id": "macro.dbt_duckdb.duckdb__get_binding_char",
+          "macro_sql": "{% macro duckdb__get_binding_char() %}\n  {{ return(adapter.get_binding_char()) }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": []
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240840.979298
+        },
+        "macro.dbt_duckdb.duckdb__get_batch_size": {
+          "name": "duckdb__get_batch_size",
+          "resource_type": "macro",
+          "package_name": "dbt_duckdb",
+          "path": "macros/seed.sql",
+          "original_file_path": "macros/seed.sql",
+          "unique_id": "macro.dbt_duckdb.duckdb__get_batch_size",
+          "macro_sql": "{% macro duckdb__get_batch_size() %}\n  {{ return(10000) }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": []
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240840.979442
+        },
+        "macro.dbt_duckdb.duckdb__load_csv_rows": {
+          "name": "duckdb__load_csv_rows",
+          "resource_type": "macro",
+          "package_name": "dbt_duckdb",
+          "path": "macros/seed.sql",
+          "original_file_path": "macros/seed.sql",
+          "unique_id": "macro.dbt_duckdb.duckdb__load_csv_rows",
+          "macro_sql": "{% macro duckdb__load_csv_rows(model, agate_table) %}\n    {% set batch_size = get_batch_size() %}\n    {% set agate_table = adapter.convert_datetimes_to_strs(agate_table) %}\n    {% set cols_sql = get_seed_column_quoted_csv(model, agate_table.column_names) %}\n    {% set bindings = [] %}\n\n    {% set statements = [] %}\n\n    {% for chunk in agate_table.rows | batch(batch_size) %}\n        {% set bindings = [] %}\n\n        {% for row in chunk %}\n            {% do bindings.extend(row) %}\n        {% endfor %}\n\n        {% set sql %}\n            insert into {{ this.render() }} ({{ cols_sql }}) values\n            {% for row in chunk -%}\n                ({%- for column in agate_table.column_names -%}\n                    {{ get_binding_char() }}\n                    {%- if not loop.last%},{%- endif %}\n                {%- endfor -%})\n                {%- if not loop.last%},{%- endif %}\n            {%- endfor %}\n        {% endset %}\n\n        {% do adapter.add_query(sql, bindings=bindings, abridge_sql_log=True) %}\n\n        {% if loop.index0 == 0 %}\n            {% do statements.append(sql) %}\n        {% endif %}\n    {% endfor %}\n\n    {# Return SQL so we can render it out into the compiled files #}\n    {{ return(statements[0]) }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.get_batch_size",
+              "macro.dbt.get_seed_column_quoted_csv",
+              "macro.dbt.get_binding_char"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240840.980868
+        },
+        "macro.dbt_duckdb.duckdb__snapshot_merge_sql": {
+          "name": "duckdb__snapshot_merge_sql",
+          "resource_type": "macro",
+          "package_name": "dbt_duckdb",
+          "path": "macros/snapshot_merge.sql",
+          "original_file_path": "macros/snapshot_merge.sql",
+          "unique_id": "macro.dbt_duckdb.duckdb__snapshot_merge_sql",
+          "macro_sql": "{% macro duckdb__snapshot_merge_sql(target, source, insert_cols) -%}\n    {%- set insert_cols_csv = insert_cols | join(', ') -%}\n\n    update {{ target }}\n    set dbt_valid_to = DBT_INTERNAL_SOURCE.dbt_valid_to\n    from {{ source }} as DBT_INTERNAL_SOURCE\n    where DBT_INTERNAL_SOURCE.dbt_scd_id::text = {{ target }}.dbt_scd_id::text\n      and DBT_INTERNAL_SOURCE.dbt_change_type::text in ('update'::text, 'delete'::text)\n      and {{ target }}.dbt_valid_to is null;\n\n    insert into {{ target }} ({{ insert_cols_csv }})\n    select {% for column in insert_cols -%}\n        DBT_INTERNAL_SOURCE.{{ column }} {%- if not loop.last %}, {%- endif %}\n    {%- endfor %}\n    from {{ source }} as DBT_INTERNAL_SOURCE\n    where DBT_INTERNAL_SOURCE.dbt_change_type::text = 'insert'::text;\n\n{% endmacro %}",
+          "depends_on": {
+            "macros": []
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240840.982239
+        },
+        "macro.dbt_duckdb.duckdb__get_catalog": {
+          "name": "duckdb__get_catalog",
+          "resource_type": "macro",
+          "package_name": "dbt_duckdb",
+          "path": "macros/catalog.sql",
+          "original_file_path": "macros/catalog.sql",
+          "unique_id": "macro.dbt_duckdb.duckdb__get_catalog",
+          "macro_sql": "{% macro duckdb__get_catalog(information_schema, schemas) -%}\n  {%- call statement('catalog', fetch_result=True) -%}\n    select\n        '{{ database }}' as table_database,\n        t.table_schema,\n        t.table_name,\n        t.table_type,\n        '' as table_comment,\n        c.column_name,\n        c.ordinal_position as column_index,\n        c.data_type column_type,\n        '' as column_comment,\n        '' as table_owner\n    FROM information_schema.tables t JOIN information_schema.columns c ON t.table_schema = c.table_schema AND t.table_name = c.table_name\n    WHERE (\n        {%- for schema in schemas -%}\n          upper(t.table_schema) = upper('{{ schema }}'){%- if not loop.last %} or {% endif -%}\n        {%- endfor -%}\n    )\n    AND t.table_type IN ('BASE TABLE', 'VIEW')\n    ORDER BY\n        t.table_schema,\n        t.table_name,\n        c.ordinal_position\n  {%- endcall -%}\n  {{ return(load_result('catalog').table) }}\n{%- endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.statement"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240840.982949
+        },
+        "macro.dbt_duckdb.duckdb__create_schema": {
+          "name": "duckdb__create_schema",
+          "resource_type": "macro",
+          "package_name": "dbt_duckdb",
+          "path": "macros/adapters.sql",
+          "original_file_path": "macros/adapters.sql",
+          "unique_id": "macro.dbt_duckdb.duckdb__create_schema",
+          "macro_sql": "{% macro duckdb__create_schema(relation) -%}\n  {%- call statement('create_schema') -%}\n    create schema if not exists {{ relation.without_identifier().include(database=adapter.use_database()) }}\n  {%- endcall -%}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.statement"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240840.9923341
+        },
+        "macro.dbt_duckdb.duckdb__drop_schema": {
+          "name": "duckdb__drop_schema",
+          "resource_type": "macro",
+          "package_name": "dbt_duckdb",
+          "path": "macros/adapters.sql",
+          "original_file_path": "macros/adapters.sql",
+          "unique_id": "macro.dbt_duckdb.duckdb__drop_schema",
+          "macro_sql": "{% macro duckdb__drop_schema(relation) -%}\n  {%- call statement('drop_schema') -%}\n    drop schema if exists {{ relation.without_identifier().include(database=adapter.use_database()) }} cascade\n  {%- endcall -%}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.statement"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240840.992574
+        },
+        "macro.dbt_duckdb.duckdb__list_schemas": {
+          "name": "duckdb__list_schemas",
+          "resource_type": "macro",
+          "package_name": "dbt_duckdb",
+          "path": "macros/adapters.sql",
+          "original_file_path": "macros/adapters.sql",
+          "unique_id": "macro.dbt_duckdb.duckdb__list_schemas",
+          "macro_sql": "{% macro duckdb__list_schemas(database) -%}\n  {% set sql %}\n    select schema_name\n    from information_schema.schemata\n  {% endset %}\n  {{ return(run_query(sql)) }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.run_query"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240840.99277
+        },
+        "macro.dbt_duckdb.duckdb__check_schema_exists": {
+          "name": "duckdb__check_schema_exists",
+          "resource_type": "macro",
+          "package_name": "dbt_duckdb",
+          "path": "macros/adapters.sql",
+          "original_file_path": "macros/adapters.sql",
+          "unique_id": "macro.dbt_duckdb.duckdb__check_schema_exists",
+          "macro_sql": "{% macro duckdb__check_schema_exists(information_schema, schema) -%}\n  {% set sql -%}\n        select count(*)\n        from information_schema.schemata\n        where schema_name='{{ schema }}'\n  {%- endset %}\n  {{ return(run_query(sql)) }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.run_query"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240840.9929862
+        },
+        "macro.dbt_duckdb.get_column_names": {
+          "name": "get_column_names",
+          "resource_type": "macro",
+          "package_name": "dbt_duckdb",
+          "path": "macros/adapters.sql",
+          "original_file_path": "macros/adapters.sql",
+          "unique_id": "macro.dbt_duckdb.get_column_names",
+          "macro_sql": "{% macro get_column_names() %}\n  {# loop through user_provided_columns to get column names #}\n    {%- set user_provided_columns = model['columns'] -%}\n    (\n    {% for i in user_provided_columns %}\n      {% set col = user_provided_columns[i] %}\n      {{ col['name'] }} {{ \",\" if not loop.last }}\n    {% endfor %}\n  )\n{% endmacro %}",
+          "depends_on": {
+            "macros": []
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240840.993359
+        },
+        "macro.dbt_duckdb.duckdb__create_table_as": {
+          "name": "duckdb__create_table_as",
+          "resource_type": "macro",
+          "package_name": "dbt_duckdb",
+          "path": "macros/adapters.sql",
+          "original_file_path": "macros/adapters.sql",
+          "unique_id": "macro.dbt_duckdb.duckdb__create_table_as",
+          "macro_sql": "{% macro duckdb__create_table_as(temporary, relation, compiled_code, language='sql') -%}\n  {%- if language == 'sql' -%}\n    {% set contract_config = config.get('contract') %}\n    {% if contract_config.enforced %}\n      {{ get_assert_columns_equivalent(compiled_code) }}\n    {% endif %}\n    {%- set sql_header = config.get('sql_header', none) -%}\n\n    {{ sql_header if sql_header is not none }}\n\n    create {% if temporary: -%}temporary{%- endif %} table\n      {{ relation.include(database=(not temporary and adapter.use_database()), schema=(not temporary)) }}\n  {% if contract_config.enforced and not temporary %}\n    {#-- DuckDB doesnt support constraints on temp tables --#}\n    {{ get_table_columns_and_constraints() }} ;\n    insert into {{ relation }} {{ get_column_names() }} (\n      {{ get_select_subquery(compiled_code) }}\n    );\n  {% else %}\n    as (\n      {{ compiled_code }}\n    );\n  {% endif %}\n  {%- elif language == 'python' -%}\n    {{ py_write_table(temporary=temporary, relation=relation, compiled_code=compiled_code) }}\n  {%- else -%}\n      {% do exceptions.raise_compiler_error(\"duckdb__create_table_as macro didn't get supported language, it got %s\" % language) %}\n  {%- endif -%}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.get_assert_columns_equivalent",
+              "macro.dbt.get_table_columns_and_constraints",
+              "macro.dbt_duckdb.get_column_names",
+              "macro.dbt.get_select_subquery",
+              "macro.dbt_duckdb.py_write_table"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240840.994494
+        },
+        "macro.dbt_duckdb.py_write_table": {
+          "name": "py_write_table",
+          "resource_type": "macro",
+          "package_name": "dbt_duckdb",
+          "path": "macros/adapters.sql",
+          "original_file_path": "macros/adapters.sql",
+          "unique_id": "macro.dbt_duckdb.py_write_table",
+          "macro_sql": "{% macro py_write_table(temporary, relation, compiled_code) -%}\n{{ compiled_code }}\n\ndef materialize(df, con):\n    try:\n        import pyarrow\n        pyarrow_available = True\n    except ImportError:\n        pyarrow_available = False\n    finally:\n        if pyarrow_available and isinstance(df, pyarrow.Table):\n            # https://github.com/duckdb/duckdb/issues/6584\n            import pyarrow.dataset\n    con.execute('create table {{ relation.include(database=adapter.use_database()) }} as select * from df')\n{% endmacro %}",
+          "depends_on": {
+            "macros": []
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240840.99472
+        },
+        "macro.dbt_duckdb.duckdb__create_view_as": {
+          "name": "duckdb__create_view_as",
+          "resource_type": "macro",
+          "package_name": "dbt_duckdb",
+          "path": "macros/adapters.sql",
+          "original_file_path": "macros/adapters.sql",
+          "unique_id": "macro.dbt_duckdb.duckdb__create_view_as",
+          "macro_sql": "{% macro duckdb__create_view_as(relation, sql) -%}\n  {% set contract_config = config.get('contract') %}\n  {% if contract_config.enforced %}\n    {{ get_assert_columns_equivalent(sql) }}\n  {%- endif %}\n  {%- set sql_header = config.get('sql_header', none) -%}\n\n  {{ sql_header if sql_header is not none }}\n  create view {{ relation.include(database=adapter.use_database()) }} as (\n    {{ sql }}\n  );\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.get_assert_columns_equivalent"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240840.9951801
+        },
+        "macro.dbt_duckdb.duckdb__get_columns_in_relation": {
+          "name": "duckdb__get_columns_in_relation",
+          "resource_type": "macro",
+          "package_name": "dbt_duckdb",
+          "path": "macros/adapters.sql",
+          "original_file_path": "macros/adapters.sql",
+          "unique_id": "macro.dbt_duckdb.duckdb__get_columns_in_relation",
+          "macro_sql": "{% macro duckdb__get_columns_in_relation(relation) -%}\n  {% call statement('get_columns_in_relation', fetch_result=True) %}\n      select\n          column_name,\n          data_type,\n          character_maximum_length,\n          numeric_precision,\n          numeric_scale\n\n      from information_schema.columns\n      where table_name = '{{ relation.identifier }}'\n        {% if relation.schema %}\n        and table_schema = '{{ relation.schema }}'\n        {% endif %}\n      order by ordinal_position\n\n  {% endcall %}\n  {% set table = load_result('get_columns_in_relation').table %}\n  {{ return(sql_convert_columns_in_relation(table)) }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.statement",
+              "macro.dbt.sql_convert_columns_in_relation"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240840.9956
+        },
+        "macro.dbt_duckdb.duckdb__list_relations_without_caching": {
+          "name": "duckdb__list_relations_without_caching",
+          "resource_type": "macro",
+          "package_name": "dbt_duckdb",
+          "path": "macros/adapters.sql",
+          "original_file_path": "macros/adapters.sql",
+          "unique_id": "macro.dbt_duckdb.duckdb__list_relations_without_caching",
+          "macro_sql": "{% macro duckdb__list_relations_without_caching(schema_relation) %}\n  {% call statement('list_relations_without_caching', fetch_result=True) -%}\n    select\n      '{{ schema_relation.database }}' as database,\n      table_name as name,\n      table_schema as schema,\n      CASE table_type\n        WHEN 'BASE TABLE' THEN 'table'\n        WHEN 'VIEW' THEN 'view'\n        WHEN 'LOCAL TEMPORARY' THEN 'table'\n        END as type\n    from information_schema.tables\n    where table_schema = '{{ schema_relation.schema }}'\n  {% endcall %}\n  {{ return(load_result('list_relations_without_caching').table) }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.statement"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240840.9959092
+        },
+        "macro.dbt_duckdb.duckdb__drop_relation": {
+          "name": "duckdb__drop_relation",
+          "resource_type": "macro",
+          "package_name": "dbt_duckdb",
+          "path": "macros/adapters.sql",
+          "original_file_path": "macros/adapters.sql",
+          "unique_id": "macro.dbt_duckdb.duckdb__drop_relation",
+          "macro_sql": "{% macro duckdb__drop_relation(relation) -%}\n  {% call statement('drop_relation', auto_begin=False) -%}\n    drop {{ relation.type }} if exists {{ relation.include(database=adapter.use_database()) }} cascade\n  {%- endcall %}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.statement"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240840.996166
+        },
+        "macro.dbt_duckdb.duckdb__truncate_relation": {
+          "name": "duckdb__truncate_relation",
+          "resource_type": "macro",
+          "package_name": "dbt_duckdb",
+          "path": "macros/adapters.sql",
+          "original_file_path": "macros/adapters.sql",
+          "unique_id": "macro.dbt_duckdb.duckdb__truncate_relation",
+          "macro_sql": "{% macro duckdb__truncate_relation(relation) -%}\n  {% call statement('truncate_relation') -%}\n    DELETE FROM {{ relation.include(database=adapter.use_database()) }} WHERE 1=1\n  {%- endcall %}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.statement"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240840.996377
+        },
+        "macro.dbt_duckdb.duckdb__rename_relation": {
+          "name": "duckdb__rename_relation",
+          "resource_type": "macro",
+          "package_name": "dbt_duckdb",
+          "path": "macros/adapters.sql",
+          "original_file_path": "macros/adapters.sql",
+          "unique_id": "macro.dbt_duckdb.duckdb__rename_relation",
+          "macro_sql": "{% macro duckdb__rename_relation(from_relation, to_relation) -%}\n  {% set target_name = adapter.quote_as_configured(to_relation.identifier, 'identifier') %}\n  {% call statement('rename_relation') -%}\n    alter {{ to_relation.type }} {{ from_relation }} rename to {{ target_name }}\n  {%- endcall %}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.statement"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240840.996756
+        },
+        "macro.dbt_duckdb.duckdb__make_temp_relation": {
+          "name": "duckdb__make_temp_relation",
+          "resource_type": "macro",
+          "package_name": "dbt_duckdb",
+          "path": "macros/adapters.sql",
+          "original_file_path": "macros/adapters.sql",
+          "unique_id": "macro.dbt_duckdb.duckdb__make_temp_relation",
+          "macro_sql": "{% macro duckdb__make_temp_relation(base_relation, suffix) %}\n    {% set tmp_identifier = base_relation.identifier ~ suffix ~ py_current_timestring() %}\n    {% do return(base_relation.incorporate(\n                                  path={\n                                    \"identifier\": tmp_identifier,\n                                    \"schema\": none,\n                                    \"database\": none\n                                  })) -%}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.py_current_timestring"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240840.997101
+        },
+        "macro.dbt_duckdb.duckdb__current_timestamp": {
+          "name": "duckdb__current_timestamp",
+          "resource_type": "macro",
+          "package_name": "dbt_duckdb",
+          "path": "macros/adapters.sql",
+          "original_file_path": "macros/adapters.sql",
+          "unique_id": "macro.dbt_duckdb.duckdb__current_timestamp",
+          "macro_sql": "{% macro duckdb__current_timestamp() -%}\n  now()\n{%- endmacro %}",
+          "depends_on": {
+            "macros": []
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240840.9971771
+        },
+        "macro.dbt_duckdb.duckdb__snapshot_string_as_time": {
+          "name": "duckdb__snapshot_string_as_time",
+          "resource_type": "macro",
+          "package_name": "dbt_duckdb",
+          "path": "macros/adapters.sql",
+          "original_file_path": "macros/adapters.sql",
+          "unique_id": "macro.dbt_duckdb.duckdb__snapshot_string_as_time",
+          "macro_sql": "{% macro duckdb__snapshot_string_as_time(timestamp) -%}\n    {%- set result = \"'\" ~ timestamp ~ \"'::timestamp\" -%}\n    {{ return(result) }}\n{%- endmacro %}",
+          "depends_on": {
+            "macros": []
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240840.9973462
+        },
+        "macro.dbt_duckdb.duckdb__snapshot_get_time": {
+          "name": "duckdb__snapshot_get_time",
+          "resource_type": "macro",
+          "package_name": "dbt_duckdb",
+          "path": "macros/adapters.sql",
+          "original_file_path": "macros/adapters.sql",
+          "unique_id": "macro.dbt_duckdb.duckdb__snapshot_get_time",
+          "macro_sql": "{% macro duckdb__snapshot_get_time() -%}\n  {{ current_timestamp() }}::timestamp\n{%- endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.current_timestamp"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240840.9974442
+        },
+        "macro.dbt_duckdb.duckdb__get_incremental_default_sql": {
+          "name": "duckdb__get_incremental_default_sql",
+          "resource_type": "macro",
+          "package_name": "dbt_duckdb",
+          "path": "macros/adapters.sql",
+          "original_file_path": "macros/adapters.sql",
+          "unique_id": "macro.dbt_duckdb.duckdb__get_incremental_default_sql",
+          "macro_sql": "{% macro duckdb__get_incremental_default_sql(arg_dict) %}\n  {% do return(get_incremental_delete_insert_sql(arg_dict)) %}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.get_incremental_delete_insert_sql"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240840.99759
+        },
+        "macro.dbt_duckdb.duckdb__get_incremental_delete_insert_sql": {
+          "name": "duckdb__get_incremental_delete_insert_sql",
+          "resource_type": "macro",
+          "package_name": "dbt_duckdb",
+          "path": "macros/adapters.sql",
+          "original_file_path": "macros/adapters.sql",
+          "unique_id": "macro.dbt_duckdb.duckdb__get_incremental_delete_insert_sql",
+          "macro_sql": "{% macro duckdb__get_incremental_delete_insert_sql(arg_dict) %}\n  {% do return(get_delete_insert_merge_sql(arg_dict[\"target_relation\"].include(database=adapter.use_database()), arg_dict[\"temp_relation\"], arg_dict[\"unique_key\"], arg_dict[\"dest_columns\"])) %}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.get_delete_insert_merge_sql"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240840.997893
+        },
+        "macro.dbt_duckdb.duckdb__get_incremental_append_sql": {
+          "name": "duckdb__get_incremental_append_sql",
+          "resource_type": "macro",
+          "package_name": "dbt_duckdb",
+          "path": "macros/adapters.sql",
+          "original_file_path": "macros/adapters.sql",
+          "unique_id": "macro.dbt_duckdb.duckdb__get_incremental_append_sql",
+          "macro_sql": "{% macro duckdb__get_incremental_append_sql(arg_dict) %}\n  {% do return(get_insert_into_sql(arg_dict[\"target_relation\"].include(database=adapter.use_database()), arg_dict[\"temp_relation\"], arg_dict[\"dest_columns\"])) %}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.get_insert_into_sql"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240840.998168
+        },
+        "macro.dbt_duckdb.location_exists": {
+          "name": "location_exists",
+          "resource_type": "macro",
+          "package_name": "dbt_duckdb",
+          "path": "macros/adapters.sql",
+          "original_file_path": "macros/adapters.sql",
+          "unique_id": "macro.dbt_duckdb.location_exists",
+          "macro_sql": "{% macro location_exists(location) -%}\n  {% do return(adapter.location_exists(location)) %}\n{% endmacro %}",
+          "depends_on": {
+            "macros": []
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240840.998315
+        },
+        "macro.dbt_duckdb.write_to_file": {
+          "name": "write_to_file",
+          "resource_type": "macro",
+          "package_name": "dbt_duckdb",
+          "path": "macros/adapters.sql",
+          "original_file_path": "macros/adapters.sql",
+          "unique_id": "macro.dbt_duckdb.write_to_file",
+          "macro_sql": "{% macro write_to_file(relation, location, options) -%}\n  {% call statement('write_to_file') -%}\n    copy {{ relation }} to '{{ location }}' ({{ options }})\n  {%- endcall %}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.statement"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240840.9985259
+        },
+        "macro.dbt_duckdb.register_glue_table": {
+          "name": "register_glue_table",
+          "resource_type": "macro",
+          "package_name": "dbt_duckdb",
+          "path": "macros/adapters.sql",
+          "original_file_path": "macros/adapters.sql",
+          "unique_id": "macro.dbt_duckdb.register_glue_table",
+          "macro_sql": "{% macro register_glue_table(register, glue_database, relation, location, format) -%}\n  {% if location.startswith(\"s3://\") and register == true %}\n    {%- set column_list = adapter.get_columns_in_relation(relation) -%}\n    {% do adapter.register_glue_table(glue_database, relation.identifier, column_list, location, format) %}\n  {% endif %}\n{% endmacro %}",
+          "depends_on": {
+            "macros": []
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240840.9989078
+        },
+        "macro.dbt_duckdb.render_write_options": {
+          "name": "render_write_options",
+          "resource_type": "macro",
+          "package_name": "dbt_duckdb",
+          "path": "macros/adapters.sql",
+          "original_file_path": "macros/adapters.sql",
+          "unique_id": "macro.dbt_duckdb.render_write_options",
+          "macro_sql": "{% macro render_write_options(config) -%}\n  {% set options = config.get('options', {}) %}\n  {% for k in options %}\n    {% if options[k] is string %}\n      {% set _ = options.update({k: render(options[k])}) %}\n    {% else %}\n      {% set _ = options.update({k: render(options[k])}) %}\n    {% endif %}\n  {% endfor %}\n\n  {# legacy top-level write options #}\n  {% if config.get('format') %}\n    {% set _ = options.update({'format': render(config.get('format'))}) %}\n  {% endif %}\n  {% if config.get('delimiter') %}\n    {% set _ = options.update({'delimiter': render(config.get('delimiter'))}) %}\n  {% endif %}\n\n  {% do return(options) %}\n{%- endmacro %}",
+          "depends_on": {
+            "macros": []
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240840.999964
+        },
+        "macro.dbt_duckdb.materialization_table_duckdb": {
+          "name": "materialization_table_duckdb",
+          "resource_type": "macro",
+          "package_name": "dbt_duckdb",
+          "path": "macros/materializations/table.sql",
+          "original_file_path": "macros/materializations/table.sql",
+          "unique_id": "macro.dbt_duckdb.materialization_table_duckdb",
+          "macro_sql": "{% materialization table, adapter=\"duckdb\", supported_languages=['sql', 'python'] %}\n\n  {%- set language = model['language'] -%}\n\n  {%- set existing_relation = load_cached_relation(this) -%}\n  {%- set target_relation = this.incorporate(type='table') %}\n  {%- set intermediate_relation =  make_intermediate_relation(target_relation) -%}\n  -- the intermediate_relation should not already exist in the database; get_relation\n  -- will return None in that case. Otherwise, we get a relation that we can drop\n  -- later, before we try to use this name for the current operation\n  {%- set preexisting_intermediate_relation = load_cached_relation(intermediate_relation) -%}\n  /*\n      See ../view/view.sql for more information about this relation.\n  */\n  {%- set backup_relation_type = 'table' if existing_relation is none else existing_relation.type -%}\n  {%- set backup_relation = make_backup_relation(target_relation, backup_relation_type) -%}\n  -- as above, the backup_relation should not already exist\n  {%- set preexisting_backup_relation = load_cached_relation(backup_relation) -%}\n  -- grab current tables grants config for comparision later on\n  {% set grant_config = config.get('grants') %}\n\n  -- drop the temp relations if they exist already in the database\n  {{ drop_relation_if_exists(preexisting_intermediate_relation) }}\n  {{ drop_relation_if_exists(preexisting_backup_relation) }}\n\n  {{ run_hooks(pre_hooks, inside_transaction=False) }}\n\n  -- `BEGIN` happens here:\n  {{ run_hooks(pre_hooks, inside_transaction=True) }}\n\n  -- build model\n  {% call statement('main', language=language) -%}\n    {{- create_table_as(False, intermediate_relation, compiled_code, language) }}\n  {%- endcall %}\n\n  -- cleanup\n  {% if existing_relation is not none %}\n      {{ adapter.rename_relation(existing_relation, backup_relation) }}\n  {% endif %}\n\n  {{ adapter.rename_relation(intermediate_relation, target_relation) }}\n\n  {% do create_indexes(target_relation) %}\n\n  {{ run_hooks(post_hooks, inside_transaction=True) }}\n\n  {% set should_revoke = should_revoke(existing_relation, full_refresh_mode=True) %}\n  {% do apply_grants(target_relation, grant_config, should_revoke=should_revoke) %}\n\n  {% do persist_docs(target_relation, model) %}\n\n  -- `COMMIT` happens here\n  {{ adapter.commit() }}\n\n  -- finally, drop the existing/backup relation after the commit\n  {{ drop_relation_if_exists(backup_relation) }}\n\n  {{ run_hooks(post_hooks, inside_transaction=False) }}\n\n  {{ return({'relations': [target_relation]}) }}\n{% endmaterialization %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.load_cached_relation",
+              "macro.dbt.make_intermediate_relation",
+              "macro.dbt.make_backup_relation",
+              "macro.dbt.drop_relation_if_exists",
+              "macro.dbt.run_hooks",
+              "macro.dbt.statement",
+              "macro.dbt.create_table_as",
+              "macro.dbt.create_indexes",
+              "macro.dbt.should_revoke",
+              "macro.dbt.apply_grants",
+              "macro.dbt.persist_docs"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.00273,
+          "supported_languages": [
+            "sql",
+            "python"
+          ]
+        },
+        "macro.dbt_duckdb.materialization_external_duckdb": {
+          "name": "materialization_external_duckdb",
+          "resource_type": "macro",
+          "package_name": "dbt_duckdb",
+          "path": "macros/materializations/external.sql",
+          "original_file_path": "macros/materializations/external.sql",
+          "unique_id": "macro.dbt_duckdb.materialization_external_duckdb",
+          "macro_sql": "{% materialization external, adapter=\"duckdb\", supported_languages=['sql', 'python'] %}\n\n  {%- set location = render(config.get('location', default=external_location(this, config))) -%})\n  {%- set rendered_options = render_write_options(config) -%}\n  {%- set format = config.get('format', 'parquet') -%}\n  {%- set write_options = adapter.external_write_options(location, rendered_options) -%}\n  {%- set read_location = adapter.external_read_location(location, rendered_options) -%}\n\n  -- set language - python or sql\n  {%- set language = model['language'] -%}\n\n  {%- set target_relation = this.incorporate(type='view') %}\n\n  -- Continue as normal materialization\n  {%- set existing_relation = load_cached_relation(this) -%}\n  {%- set temp_relation =  make_intermediate_relation(this.incorporate(type='table'), suffix='__dbt_tmp') -%}\n  {%- set intermediate_relation =  make_intermediate_relation(target_relation, suffix='__dbt_int') -%}\n  -- the intermediate_relation should not already exist in the database; get_relation\n  -- will return None in that case. Otherwise, we get a relation that we can drop\n  -- later, before we try to use this name for the current operation\n  {%- set preexisting_temp_relation = load_cached_relation(temp_relation) -%}\n  {%- set preexisting_intermediate_relation = load_cached_relation(intermediate_relation) -%}\n  /*\n      See ../view/view.sql for more information about this relation.\n  */\n  {%- set backup_relation_type = 'table' if existing_relation is none else existing_relation.type -%}\n  {%- set backup_relation = make_backup_relation(target_relation, backup_relation_type) -%}\n  -- as above, the backup_relation should not already exist\n  {%- set preexisting_backup_relation = load_cached_relation(backup_relation) -%}\n  -- grab current tables grants config for comparision later on\n  {% set grant_config = config.get('grants') %}\n\n  -- drop the temp relations if they exist already in the database\n  {{ drop_relation_if_exists(preexisting_intermediate_relation) }}\n  {{ drop_relation_if_exists(preexisting_temp_relation) }}\n  {{ drop_relation_if_exists(preexisting_backup_relation) }}\n\n  {{ run_hooks(pre_hooks, inside_transaction=False) }}\n\n  -- `BEGIN` happens here:\n  {{ run_hooks(pre_hooks, inside_transaction=True) }}\n\n  -- build model\n  {% call statement('create_table', language=language) -%}\n    {{- create_table_as(False, temp_relation, compiled_code, language) }}\n  {%- endcall %}\n\n  -- write an temp relation into file\n  {{ write_to_file(temp_relation, location, write_options) }}\n  -- create a view on top of the location\n  {% call statement('main', language='sql') -%}\n    create or replace view {{ intermediate_relation.include(database=adapter.use_database()) }} as (\n        select * from '{{ read_location }}'\n    );\n  {%- endcall %}\n\n  -- cleanup\n  {% if existing_relation is not none %}\n      {{ adapter.rename_relation(existing_relation, backup_relation) }}\n  {% endif %}\n\n  {{ adapter.rename_relation(intermediate_relation, target_relation) }}\n\n  {{ run_hooks(post_hooks, inside_transaction=True) }}\n\n  {% set should_revoke = should_revoke(existing_relation, full_refresh_mode=True) %}\n  {% do apply_grants(target_relation, grant_config, should_revoke=should_revoke) %}\n\n  {% do persist_docs(target_relation, model) %}\n\n  -- `COMMIT` happens here\n  {{ adapter.commit() }}\n\n  -- finally, drop the existing/backup relation after the commit\n  {{ drop_relation_if_exists(backup_relation) }}\n  {{ drop_relation_if_exists(temp_relation) }}\n\n  -- register table into glue\n  {%- set glue_register = config.get('glue_register', default=false) -%}\n  {%- set glue_database = render(config.get('glue_database', default='default')) -%}\n  {% do register_glue_table(glue_register, glue_database, target_relation, location, format) %}\n\n  {{ run_hooks(post_hooks, inside_transaction=False) }}\n\n  {{ return({'relations': [target_relation]}) }}\n\n{% endmaterialization %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt_duckdb.external_location",
+              "macro.dbt_duckdb.render_write_options",
+              "macro.dbt.load_cached_relation",
+              "macro.dbt.make_intermediate_relation",
+              "macro.dbt.make_backup_relation",
+              "macro.dbt.drop_relation_if_exists",
+              "macro.dbt.run_hooks",
+              "macro.dbt.statement",
+              "macro.dbt.create_table_as",
+              "macro.dbt_duckdb.write_to_file",
+              "macro.dbt.should_revoke",
+              "macro.dbt.apply_grants",
+              "macro.dbt.persist_docs",
+              "macro.dbt_duckdb.register_glue_table"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.007924,
+          "supported_languages": [
+            "sql",
+            "python"
+          ]
+        },
+        "macro.dbt_duckdb.materialization_incremental_duckdb": {
+          "name": "materialization_incremental_duckdb",
+          "resource_type": "macro",
+          "package_name": "dbt_duckdb",
+          "path": "macros/materializations/incremental.sql",
+          "original_file_path": "macros/materializations/incremental.sql",
+          "unique_id": "macro.dbt_duckdb.materialization_incremental_duckdb",
+          "macro_sql": "{% materialization incremental, adapter=\"duckdb\", supported_languages=['sql', 'python'] -%}\n\n  {%- set language = model['language'] -%}\n\n  -- relations\n  {%- set existing_relation = load_cached_relation(this) -%}\n  {%- set target_relation = this.incorporate(type='table') -%}\n  {%- set temp_relation = make_temp_relation(target_relation)-%}\n  {%- set intermediate_relation = make_intermediate_relation(target_relation)-%}\n  {%- set backup_relation_type = 'table' if existing_relation is none else existing_relation.type -%}\n  {%- set backup_relation = make_backup_relation(target_relation, backup_relation_type) -%}\n\n  -- configs\n  {%- set unique_key = config.get('unique_key') -%}\n  {%- set full_refresh_mode = (should_full_refresh()  or existing_relation.is_view) -%}\n  {%- set on_schema_change = incremental_validate_on_schema_change(config.get('on_schema_change'), default='ignore') -%}\n\n  -- the temp_ and backup_ relations should not already exist in the database; get_relation\n  -- will return None in that case. Otherwise, we get a relation that we can drop\n  -- later, before we try to use this name for the current operation. This has to happen before\n  -- BEGIN, in a separate transaction\n  {%- set preexisting_intermediate_relation = load_cached_relation(intermediate_relation)-%}\n  {%- set preexisting_backup_relation = load_cached_relation(backup_relation) -%}\n   -- grab current tables grants config for comparision later on\n  {% set grant_config = config.get('grants') %}\n  {{ drop_relation_if_exists(preexisting_intermediate_relation) }}\n  {{ drop_relation_if_exists(preexisting_backup_relation) }}\n\n  {{ run_hooks(pre_hooks, inside_transaction=False) }}\n\n  -- `BEGIN` happens here:\n  {{ run_hooks(pre_hooks, inside_transaction=True) }}\n\n  {% set to_drop = [] %}\n\n  {% if existing_relation is none %}\n    {% set build_sql = create_table_as(False, target_relation, compiled_code, language) %}\n  {% elif full_refresh_mode %}\n    {% set build_sql = create_table_as(False, intermediate_relation, compiled_code, language) %}\n    {% set need_swap = true %}\n  {% else %}\n    {% if language == 'python' %}\n      {% set build_python = create_table_as(False, temp_relation, compiled_code, language) %}\n      {% call statement(\"pre\", language=language) %}\n        {{- build_python }}\n      {% endcall %}\n    {% else %} {# SQL #}\n      {% do run_query(create_table_as(True, temp_relation, compiled_code, language)) %}\n    {% endif %}\n    {% do adapter.expand_target_column_types(\n             from_relation=temp_relation,\n             to_relation=target_relation) %}\n    {#-- Process schema changes. Returns dict of changes if successful. Use source columns for upserting/merging --#}\n    {% set dest_columns = process_schema_changes(on_schema_change, temp_relation, existing_relation) %}\n    {% if not dest_columns %}\n      {% set dest_columns = adapter.get_columns_in_relation(existing_relation) %}\n    {% endif %}\n\n    {#-- Get the incremental_strategy, the macro to use for the strategy, and build the sql --#}\n    {% set incremental_strategy = config.get('incremental_strategy') or 'default' %}\n    {% set incremental_predicates = config.get('incremental_predicates', none) %}\n    {% set strategy_sql_macro_func = adapter.get_incremental_strategy_macro(context, incremental_strategy) %}\n    {% set strategy_arg_dict = ({'target_relation': target_relation, 'temp_relation': temp_relation, 'unique_key': unique_key, 'dest_columns': dest_columns, 'predicates': incremental_predicates }) %}\n    {% set build_sql = strategy_sql_macro_func(strategy_arg_dict) %}\n    {% set language = \"sql\" %}\n\n  {% endif %}\n\n  {% call statement(\"main\", language=language) %}\n      {{- build_sql }}\n  {% endcall %}\n\n  {% if need_swap %}\n      {% do adapter.rename_relation(target_relation, backup_relation) %}\n      {% do adapter.rename_relation(intermediate_relation, target_relation) %}\n      {% do to_drop.append(backup_relation) %}\n  {% endif %}\n\n  {% set should_revoke = should_revoke(existing_relation, full_refresh_mode) %}\n  {% do apply_grants(target_relation, grant_config, should_revoke=should_revoke) %}\n\n  {% do persist_docs(target_relation, model) %}\n\n  {% if existing_relation is none or existing_relation.is_view or should_full_refresh() %}\n    {% do create_indexes(target_relation) %}\n  {% endif %}\n\n  {{ run_hooks(post_hooks, inside_transaction=True) }}\n\n  -- `COMMIT` happens here\n  {% do adapter.commit() %}\n\n  {% for rel in to_drop %}\n      {% do adapter.drop_relation(rel) %}\n  {% endfor %}\n\n  {{ run_hooks(post_hooks, inside_transaction=False) }}\n\n  {{ return({'relations': [target_relation]}) }}\n\n{%- endmaterialization %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.load_cached_relation",
+              "macro.dbt.make_temp_relation",
+              "macro.dbt.make_intermediate_relation",
+              "macro.dbt.make_backup_relation",
+              "macro.dbt.should_full_refresh",
+              "macro.dbt.incremental_validate_on_schema_change",
+              "macro.dbt.drop_relation_if_exists",
+              "macro.dbt.run_hooks",
+              "macro.dbt.create_table_as",
+              "macro.dbt.statement",
+              "macro.dbt.run_query",
+              "macro.dbt.process_schema_changes",
+              "macro.dbt.should_revoke",
+              "macro.dbt.apply_grants",
+              "macro.dbt.persist_docs",
+              "macro.dbt.create_indexes"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.01354,
+          "supported_languages": [
+            "sql",
+            "python"
+          ]
+        },
+        "macro.dbt_duckdb.duckdb__dateadd": {
+          "name": "duckdb__dateadd",
+          "resource_type": "macro",
+          "package_name": "dbt_duckdb",
+          "path": "macros/utils/dateadd.sql",
+          "original_file_path": "macros/utils/dateadd.sql",
+          "unique_id": "macro.dbt_duckdb.duckdb__dateadd",
+          "macro_sql": "{% macro duckdb__dateadd(datepart, interval, from_date_or_timestamp) %}\n\n    {{ from_date_or_timestamp }} + ((interval '1 {{ datepart }}') * ({{ interval }}))\n\n{% endmacro %}",
+          "depends_on": {
+            "macros": []
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.013786
+        },
+        "macro.dbt_duckdb.duckdb__listagg": {
+          "name": "duckdb__listagg",
+          "resource_type": "macro",
+          "package_name": "dbt_duckdb",
+          "path": "macros/utils/listagg.sql",
+          "original_file_path": "macros/utils/listagg.sql",
+          "unique_id": "macro.dbt_duckdb.duckdb__listagg",
+          "macro_sql": "{% macro duckdb__listagg(measure, delimiter_text, order_by_clause, limit_num) -%}\n    {% if limit_num -%}\n    list_aggr(\n        (array_agg(\n            {{ measure }}\n            {% if order_by_clause -%}\n            {{ order_by_clause }}\n            {%- endif %}\n        ))[1:{{ limit_num }}],\n        'string_agg',\n        {{ delimiter_text }}\n        )\n    {%- else %}\n    string_agg(\n        {{ measure }},\n        {{ delimiter_text }}\n        {% if order_by_clause -%}\n        {{ order_by_clause }}\n        {%- endif %}\n        )\n    {%- endif %}\n{%- endmacro %}",
+          "depends_on": {
+            "macros": []
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.014453
+        },
+        "macro.dbt_duckdb.duckdb__datediff": {
+          "name": "duckdb__datediff",
+          "resource_type": "macro",
+          "package_name": "dbt_duckdb",
+          "path": "macros/utils/datediff.sql",
+          "original_file_path": "macros/utils/datediff.sql",
+          "unique_id": "macro.dbt_duckdb.duckdb__datediff",
+          "macro_sql": "{% macro duckdb__datediff(first_date, second_date, datepart) -%}\n\n    {% if datepart == 'year' %}\n        (date_part('year', ({{second_date}})::date) - date_part('year', ({{first_date}})::date))\n    {% elif datepart == 'quarter' %}\n        ({{ datediff(first_date, second_date, 'year') }} * 4 + date_part('quarter', ({{second_date}})::date) - date_part('quarter', ({{first_date}})::date))\n    {% elif datepart == 'month' %}\n        ({{ datediff(first_date, second_date, 'year') }} * 12 + date_part('month', ({{second_date}})::date) - date_part('month', ({{first_date}})::date))\n    {% elif datepart == 'day' %}\n        (({{second_date}})::date - ({{first_date}})::date)\n    {% elif datepart == 'week' %}\n        ({{ datediff(first_date, second_date, 'day') }} / 7 + case\n            when date_part('dow', ({{first_date}})::timestamp) <= date_part('dow', ({{second_date}})::timestamp) then\n                case when {{first_date}} <= {{second_date}} then 0 else -1 end\n            else\n                case when {{first_date}} <= {{second_date}} then 1 else 0 end\n        end)\n    {% elif datepart == 'hour' %}\n        ({{ datediff(first_date, second_date, 'day') }} * 24 + date_part('hour', ({{second_date}})::timestamp) - date_part('hour', ({{first_date}})::timestamp))\n    {% elif datepart == 'minute' %}\n        ({{ datediff(first_date, second_date, 'hour') }} * 60 + date_part('minute', ({{second_date}})::timestamp) - date_part('minute', ({{first_date}})::timestamp))\n    {% elif datepart == 'second' %}\n        ({{ datediff(first_date, second_date, 'minute') }} * 60 + floor(date_part('second', ({{second_date}})::timestamp)) - floor(date_part('second', ({{first_date}})::timestamp)))\n    {% elif datepart == 'millisecond' %}\n        ({{ datediff(first_date, second_date, 'minute') }} * 60000 + floor(date_part('millisecond', ({{second_date}})::timestamp)) - floor(date_part('millisecond', ({{first_date}})::timestamp)))\n    {% elif datepart == 'microsecond' %}\n        ({{ datediff(first_date, second_date, 'minute') }} * 60000000 + floor(date_part('microsecond', ({{second_date}})::timestamp)) - floor(date_part('microsecond', ({{first_date}})::timestamp)))\n    {% else %}\n        {{ exceptions.raise_compiler_error(\"Unsupported datepart for macro datediff in postgres: {!r}\".format(datepart)) }}\n    {% endif %}\n\n{%- endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.datediff"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.0176718
+        },
+        "macro.dbt_duckdb.duckdb__any_value": {
+          "name": "duckdb__any_value",
+          "resource_type": "macro",
+          "package_name": "dbt_duckdb",
+          "path": "macros/utils/any_value.sql",
+          "original_file_path": "macros/utils/any_value.sql",
+          "unique_id": "macro.dbt_duckdb.duckdb__any_value",
+          "macro_sql": "{% macro duckdb__any_value(expression) -%}\n\n    arbitrary({{ expression }})\n\n{%- endmacro %}",
+          "depends_on": {
+            "macros": []
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.017814
+        },
+        "macro.dbt_duckdb.register_upstream_external_models": {
+          "name": "register_upstream_external_models",
+          "resource_type": "macro",
+          "package_name": "dbt_duckdb",
+          "path": "macros/utils/upstream.sql",
+          "original_file_path": "macros/utils/upstream.sql",
+          "unique_id": "macro.dbt_duckdb.register_upstream_external_models",
+          "macro_sql": "{%- macro register_upstream_external_models() -%}\n{% if execute %}\n{% set upstream_nodes = {} %}\n{% set upstream_schemas = {} %}\n{% for node in selected_resources %}\n  {% for upstream_node in graph['nodes'][node]['depends_on']['nodes'] %}\n    {% if upstream_node not in upstream_nodes and upstream_node not in selected_resources %}\n      {% do upstream_nodes.update({upstream_node: None}) %}\n      {% set upstream = graph['nodes'].get(upstream_node) %}\n      {% if upstream\n         and upstream.resource_type in ('model', 'seed')\n         and upstream.config.materialized=='external'\n      %}\n        {%- set upstream_rel = api.Relation.create(\n          database=upstream['database'],\n          schema=upstream['schema'],\n          identifier=upstream['alias']\n        ) -%}\n        {%- set location = upstream.config.get('location', external_location(upstream_rel, upstream.config)) -%}\n        {%- set rendered_options = render_write_options(upstream.config) -%}\n        {%- set upstream_location = adapter.external_read_location(location, rendered_options) -%}\n        {% if upstream_rel.schema not in upstream_schemas %}\n          {% call statement('main', language='sql') -%}\n            create schema if not exists {{ upstream_rel.schema }}\n          {%- endcall %}\n          {% do upstream_schemas.update({upstream_rel.schema: None}) %}\n        {% endif %}\n        {% call statement('main', language='sql') -%}\n          create or replace view {{ upstream_rel.include(database=adapter.use_database()) }} as (\n            select * from '{{ upstream_location }}'\n          );\n        {%- endcall %}\n      {%- endif %}\n    {% endif %}\n  {% endfor %}\n{% endfor %}\n{% do adapter.commit() %}\n{% endif %}\n{%- endmacro -%}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt_duckdb.external_location",
+              "macro.dbt_duckdb.render_write_options",
+              "macro.dbt.statement"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.020319
+        },
+        "macro.dbt_duckdb.duckdb__split_part": {
+          "name": "duckdb__split_part",
+          "resource_type": "macro",
+          "package_name": "dbt_duckdb",
+          "path": "macros/utils/splitpart.sql",
+          "original_file_path": "macros/utils/splitpart.sql",
+          "unique_id": "macro.dbt_duckdb.duckdb__split_part",
+          "macro_sql": "{% macro duckdb__split_part(string_text, delimiter_text, part_number) %}\n\n  {% if part_number >= 0 %}\n    coalesce(string_split({{ string_text }}, {{ delimiter_text }})[ {{ part_number }} ], '')\n  {% else %}\n    {{ dbt._split_part_negative(string_text, delimiter_text, part_number) }}\n  {% endif %}\n\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt._split_part_negative"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.020725
+        },
+        "macro.dbt_duckdb.duckdb__last_day": {
+          "name": "duckdb__last_day",
+          "resource_type": "macro",
+          "package_name": "dbt_duckdb",
+          "path": "macros/utils/lastday.sql",
+          "original_file_path": "macros/utils/lastday.sql",
+          "unique_id": "macro.dbt_duckdb.duckdb__last_day",
+          "macro_sql": "{% macro duckdb__last_day(date, datepart) -%}\n\n    {%- if datepart == 'quarter' -%}\n    -- duckdb dateadd does not support quarter interval.\n    cast(\n        {{dbt.dateadd('day', '-1',\n        dbt.dateadd('month', '3', dbt.date_trunc(datepart, date))\n        )}}\n        as date)\n    {%- else -%}\n    {{dbt.default_last_day(date, datepart)}}\n    {%- endif -%}\n\n{%- endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.dateadd",
+              "macro.dbt.date_trunc",
+              "macro.dbt.default_last_day"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.021207
+        },
+        "macro.dbt_duckdb.external_location": {
+          "name": "external_location",
+          "resource_type": "macro",
+          "package_name": "dbt_duckdb",
+          "path": "macros/utils/external_location.sql",
+          "original_file_path": "macros/utils/external_location.sql",
+          "unique_id": "macro.dbt_duckdb.external_location",
+          "macro_sql": "{%- macro external_location(relation, config) -%}\n  {%- if config.get('options', {}).get('partition_by') is none -%}\n    {%- set format = config.get('format', 'parquet') -%}\n    {{- adapter.external_root() }}/{{ relation.identifier }}.{{ format }}\n  {%- else -%}\n    {{- adapter.external_root() }}/{{ relation.identifier }}\n  {%- endif -%}\n{%- endmacro -%}",
+          "depends_on": {
+            "macros": []
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.02174
+        },
+        "macro.dbt.run_hooks": {
+          "name": "run_hooks",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/materializations/hooks.sql",
+          "original_file_path": "macros/materializations/hooks.sql",
+          "unique_id": "macro.dbt.run_hooks",
+          "macro_sql": "{% macro run_hooks(hooks, inside_transaction=True) %}\n  {% for hook in hooks | selectattr('transaction', 'equalto', inside_transaction)  %}\n    {% if not inside_transaction and loop.first %}\n      {% call statement(auto_begin=inside_transaction) %}\n        commit;\n      {% endcall %}\n    {% endif %}\n    {% set rendered = render(hook.get('sql')) | trim %}\n    {% if (rendered | length) > 0 %}\n      {% call statement(auto_begin=inside_transaction) %}\n        {{ rendered }}\n      {% endcall %}\n    {% endif %}\n  {% endfor %}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.statement"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.022822
+        },
+        "macro.dbt.make_hook_config": {
+          "name": "make_hook_config",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/materializations/hooks.sql",
+          "original_file_path": "macros/materializations/hooks.sql",
+          "unique_id": "macro.dbt.make_hook_config",
+          "macro_sql": "{% macro make_hook_config(sql, inside_transaction) %}\n    {{ tojson({\"sql\": sql, \"transaction\": inside_transaction}) }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": []
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.02301
+        },
+        "macro.dbt.before_begin": {
+          "name": "before_begin",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/materializations/hooks.sql",
+          "original_file_path": "macros/materializations/hooks.sql",
+          "unique_id": "macro.dbt.before_begin",
+          "macro_sql": "{% macro before_begin(sql) %}\n    {{ make_hook_config(sql, inside_transaction=False) }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.make_hook_config"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.023144
+        },
+        "macro.dbt.in_transaction": {
+          "name": "in_transaction",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/materializations/hooks.sql",
+          "original_file_path": "macros/materializations/hooks.sql",
+          "unique_id": "macro.dbt.in_transaction",
+          "macro_sql": "{% macro in_transaction(sql) %}\n    {{ make_hook_config(sql, inside_transaction=True) }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.make_hook_config"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.0232792
+        },
+        "macro.dbt.after_commit": {
+          "name": "after_commit",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/materializations/hooks.sql",
+          "original_file_path": "macros/materializations/hooks.sql",
+          "unique_id": "macro.dbt.after_commit",
+          "macro_sql": "{% macro after_commit(sql) %}\n    {{ make_hook_config(sql, inside_transaction=False) }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.make_hook_config"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.023416
+        },
+        "macro.dbt.set_sql_header": {
+          "name": "set_sql_header",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/materializations/configs.sql",
+          "original_file_path": "macros/materializations/configs.sql",
+          "unique_id": "macro.dbt.set_sql_header",
+          "macro_sql": "{% macro set_sql_header(config) -%}\n  {{ config.set('sql_header', caller()) }}\n{%- endmacro %}",
+          "depends_on": {
+            "macros": []
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.0237749
+        },
+        "macro.dbt.should_full_refresh": {
+          "name": "should_full_refresh",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/materializations/configs.sql",
+          "original_file_path": "macros/materializations/configs.sql",
+          "unique_id": "macro.dbt.should_full_refresh",
+          "macro_sql": "{% macro should_full_refresh() %}\n  {% set config_full_refresh = config.get('full_refresh') %}\n  {% if config_full_refresh is none %}\n    {% set config_full_refresh = flags.FULL_REFRESH %}\n  {% endif %}\n  {% do return(config_full_refresh) %}\n{% endmacro %}",
+          "depends_on": {
+            "macros": []
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.024066
+        },
+        "macro.dbt.should_store_failures": {
+          "name": "should_store_failures",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/materializations/configs.sql",
+          "original_file_path": "macros/materializations/configs.sql",
+          "unique_id": "macro.dbt.should_store_failures",
+          "macro_sql": "{% macro should_store_failures() %}\n  {% set config_store_failures = config.get('store_failures') %}\n  {% if config_store_failures is none %}\n    {% set config_store_failures = flags.STORE_FAILURES %}\n  {% endif %}\n  {% do return(config_store_failures) %}\n{% endmacro %}",
+          "depends_on": {
+            "macros": []
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.02436
+        },
+        "macro.dbt.snapshot_merge_sql": {
+          "name": "snapshot_merge_sql",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/materializations/snapshots/snapshot_merge.sql",
+          "original_file_path": "macros/materializations/snapshots/snapshot_merge.sql",
+          "unique_id": "macro.dbt.snapshot_merge_sql",
+          "macro_sql": "{% macro snapshot_merge_sql(target, source, insert_cols) -%}\n  {{ adapter.dispatch('snapshot_merge_sql', 'dbt')(target, source, insert_cols) }}\n{%- endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt_duckdb.duckdb__snapshot_merge_sql"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.0248032
+        },
+        "macro.dbt.default__snapshot_merge_sql": {
+          "name": "default__snapshot_merge_sql",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/materializations/snapshots/snapshot_merge.sql",
+          "original_file_path": "macros/materializations/snapshots/snapshot_merge.sql",
+          "unique_id": "macro.dbt.default__snapshot_merge_sql",
+          "macro_sql": "{% macro default__snapshot_merge_sql(target, source, insert_cols) -%}\n    {%- set insert_cols_csv = insert_cols | join(', ') -%}\n\n    merge into {{ target }} as DBT_INTERNAL_DEST\n    using {{ source }} as DBT_INTERNAL_SOURCE\n    on DBT_INTERNAL_SOURCE.dbt_scd_id = DBT_INTERNAL_DEST.dbt_scd_id\n\n    when matched\n     and DBT_INTERNAL_DEST.dbt_valid_to is null\n     and DBT_INTERNAL_SOURCE.dbt_change_type in ('update', 'delete')\n        then update\n        set dbt_valid_to = DBT_INTERNAL_SOURCE.dbt_valid_to\n\n    when not matched\n     and DBT_INTERNAL_SOURCE.dbt_change_type = 'insert'\n        then insert ({{ insert_cols_csv }})\n        values ({{ insert_cols_csv }})\n\n{% endmacro %}",
+          "depends_on": {
+            "macros": []
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.025084
+        },
+        "macro.dbt.strategy_dispatch": {
+          "name": "strategy_dispatch",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/materializations/snapshots/strategies.sql",
+          "original_file_path": "macros/materializations/snapshots/strategies.sql",
+          "unique_id": "macro.dbt.strategy_dispatch",
+          "macro_sql": "{% macro strategy_dispatch(name) -%}\n{% set original_name = name %}\n  {% if '.' in name %}\n    {% set package_name, name = name.split(\".\", 1) %}\n  {% else %}\n    {% set package_name = none %}\n  {% endif %}\n\n  {% if package_name is none %}\n    {% set package_context = context %}\n  {% elif package_name in context %}\n    {% set package_context = context[package_name] %}\n  {% else %}\n    {% set error_msg %}\n        Could not find package '{{package_name}}', called with '{{original_name}}'\n    {% endset %}\n    {{ exceptions.raise_compiler_error(error_msg | trim) }}\n  {% endif %}\n\n  {%- set search_name = 'snapshot_' ~ name ~ '_strategy' -%}\n\n  {% if search_name not in package_context %}\n    {% set error_msg %}\n        The specified strategy macro '{{name}}' was not found in package '{{ package_name }}'\n    {% endset %}\n    {{ exceptions.raise_compiler_error(error_msg | trim) }}\n  {% endif %}\n  {{ return(package_context[search_name]) }}\n{%- endmacro %}",
+          "depends_on": {
+            "macros": []
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.028735
+        },
+        "macro.dbt.snapshot_hash_arguments": {
+          "name": "snapshot_hash_arguments",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/materializations/snapshots/strategies.sql",
+          "original_file_path": "macros/materializations/snapshots/strategies.sql",
+          "unique_id": "macro.dbt.snapshot_hash_arguments",
+          "macro_sql": "{% macro snapshot_hash_arguments(args) -%}\n  {{ adapter.dispatch('snapshot_hash_arguments', 'dbt')(args) }}\n{%- endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.default__snapshot_hash_arguments"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.028897
+        },
+        "macro.dbt.default__snapshot_hash_arguments": {
+          "name": "default__snapshot_hash_arguments",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/materializations/snapshots/strategies.sql",
+          "original_file_path": "macros/materializations/snapshots/strategies.sql",
+          "unique_id": "macro.dbt.default__snapshot_hash_arguments",
+          "macro_sql": "{% macro default__snapshot_hash_arguments(args) -%}\n    md5({%- for arg in args -%}\n        coalesce(cast({{ arg }} as varchar ), '')\n        {% if not loop.last %} || '|' || {% endif %}\n    {%- endfor -%})\n{%- endmacro %}",
+          "depends_on": {
+            "macros": []
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.0291042
+        },
+        "macro.dbt.snapshot_timestamp_strategy": {
+          "name": "snapshot_timestamp_strategy",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/materializations/snapshots/strategies.sql",
+          "original_file_path": "macros/materializations/snapshots/strategies.sql",
+          "unique_id": "macro.dbt.snapshot_timestamp_strategy",
+          "macro_sql": "{% macro snapshot_timestamp_strategy(node, snapshotted_rel, current_rel, config, target_exists) %}\n    {% set primary_key = config['unique_key'] %}\n    {% set updated_at = config['updated_at'] %}\n    {% set invalidate_hard_deletes = config.get('invalidate_hard_deletes', false) %}\n\n    {#/*\n        The snapshot relation might not have an {{ updated_at }} value if the\n        snapshot strategy is changed from `check` to `timestamp`. We\n        should use a dbt-created column for the comparison in the snapshot\n        table instead of assuming that the user-supplied {{ updated_at }}\n        will be present in the historical data.\n\n        See https://github.com/dbt-labs/dbt-core/issues/2350\n    */ #}\n    {% set row_changed_expr -%}\n        ({{ snapshotted_rel }}.dbt_valid_from < {{ current_rel }}.{{ updated_at }})\n    {%- endset %}\n\n    {% set scd_id_expr = snapshot_hash_arguments([primary_key, updated_at]) %}\n\n    {% do return({\n        \"unique_key\": primary_key,\n        \"updated_at\": updated_at,\n        \"row_changed\": row_changed_expr,\n        \"scd_id\": scd_id_expr,\n        \"invalidate_hard_deletes\": invalidate_hard_deletes\n    }) %}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.snapshot_hash_arguments"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.029804
+        },
+        "macro.dbt.snapshot_string_as_time": {
+          "name": "snapshot_string_as_time",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/materializations/snapshots/strategies.sql",
+          "original_file_path": "macros/materializations/snapshots/strategies.sql",
+          "unique_id": "macro.dbt.snapshot_string_as_time",
+          "macro_sql": "{% macro snapshot_string_as_time(timestamp) -%}\n    {{ adapter.dispatch('snapshot_string_as_time', 'dbt')(timestamp) }}\n{%- endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt_duckdb.duckdb__snapshot_string_as_time"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.0299609
+        },
+        "macro.dbt.default__snapshot_string_as_time": {
+          "name": "default__snapshot_string_as_time",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/materializations/snapshots/strategies.sql",
+          "original_file_path": "macros/materializations/snapshots/strategies.sql",
+          "unique_id": "macro.dbt.default__snapshot_string_as_time",
+          "macro_sql": "{% macro default__snapshot_string_as_time(timestamp) %}\n    {% do exceptions.raise_not_implemented(\n        'snapshot_string_as_time macro not implemented for adapter '+adapter.type()\n    ) %}\n{% endmacro %}",
+          "depends_on": {
+            "macros": []
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.030132
+        },
+        "macro.dbt.snapshot_check_all_get_existing_columns": {
+          "name": "snapshot_check_all_get_existing_columns",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/materializations/snapshots/strategies.sql",
+          "original_file_path": "macros/materializations/snapshots/strategies.sql",
+          "unique_id": "macro.dbt.snapshot_check_all_get_existing_columns",
+          "macro_sql": "{% macro snapshot_check_all_get_existing_columns(node, target_exists, check_cols_config) -%}\n    {%- if not target_exists -%}\n        {#-- no table yet -> return whatever the query does --#}\n        {{ return((false, query_columns)) }}\n    {%- endif -%}\n\n    {#-- handle any schema changes --#}\n    {%- set target_relation = adapter.get_relation(database=node.database, schema=node.schema, identifier=node.alias) -%}\n\n    {% if check_cols_config == 'all' %}\n        {%- set query_columns = get_columns_in_query(node['compiled_code']) -%}\n\n    {% elif check_cols_config is iterable and (check_cols_config | length) > 0 %}\n        {#-- query for proper casing/quoting, to support comparison below --#}\n        {%- set select_check_cols_from_target -%}\n            {#-- N.B. The whitespace below is necessary to avoid edge case issue with comments --#}\n            {#-- See: https://github.com/dbt-labs/dbt-core/issues/6781 --#}\n            select {{ check_cols_config | join(', ') }} from (\n                {{ node['compiled_code'] }}\n            ) subq\n        {%- endset -%}\n        {% set query_columns = get_columns_in_query(select_check_cols_from_target) %}\n\n    {% else %}\n        {% do exceptions.raise_compiler_error(\"Invalid value for 'check_cols': \" ~ check_cols_config) %}\n    {% endif %}\n\n    {%- set existing_cols = adapter.get_columns_in_relation(target_relation) | map(attribute = 'name') | list -%}\n    {%- set ns = namespace() -%} {#-- handle for-loop scoping with a namespace --#}\n    {%- set ns.column_added = false -%}\n\n    {%- set intersection = [] -%}\n    {%- for col in query_columns -%}\n        {%- if col in existing_cols -%}\n            {%- do intersection.append(adapter.quote(col)) -%}\n        {%- else -%}\n            {% set ns.column_added = true %}\n        {%- endif -%}\n    {%- endfor -%}\n    {{ return((ns.column_added, intersection)) }}\n{%- endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.get_columns_in_query"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.0314739
+        },
+        "macro.dbt.snapshot_check_strategy": {
+          "name": "snapshot_check_strategy",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/materializations/snapshots/strategies.sql",
+          "original_file_path": "macros/materializations/snapshots/strategies.sql",
+          "unique_id": "macro.dbt.snapshot_check_strategy",
+          "macro_sql": "{% macro snapshot_check_strategy(node, snapshotted_rel, current_rel, config, target_exists) %}\n    {% set check_cols_config = config['check_cols'] %}\n    {% set primary_key = config['unique_key'] %}\n    {% set invalidate_hard_deletes = config.get('invalidate_hard_deletes', false) %}\n    {% set updated_at = config.get('updated_at', snapshot_get_time()) %}\n\n    {% set column_added = false %}\n\n    {% set column_added, check_cols = snapshot_check_all_get_existing_columns(node, target_exists, check_cols_config) %}\n\n    {%- set row_changed_expr -%}\n    (\n    {%- if column_added -%}\n        {{ get_true_sql() }}\n    {%- else -%}\n    {%- for col in check_cols -%}\n        {{ snapshotted_rel }}.{{ col }} != {{ current_rel }}.{{ col }}\n        or\n        (\n            (({{ snapshotted_rel }}.{{ col }} is null) and not ({{ current_rel }}.{{ col }} is null))\n            or\n            ((not {{ snapshotted_rel }}.{{ col }} is null) and ({{ current_rel }}.{{ col }} is null))\n        )\n        {%- if not loop.last %} or {% endif -%}\n    {%- endfor -%}\n    {%- endif -%}\n    )\n    {%- endset %}\n\n    {% set scd_id_expr = snapshot_hash_arguments([primary_key, updated_at]) %}\n\n    {% do return({\n        \"unique_key\": primary_key,\n        \"updated_at\": updated_at,\n        \"row_changed\": row_changed_expr,\n        \"scd_id\": scd_id_expr,\n        \"invalidate_hard_deletes\": invalidate_hard_deletes\n    }) %}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.snapshot_get_time",
+              "macro.dbt.snapshot_check_all_get_existing_columns",
+              "macro.dbt.get_true_sql",
+              "macro.dbt.snapshot_hash_arguments"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.0327759
+        },
+        "macro.dbt.create_columns": {
+          "name": "create_columns",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/materializations/snapshots/helpers.sql",
+          "original_file_path": "macros/materializations/snapshots/helpers.sql",
+          "unique_id": "macro.dbt.create_columns",
+          "macro_sql": "{% macro create_columns(relation, columns) %}\n  {{ adapter.dispatch('create_columns', 'dbt')(relation, columns) }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.default__create_columns"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.037131
+        },
+        "macro.dbt.default__create_columns": {
+          "name": "default__create_columns",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/materializations/snapshots/helpers.sql",
+          "original_file_path": "macros/materializations/snapshots/helpers.sql",
+          "unique_id": "macro.dbt.default__create_columns",
+          "macro_sql": "{% macro default__create_columns(relation, columns) %}\n  {% for column in columns %}\n    {% call statement() %}\n      alter table {{ relation }} add column \"{{ column.name }}\" {{ column.data_type }};\n    {% endcall %}\n  {% endfor %}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.statement"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.0374029
+        },
+        "macro.dbt.post_snapshot": {
+          "name": "post_snapshot",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/materializations/snapshots/helpers.sql",
+          "original_file_path": "macros/materializations/snapshots/helpers.sql",
+          "unique_id": "macro.dbt.post_snapshot",
+          "macro_sql": "{% macro post_snapshot(staging_relation) %}\n  {{ adapter.dispatch('post_snapshot', 'dbt')(staging_relation) }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.default__post_snapshot"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.0375628
+        },
+        "macro.dbt.default__post_snapshot": {
+          "name": "default__post_snapshot",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/materializations/snapshots/helpers.sql",
+          "original_file_path": "macros/materializations/snapshots/helpers.sql",
+          "unique_id": "macro.dbt.default__post_snapshot",
+          "macro_sql": "{% macro default__post_snapshot(staging_relation) %}\n    {# no-op #}\n{% endmacro %}",
+          "depends_on": {
+            "macros": []
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.037645
+        },
+        "macro.dbt.get_true_sql": {
+          "name": "get_true_sql",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/materializations/snapshots/helpers.sql",
+          "original_file_path": "macros/materializations/snapshots/helpers.sql",
+          "unique_id": "macro.dbt.get_true_sql",
+          "macro_sql": "{% macro get_true_sql() %}\n  {{ adapter.dispatch('get_true_sql', 'dbt')() }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.default__get_true_sql"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.037782
+        },
+        "macro.dbt.default__get_true_sql": {
+          "name": "default__get_true_sql",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/materializations/snapshots/helpers.sql",
+          "original_file_path": "macros/materializations/snapshots/helpers.sql",
+          "unique_id": "macro.dbt.default__get_true_sql",
+          "macro_sql": "{% macro default__get_true_sql() %}\n    {{ return('TRUE') }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": []
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.0378911
+        },
+        "macro.dbt.snapshot_staging_table": {
+          "name": "snapshot_staging_table",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/materializations/snapshots/helpers.sql",
+          "original_file_path": "macros/materializations/snapshots/helpers.sql",
+          "unique_id": "macro.dbt.snapshot_staging_table",
+          "macro_sql": "{% macro snapshot_staging_table(strategy, source_sql, target_relation) -%}\n  {{ adapter.dispatch('snapshot_staging_table', 'dbt')(strategy, source_sql, target_relation) }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.default__snapshot_staging_table"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.038089
+        },
+        "macro.dbt.default__snapshot_staging_table": {
+          "name": "default__snapshot_staging_table",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/materializations/snapshots/helpers.sql",
+          "original_file_path": "macros/materializations/snapshots/helpers.sql",
+          "unique_id": "macro.dbt.default__snapshot_staging_table",
+          "macro_sql": "{% macro default__snapshot_staging_table(strategy, source_sql, target_relation) -%}\n\n    with snapshot_query as (\n\n        {{ source_sql }}\n\n    ),\n\n    snapshotted_data as (\n\n        select *,\n            {{ strategy.unique_key }} as dbt_unique_key\n\n        from {{ target_relation }}\n        where dbt_valid_to is null\n\n    ),\n\n    insertions_source_data as (\n\n        select\n            *,\n            {{ strategy.unique_key }} as dbt_unique_key,\n            {{ strategy.updated_at }} as dbt_updated_at,\n            {{ strategy.updated_at }} as dbt_valid_from,\n            nullif({{ strategy.updated_at }}, {{ strategy.updated_at }}) as dbt_valid_to,\n            {{ strategy.scd_id }} as dbt_scd_id\n\n        from snapshot_query\n    ),\n\n    updates_source_data as (\n\n        select\n            *,\n            {{ strategy.unique_key }} as dbt_unique_key,\n            {{ strategy.updated_at }} as dbt_updated_at,\n            {{ strategy.updated_at }} as dbt_valid_from,\n            {{ strategy.updated_at }} as dbt_valid_to\n\n        from snapshot_query\n    ),\n\n    {%- if strategy.invalidate_hard_deletes %}\n\n    deletes_source_data as (\n\n        select\n            *,\n            {{ strategy.unique_key }} as dbt_unique_key\n        from snapshot_query\n    ),\n    {% endif %}\n\n    insertions as (\n\n        select\n            'insert' as dbt_change_type,\n            source_data.*\n\n        from insertions_source_data as source_data\n        left outer join snapshotted_data on snapshotted_data.dbt_unique_key = source_data.dbt_unique_key\n        where snapshotted_data.dbt_unique_key is null\n           or (\n                snapshotted_data.dbt_unique_key is not null\n            and (\n                {{ strategy.row_changed }}\n            )\n        )\n\n    ),\n\n    updates as (\n\n        select\n            'update' as dbt_change_type,\n            source_data.*,\n            snapshotted_data.dbt_scd_id\n\n        from updates_source_data as source_data\n        join snapshotted_data on snapshotted_data.dbt_unique_key = source_data.dbt_unique_key\n        where (\n            {{ strategy.row_changed }}\n        )\n    )\n\n    {%- if strategy.invalidate_hard_deletes -%}\n    ,\n\n    deletes as (\n\n        select\n            'delete' as dbt_change_type,\n            source_data.*,\n            {{ snapshot_get_time() }} as dbt_valid_from,\n            {{ snapshot_get_time() }} as dbt_updated_at,\n            {{ snapshot_get_time() }} as dbt_valid_to,\n            snapshotted_data.dbt_scd_id\n\n        from snapshotted_data\n        left join deletes_source_data as source_data on snapshotted_data.dbt_unique_key = source_data.dbt_unique_key\n        where source_data.dbt_unique_key is null\n    )\n    {%- endif %}\n\n    select * from insertions\n    union all\n    select * from updates\n    {%- if strategy.invalidate_hard_deletes %}\n    union all\n    select * from deletes\n    {%- endif %}\n\n{%- endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.snapshot_get_time"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.038971
+        },
+        "macro.dbt.build_snapshot_table": {
+          "name": "build_snapshot_table",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/materializations/snapshots/helpers.sql",
+          "original_file_path": "macros/materializations/snapshots/helpers.sql",
+          "unique_id": "macro.dbt.build_snapshot_table",
+          "macro_sql": "{% macro build_snapshot_table(strategy, sql) -%}\n  {{ adapter.dispatch('build_snapshot_table', 'dbt')(strategy, sql) }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.default__build_snapshot_table"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.039165
+        },
+        "macro.dbt.default__build_snapshot_table": {
+          "name": "default__build_snapshot_table",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/materializations/snapshots/helpers.sql",
+          "original_file_path": "macros/materializations/snapshots/helpers.sql",
+          "unique_id": "macro.dbt.default__build_snapshot_table",
+          "macro_sql": "{% macro default__build_snapshot_table(strategy, sql) %}\n\n    select *,\n        {{ strategy.scd_id }} as dbt_scd_id,\n        {{ strategy.updated_at }} as dbt_updated_at,\n        {{ strategy.updated_at }} as dbt_valid_from,\n        nullif({{ strategy.updated_at }}, {{ strategy.updated_at }}) as dbt_valid_to\n    from (\n        {{ sql }}\n    ) sbq\n\n{% endmacro %}",
+          "depends_on": {
+            "macros": []
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.039469
+        },
+        "macro.dbt.build_snapshot_staging_table": {
+          "name": "build_snapshot_staging_table",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/materializations/snapshots/helpers.sql",
+          "original_file_path": "macros/materializations/snapshots/helpers.sql",
+          "unique_id": "macro.dbt.build_snapshot_staging_table",
+          "macro_sql": "{% macro build_snapshot_staging_table(strategy, sql, target_relation) %}\n    {% set temp_relation = make_temp_relation(target_relation) %}\n\n    {% set select = snapshot_staging_table(strategy, sql, target_relation) %}\n\n    {% call statement('build_snapshot_staging_relation') %}\n        {{ create_table_as(True, temp_relation, select) }}\n    {% endcall %}\n\n    {% do return(temp_relation) %}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.make_temp_relation",
+              "macro.dbt.snapshot_staging_table",
+              "macro.dbt.statement",
+              "macro.dbt.create_table_as"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.0399292
+        },
+        "macro.dbt.materialization_snapshot_default": {
+          "name": "materialization_snapshot_default",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/materializations/snapshots/snapshot.sql",
+          "original_file_path": "macros/materializations/snapshots/snapshot.sql",
+          "unique_id": "macro.dbt.materialization_snapshot_default",
+          "macro_sql": "{% materialization snapshot, default %}\n  {%- set config = model['config'] -%}\n\n  {%- set target_table = model.get('alias', model.get('name')) -%}\n\n  {%- set strategy_name = config.get('strategy') -%}\n  {%- set unique_key = config.get('unique_key') %}\n  -- grab current tables grants config for comparision later on\n  {%- set grant_config = config.get('grants') -%}\n\n  {% set target_relation_exists, target_relation = get_or_create_relation(\n          database=model.database,\n          schema=model.schema,\n          identifier=target_table,\n          type='table') -%}\n\n  {%- if not target_relation.is_table -%}\n    {% do exceptions.relation_wrong_type(target_relation, 'table') %}\n  {%- endif -%}\n\n\n  {{ run_hooks(pre_hooks, inside_transaction=False) }}\n\n  {{ run_hooks(pre_hooks, inside_transaction=True) }}\n\n  {% set strategy_macro = strategy_dispatch(strategy_name) %}\n  {% set strategy = strategy_macro(model, \"snapshotted_data\", \"source_data\", config, target_relation_exists) %}\n\n  {% if not target_relation_exists %}\n\n      {% set build_sql = build_snapshot_table(strategy, model['compiled_code']) %}\n      {% set final_sql = create_table_as(False, target_relation, build_sql) %}\n\n  {% else %}\n\n      {{ adapter.valid_snapshot_target(target_relation) }}\n\n      {% set staging_table = build_snapshot_staging_table(strategy, sql, target_relation) %}\n\n      -- this may no-op if the database does not require column expansion\n      {% do adapter.expand_target_column_types(from_relation=staging_table,\n                                               to_relation=target_relation) %}\n\n      {% set missing_columns = adapter.get_missing_columns(staging_table, target_relation)\n                                   | rejectattr('name', 'equalto', 'dbt_change_type')\n                                   | rejectattr('name', 'equalto', 'DBT_CHANGE_TYPE')\n                                   | rejectattr('name', 'equalto', 'dbt_unique_key')\n                                   | rejectattr('name', 'equalto', 'DBT_UNIQUE_KEY')\n                                   | list %}\n\n      {% do create_columns(target_relation, missing_columns) %}\n\n      {% set source_columns = adapter.get_columns_in_relation(staging_table)\n                                   | rejectattr('name', 'equalto', 'dbt_change_type')\n                                   | rejectattr('name', 'equalto', 'DBT_CHANGE_TYPE')\n                                   | rejectattr('name', 'equalto', 'dbt_unique_key')\n                                   | rejectattr('name', 'equalto', 'DBT_UNIQUE_KEY')\n                                   | list %}\n\n      {% set quoted_source_columns = [] %}\n      {% for column in source_columns %}\n        {% do quoted_source_columns.append(adapter.quote(column.name)) %}\n      {% endfor %}\n\n      {% set final_sql = snapshot_merge_sql(\n            target = target_relation,\n            source = staging_table,\n            insert_cols = quoted_source_columns\n         )\n      %}\n\n  {% endif %}\n\n  {% call statement('main') %}\n      {{ final_sql }}\n  {% endcall %}\n\n  {% set should_revoke = should_revoke(target_relation_exists, full_refresh_mode=False) %}\n  {% do apply_grants(target_relation, grant_config, should_revoke=should_revoke) %}\n\n  {% do persist_docs(target_relation, model) %}\n\n  {% if not target_relation_exists %}\n    {% do create_indexes(target_relation) %}\n  {% endif %}\n\n  {{ run_hooks(post_hooks, inside_transaction=True) }}\n\n  {{ adapter.commit() }}\n\n  {% if staging_table is defined %}\n      {% do post_snapshot(staging_table) %}\n  {% endif %}\n\n  {{ run_hooks(post_hooks, inside_transaction=False) }}\n\n  {{ return({'relations': [target_relation]}) }}\n\n{% endmaterialization %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.get_or_create_relation",
+              "macro.dbt.run_hooks",
+              "macro.dbt.strategy_dispatch",
+              "macro.dbt.build_snapshot_table",
+              "macro.dbt.create_table_as",
+              "macro.dbt.build_snapshot_staging_table",
+              "macro.dbt.create_columns",
+              "macro.dbt.snapshot_merge_sql",
+              "macro.dbt.statement",
+              "macro.dbt.should_revoke",
+              "macro.dbt.apply_grants",
+              "macro.dbt.persist_docs",
+              "macro.dbt.create_indexes",
+              "macro.dbt.post_snapshot"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.0464299,
+          "supported_languages": [
+            "sql"
+          ]
+        },
+        "macro.dbt.materialization_test_default": {
+          "name": "materialization_test_default",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/materializations/tests/test.sql",
+          "original_file_path": "macros/materializations/tests/test.sql",
+          "unique_id": "macro.dbt.materialization_test_default",
+          "macro_sql": "{%- materialization test, default -%}\n\n  {% set relations = [] %}\n\n  {% if should_store_failures() %}\n\n    {% set identifier = model['alias'] %}\n    {% set old_relation = adapter.get_relation(database=database, schema=schema, identifier=identifier) %}\n    {% set target_relation = api.Relation.create(\n        identifier=identifier, schema=schema, database=database, type='table') -%} %}\n\n    {% if old_relation %}\n        {% do adapter.drop_relation(old_relation) %}\n    {% endif %}\n\n    {% call statement(auto_begin=True) %}\n        {{ create_table_as(False, target_relation, sql) }}\n    {% endcall %}\n\n    {% do relations.append(target_relation) %}\n\n    {% set main_sql %}\n        select *\n        from {{ target_relation }}\n    {% endset %}\n\n    {{ adapter.commit() }}\n\n  {% else %}\n\n      {% set main_sql = sql %}\n\n  {% endif %}\n\n  {% set limit = config.get('limit') %}\n  {% set fail_calc = config.get('fail_calc') %}\n  {% set warn_if = config.get('warn_if') %}\n  {% set error_if = config.get('error_if') %}\n\n  {% call statement('main', fetch_result=True) -%}\n\n    {{ get_test_sql(main_sql, fail_calc, warn_if, error_if, limit)}}\n\n  {%- endcall %}\n\n  {{ return({'relations': relations}) }}\n\n{%- endmaterialization -%}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.should_store_failures",
+              "macro.dbt.statement",
+              "macro.dbt.create_table_as",
+              "macro.dbt.get_test_sql"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.0484521,
+          "supported_languages": [
+            "sql"
+          ]
+        },
+        "macro.dbt.get_test_sql": {
+          "name": "get_test_sql",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/materializations/tests/helpers.sql",
+          "original_file_path": "macros/materializations/tests/helpers.sql",
+          "unique_id": "macro.dbt.get_test_sql",
+          "macro_sql": "{% macro get_test_sql(main_sql, fail_calc, warn_if, error_if, limit) -%}\n  {{ adapter.dispatch('get_test_sql', 'dbt')(main_sql, fail_calc, warn_if, error_if, limit) }}\n{%- endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.default__get_test_sql"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.0489228
+        },
+        "macro.dbt.default__get_test_sql": {
+          "name": "default__get_test_sql",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/materializations/tests/helpers.sql",
+          "original_file_path": "macros/materializations/tests/helpers.sql",
+          "unique_id": "macro.dbt.default__get_test_sql",
+          "macro_sql": "{% macro default__get_test_sql(main_sql, fail_calc, warn_if, error_if, limit) -%}\n    select\n      {{ fail_calc }} as failures,\n      {{ fail_calc }} {{ warn_if }} as should_warn,\n      {{ fail_calc }} {{ error_if }} as should_error\n    from (\n      {{ main_sql }}\n      {{ \"limit \" ~ limit if limit != none }}\n    ) dbt_internal_test\n{%- endmacro %}",
+          "depends_on": {
+            "macros": []
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.049221
+        },
+        "macro.dbt.get_where_subquery": {
+          "name": "get_where_subquery",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/materializations/tests/where_subquery.sql",
+          "original_file_path": "macros/materializations/tests/where_subquery.sql",
+          "unique_id": "macro.dbt.get_where_subquery",
+          "macro_sql": "{% macro get_where_subquery(relation) -%}\n    {% do return(adapter.dispatch('get_where_subquery', 'dbt')(relation)) %}\n{%- endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.default__get_where_subquery"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.049589
+        },
+        "macro.dbt.default__get_where_subquery": {
+          "name": "default__get_where_subquery",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/materializations/tests/where_subquery.sql",
+          "original_file_path": "macros/materializations/tests/where_subquery.sql",
+          "unique_id": "macro.dbt.default__get_where_subquery",
+          "macro_sql": "{% macro default__get_where_subquery(relation) -%}\n    {% set where = config.get('where', '') %}\n    {% if where %}\n        {%- set filtered -%}\n            (select * from {{ relation }} where {{ where }}) dbt_subquery\n        {%- endset -%}\n        {% do return(filtered) %}\n    {%- else -%}\n        {% do return(relation) %}\n    {%- endif -%}\n{%- endmacro %}",
+          "depends_on": {
+            "macros": []
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.049956
+        },
+        "macro.dbt.get_quoted_csv": {
+          "name": "get_quoted_csv",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/materializations/models/incremental/column_helpers.sql",
+          "original_file_path": "macros/materializations/models/incremental/column_helpers.sql",
+          "unique_id": "macro.dbt.get_quoted_csv",
+          "macro_sql": "{% macro get_quoted_csv(column_names) %}\n\n    {% set quoted = [] %}\n    {% for col in column_names -%}\n        {%- do quoted.append(adapter.quote(col)) -%}\n    {%- endfor %}\n\n    {%- set dest_cols_csv = quoted | join(', ') -%}\n    {{ return(dest_cols_csv) }}\n\n{% endmacro %}",
+          "depends_on": {
+            "macros": []
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.051552
+        },
+        "macro.dbt.diff_columns": {
+          "name": "diff_columns",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/materializations/models/incremental/column_helpers.sql",
+          "original_file_path": "macros/materializations/models/incremental/column_helpers.sql",
+          "unique_id": "macro.dbt.diff_columns",
+          "macro_sql": "{% macro diff_columns(source_columns, target_columns) %}\n\n  {% set result = [] %}\n  {% set source_names = source_columns | map(attribute = 'column') | list %}\n  {% set target_names = target_columns | map(attribute = 'column') | list %}\n\n   {# --check whether the name attribute exists in the target - this does not perform a data type check #}\n   {% for sc in source_columns %}\n     {% if sc.name not in target_names %}\n        {{ result.append(sc) }}\n     {% endif %}\n   {% endfor %}\n\n  {{ return(result) }}\n\n{% endmacro %}",
+          "depends_on": {
+            "macros": []
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.052093
+        },
+        "macro.dbt.diff_column_data_types": {
+          "name": "diff_column_data_types",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/materializations/models/incremental/column_helpers.sql",
+          "original_file_path": "macros/materializations/models/incremental/column_helpers.sql",
+          "unique_id": "macro.dbt.diff_column_data_types",
+          "macro_sql": "{% macro diff_column_data_types(source_columns, target_columns) %}\n\n  {% set result = [] %}\n  {% for sc in source_columns %}\n    {% set tc = target_columns | selectattr(\"name\", \"equalto\", sc.name) | list | first %}\n    {% if tc %}\n      {% if sc.data_type != tc.data_type and not sc.can_expand_to(other_column=tc) %}\n        {{ result.append( { 'column_name': tc.name, 'new_type': sc.data_type } ) }}\n      {% endif %}\n    {% endif %}\n  {% endfor %}\n\n  {{ return(result) }}\n\n{% endmacro %}",
+          "depends_on": {
+            "macros": []
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.052725
+        },
+        "macro.dbt.get_merge_update_columns": {
+          "name": "get_merge_update_columns",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/materializations/models/incremental/column_helpers.sql",
+          "original_file_path": "macros/materializations/models/incremental/column_helpers.sql",
+          "unique_id": "macro.dbt.get_merge_update_columns",
+          "macro_sql": "{% macro get_merge_update_columns(merge_update_columns, merge_exclude_columns, dest_columns) %}\n  {{ return(adapter.dispatch('get_merge_update_columns', 'dbt')(merge_update_columns, merge_exclude_columns, dest_columns)) }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.default__get_merge_update_columns"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.052951
+        },
+        "macro.dbt.default__get_merge_update_columns": {
+          "name": "default__get_merge_update_columns",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/materializations/models/incremental/column_helpers.sql",
+          "original_file_path": "macros/materializations/models/incremental/column_helpers.sql",
+          "unique_id": "macro.dbt.default__get_merge_update_columns",
+          "macro_sql": "{% macro default__get_merge_update_columns(merge_update_columns, merge_exclude_columns, dest_columns) %}\n  {%- set default_cols = dest_columns | map(attribute=\"quoted\") | list -%}\n\n  {%- if merge_update_columns and merge_exclude_columns -%}\n    {{ exceptions.raise_compiler_error(\n        'Model cannot specify merge_update_columns and merge_exclude_columns. Please update model to use only one config'\n    )}}\n  {%- elif merge_update_columns -%}\n    {%- set update_columns = merge_update_columns -%}\n  {%- elif merge_exclude_columns -%}\n    {%- set update_columns = [] -%}\n    {%- for column in dest_columns -%}\n      {% if column.column | lower not in merge_exclude_columns | map(\"lower\") | list %}\n        {%- do update_columns.append(column.quoted) -%}\n      {% endif %}\n    {%- endfor -%}\n  {%- else -%}\n    {%- set update_columns = default_cols -%}\n  {%- endif -%}\n\n  {{ return(update_columns) }}\n\n{% endmacro %}",
+          "depends_on": {
+            "macros": []
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.0536299
+        },
+        "macro.dbt.get_merge_sql": {
+          "name": "get_merge_sql",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/materializations/models/incremental/merge.sql",
+          "original_file_path": "macros/materializations/models/incremental/merge.sql",
+          "unique_id": "macro.dbt.get_merge_sql",
+          "macro_sql": "{% macro get_merge_sql(target, source, unique_key, dest_columns, incremental_predicates=none) -%}\n   -- back compat for old kwarg name\n  {% set incremental_predicates = kwargs.get('predicates', incremental_predicates) %}\n  {{ adapter.dispatch('get_merge_sql', 'dbt')(target, source, unique_key, dest_columns, incremental_predicates) }}\n{%- endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.default__get_merge_sql"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.060451
+        },
+        "macro.dbt.default__get_merge_sql": {
+          "name": "default__get_merge_sql",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/materializations/models/incremental/merge.sql",
+          "original_file_path": "macros/materializations/models/incremental/merge.sql",
+          "unique_id": "macro.dbt.default__get_merge_sql",
+          "macro_sql": "{% macro default__get_merge_sql(target, source, unique_key, dest_columns, incremental_predicates=none) -%}\n    {%- set predicates = [] if incremental_predicates is none else [] + incremental_predicates -%}\n    {%- set dest_cols_csv = get_quoted_csv(dest_columns | map(attribute=\"name\")) -%}\n    {%- set merge_update_columns = config.get('merge_update_columns') -%}\n    {%- set merge_exclude_columns = config.get('merge_exclude_columns') -%}\n    {%- set update_columns = get_merge_update_columns(merge_update_columns, merge_exclude_columns, dest_columns) -%}\n    {%- set sql_header = config.get('sql_header', none) -%}\n\n    {% if unique_key %}\n        {% if unique_key is sequence and unique_key is not mapping and unique_key is not string %}\n            {% for key in unique_key %}\n                {% set this_key_match %}\n                    DBT_INTERNAL_SOURCE.{{ key }} = DBT_INTERNAL_DEST.{{ key }}\n                {% endset %}\n                {% do predicates.append(this_key_match) %}\n            {% endfor %}\n        {% else %}\n            {% set unique_key_match %}\n                DBT_INTERNAL_SOURCE.{{ unique_key }} = DBT_INTERNAL_DEST.{{ unique_key }}\n            {% endset %}\n            {% do predicates.append(unique_key_match) %}\n        {% endif %}\n    {% else %}\n        {% do predicates.append('FALSE') %}\n    {% endif %}\n\n    {{ sql_header if sql_header is not none }}\n\n    merge into {{ target }} as DBT_INTERNAL_DEST\n        using {{ source }} as DBT_INTERNAL_SOURCE\n        on {{\"(\" ~ predicates | join(\") and (\") ~ \")\"}}\n\n    {% if unique_key %}\n    when matched then update set\n        {% for column_name in update_columns -%}\n            {{ column_name }} = DBT_INTERNAL_SOURCE.{{ column_name }}\n            {%- if not loop.last %}, {%- endif %}\n        {%- endfor %}\n    {% endif %}\n\n    when not matched then insert\n        ({{ dest_cols_csv }})\n    values\n        ({{ dest_cols_csv }})\n\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.get_quoted_csv",
+              "macro.dbt.get_merge_update_columns"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.06204
+        },
+        "macro.dbt.get_delete_insert_merge_sql": {
+          "name": "get_delete_insert_merge_sql",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/materializations/models/incremental/merge.sql",
+          "original_file_path": "macros/materializations/models/incremental/merge.sql",
+          "unique_id": "macro.dbt.get_delete_insert_merge_sql",
+          "macro_sql": "{% macro get_delete_insert_merge_sql(target, source, unique_key, dest_columns, incremental_predicates) -%}\n  {{ adapter.dispatch('get_delete_insert_merge_sql', 'dbt')(target, source, unique_key, dest_columns, incremental_predicates) }}\n{%- endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.default__get_delete_insert_merge_sql"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.06229
+        },
+        "macro.dbt.default__get_delete_insert_merge_sql": {
+          "name": "default__get_delete_insert_merge_sql",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/materializations/models/incremental/merge.sql",
+          "original_file_path": "macros/materializations/models/incremental/merge.sql",
+          "unique_id": "macro.dbt.default__get_delete_insert_merge_sql",
+          "macro_sql": "{% macro default__get_delete_insert_merge_sql(target, source, unique_key, dest_columns, incremental_predicates) -%}\n\n    {%- set dest_cols_csv = get_quoted_csv(dest_columns | map(attribute=\"name\")) -%}\n\n    {% if unique_key %}\n        {% if unique_key is sequence and unique_key is not string %}\n            delete from {{target }}\n            using {{ source }}\n            where (\n                {% for key in unique_key %}\n                    {{ source }}.{{ key }} = {{ target }}.{{ key }}\n                    {{ \"and \" if not loop.last}}\n                {% endfor %}\n                {% if incremental_predicates %}\n                    {% for predicate in incremental_predicates %}\n                        and {{ predicate }}\n                    {% endfor %}\n                {% endif %}\n            );\n        {% else %}\n            delete from {{ target }}\n            where (\n                {{ unique_key }}) in (\n                select ({{ unique_key }})\n                from {{ source }}\n            )\n            {%- if incremental_predicates %}\n                {% for predicate in incremental_predicates %}\n                    and {{ predicate }}\n                {% endfor %}\n            {%- endif -%};\n\n        {% endif %}\n    {% endif %}\n\n    insert into {{ target }} ({{ dest_cols_csv }})\n    (\n        select {{ dest_cols_csv }}\n        from {{ source }}\n    )\n\n{%- endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.get_quoted_csv"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.063276
+        },
+        "macro.dbt.get_insert_overwrite_merge_sql": {
+          "name": "get_insert_overwrite_merge_sql",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/materializations/models/incremental/merge.sql",
+          "original_file_path": "macros/materializations/models/incremental/merge.sql",
+          "unique_id": "macro.dbt.get_insert_overwrite_merge_sql",
+          "macro_sql": "{% macro get_insert_overwrite_merge_sql(target, source, dest_columns, predicates, include_sql_header=false) -%}\n  {{ adapter.dispatch('get_insert_overwrite_merge_sql', 'dbt')(target, source, dest_columns, predicates, include_sql_header) }}\n{%- endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.default__get_insert_overwrite_merge_sql"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.063533
+        },
+        "macro.dbt.default__get_insert_overwrite_merge_sql": {
+          "name": "default__get_insert_overwrite_merge_sql",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/materializations/models/incremental/merge.sql",
+          "original_file_path": "macros/materializations/models/incremental/merge.sql",
+          "unique_id": "macro.dbt.default__get_insert_overwrite_merge_sql",
+          "macro_sql": "{% macro default__get_insert_overwrite_merge_sql(target, source, dest_columns, predicates, include_sql_header) -%}\n    {#-- The only time include_sql_header is True: --#}\n    {#-- BigQuery + insert_overwrite strategy + \"static\" partitions config --#}\n    {#-- We should consider including the sql header at the materialization level instead --#}\n\n    {%- set predicates = [] if predicates is none else [] + predicates -%}\n    {%- set dest_cols_csv = get_quoted_csv(dest_columns | map(attribute=\"name\")) -%}\n    {%- set sql_header = config.get('sql_header', none) -%}\n\n    {{ sql_header if sql_header is not none and include_sql_header }}\n\n    merge into {{ target }} as DBT_INTERNAL_DEST\n        using {{ source }} as DBT_INTERNAL_SOURCE\n        on FALSE\n\n    when not matched by source\n        {% if predicates %} and {{ predicates | join(' and ') }} {% endif %}\n        then delete\n\n    when not matched then insert\n        ({{ dest_cols_csv }})\n    values\n        ({{ dest_cols_csv }})\n\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.get_quoted_csv"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.064149
+        },
+        "macro.dbt.is_incremental": {
+          "name": "is_incremental",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/materializations/models/incremental/is_incremental.sql",
+          "original_file_path": "macros/materializations/models/incremental/is_incremental.sql",
+          "unique_id": "macro.dbt.is_incremental",
+          "macro_sql": "{% macro is_incremental() %}\n    {#-- do not run introspective queries in parsing #}\n    {% if not execute %}\n        {{ return(False) }}\n    {% else %}\n        {% set relation = adapter.get_relation(this.database, this.schema, this.table) %}\n        {{ return(relation is not none\n                  and relation.type == 'table'\n                  and model.config.materialized == 'incremental'\n                  and not should_full_refresh()) }}\n    {% endif %}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.should_full_refresh"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.064762
+        },
+        "macro.dbt.get_incremental_append_sql": {
+          "name": "get_incremental_append_sql",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/materializations/models/incremental/strategies.sql",
+          "original_file_path": "macros/materializations/models/incremental/strategies.sql",
+          "unique_id": "macro.dbt.get_incremental_append_sql",
+          "macro_sql": "{% macro get_incremental_append_sql(arg_dict) %}\n\n  {{ return(adapter.dispatch('get_incremental_append_sql', 'dbt')(arg_dict)) }}\n\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt_duckdb.duckdb__get_incremental_append_sql"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.065634
+        },
+        "macro.dbt.default__get_incremental_append_sql": {
+          "name": "default__get_incremental_append_sql",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/materializations/models/incremental/strategies.sql",
+          "original_file_path": "macros/materializations/models/incremental/strategies.sql",
+          "unique_id": "macro.dbt.default__get_incremental_append_sql",
+          "macro_sql": "{% macro default__get_incremental_append_sql(arg_dict) %}\n\n  {% do return(get_insert_into_sql(arg_dict[\"target_relation\"], arg_dict[\"temp_relation\"], arg_dict[\"dest_columns\"])) %}\n\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.get_insert_into_sql"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.065859
+        },
+        "macro.dbt.get_incremental_delete_insert_sql": {
+          "name": "get_incremental_delete_insert_sql",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/materializations/models/incremental/strategies.sql",
+          "original_file_path": "macros/materializations/models/incremental/strategies.sql",
+          "unique_id": "macro.dbt.get_incremental_delete_insert_sql",
+          "macro_sql": "{% macro get_incremental_delete_insert_sql(arg_dict) %}\n\n  {{ return(adapter.dispatch('get_incremental_delete_insert_sql', 'dbt')(arg_dict)) }}\n\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt_duckdb.duckdb__get_incremental_delete_insert_sql"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.066036
+        },
+        "macro.dbt.default__get_incremental_delete_insert_sql": {
+          "name": "default__get_incremental_delete_insert_sql",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/materializations/models/incremental/strategies.sql",
+          "original_file_path": "macros/materializations/models/incremental/strategies.sql",
+          "unique_id": "macro.dbt.default__get_incremental_delete_insert_sql",
+          "macro_sql": "{% macro default__get_incremental_delete_insert_sql(arg_dict) %}\n\n  {% do return(get_delete_insert_merge_sql(arg_dict[\"target_relation\"], arg_dict[\"temp_relation\"], arg_dict[\"unique_key\"], arg_dict[\"dest_columns\"], arg_dict[\"incremental_predicates\"])) %}\n\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.get_delete_insert_merge_sql"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.066354
+        },
+        "macro.dbt.get_incremental_merge_sql": {
+          "name": "get_incremental_merge_sql",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/materializations/models/incremental/strategies.sql",
+          "original_file_path": "macros/materializations/models/incremental/strategies.sql",
+          "unique_id": "macro.dbt.get_incremental_merge_sql",
+          "macro_sql": "{% macro get_incremental_merge_sql(arg_dict) %}\n\n  {{ return(adapter.dispatch('get_incremental_merge_sql', 'dbt')(arg_dict)) }}\n\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.default__get_incremental_merge_sql"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.066553
+        },
+        "macro.dbt.default__get_incremental_merge_sql": {
+          "name": "default__get_incremental_merge_sql",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/materializations/models/incremental/strategies.sql",
+          "original_file_path": "macros/materializations/models/incremental/strategies.sql",
+          "unique_id": "macro.dbt.default__get_incremental_merge_sql",
+          "macro_sql": "{% macro default__get_incremental_merge_sql(arg_dict) %}\n\n  {% do return(get_merge_sql(arg_dict[\"target_relation\"], arg_dict[\"temp_relation\"], arg_dict[\"unique_key\"], arg_dict[\"dest_columns\"], arg_dict[\"incremental_predicates\"])) %}\n\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.get_merge_sql"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.06685
+        },
+        "macro.dbt.get_incremental_insert_overwrite_sql": {
+          "name": "get_incremental_insert_overwrite_sql",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/materializations/models/incremental/strategies.sql",
+          "original_file_path": "macros/materializations/models/incremental/strategies.sql",
+          "unique_id": "macro.dbt.get_incremental_insert_overwrite_sql",
+          "macro_sql": "{% macro get_incremental_insert_overwrite_sql(arg_dict) %}\n\n  {{ return(adapter.dispatch('get_incremental_insert_overwrite_sql', 'dbt')(arg_dict)) }}\n\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.default__get_incremental_insert_overwrite_sql"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.067029
+        },
+        "macro.dbt.default__get_incremental_insert_overwrite_sql": {
+          "name": "default__get_incremental_insert_overwrite_sql",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/materializations/models/incremental/strategies.sql",
+          "original_file_path": "macros/materializations/models/incremental/strategies.sql",
+          "unique_id": "macro.dbt.default__get_incremental_insert_overwrite_sql",
+          "macro_sql": "{% macro default__get_incremental_insert_overwrite_sql(arg_dict) %}\n\n  {% do return(get_insert_overwrite_merge_sql(arg_dict[\"target_relation\"], arg_dict[\"temp_relation\"], arg_dict[\"dest_columns\"], arg_dict[\"incremental_predicates\"])) %}\n\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.get_insert_overwrite_merge_sql"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.0672798
+        },
+        "macro.dbt.get_incremental_default_sql": {
+          "name": "get_incremental_default_sql",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/materializations/models/incremental/strategies.sql",
+          "original_file_path": "macros/materializations/models/incremental/strategies.sql",
+          "unique_id": "macro.dbt.get_incremental_default_sql",
+          "macro_sql": "{% macro get_incremental_default_sql(arg_dict) %}\n\n  {{ return(adapter.dispatch('get_incremental_default_sql', 'dbt')(arg_dict)) }}\n\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt_duckdb.duckdb__get_incremental_default_sql"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.067462
+        },
+        "macro.dbt.default__get_incremental_default_sql": {
+          "name": "default__get_incremental_default_sql",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/materializations/models/incremental/strategies.sql",
+          "original_file_path": "macros/materializations/models/incremental/strategies.sql",
+          "unique_id": "macro.dbt.default__get_incremental_default_sql",
+          "macro_sql": "{% macro default__get_incremental_default_sql(arg_dict) %}\n\n  {% do return(get_incremental_append_sql(arg_dict)) %}\n\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.get_incremental_append_sql"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.067604
+        },
+        "macro.dbt.get_insert_into_sql": {
+          "name": "get_insert_into_sql",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/materializations/models/incremental/strategies.sql",
+          "original_file_path": "macros/materializations/models/incremental/strategies.sql",
+          "unique_id": "macro.dbt.get_insert_into_sql",
+          "macro_sql": "{% macro get_insert_into_sql(target_relation, temp_relation, dest_columns) %}\n\n    {%- set dest_cols_csv = get_quoted_csv(dest_columns | map(attribute=\"name\")) -%}\n\n    insert into {{ target_relation }} ({{ dest_cols_csv }})\n    (\n        select {{ dest_cols_csv }}\n        from {{ temp_relation }}\n    )\n\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.get_quoted_csv"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.067873
+        },
+        "macro.dbt.materialization_incremental_default": {
+          "name": "materialization_incremental_default",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/materializations/models/incremental/incremental.sql",
+          "original_file_path": "macros/materializations/models/incremental/incremental.sql",
+          "unique_id": "macro.dbt.materialization_incremental_default",
+          "macro_sql": "{% materialization incremental, default -%}\n\n  -- relations\n  {%- set existing_relation = load_cached_relation(this) -%}\n  {%- set target_relation = this.incorporate(type='table') -%}\n  {%- set temp_relation = make_temp_relation(target_relation)-%}\n  {%- set intermediate_relation = make_intermediate_relation(target_relation)-%}\n  {%- set backup_relation_type = 'table' if existing_relation is none else existing_relation.type -%}\n  {%- set backup_relation = make_backup_relation(target_relation, backup_relation_type) -%}\n\n  -- configs\n  {%- set unique_key = config.get('unique_key') -%}\n  {%- set full_refresh_mode = (should_full_refresh()  or existing_relation.is_view) -%}\n  {%- set on_schema_change = incremental_validate_on_schema_change(config.get('on_schema_change'), default='ignore') -%}\n\n  -- the temp_ and backup_ relations should not already exist in the database; get_relation\n  -- will return None in that case. Otherwise, we get a relation that we can drop\n  -- later, before we try to use this name for the current operation. This has to happen before\n  -- BEGIN, in a separate transaction\n  {%- set preexisting_intermediate_relation = load_cached_relation(intermediate_relation)-%}\n  {%- set preexisting_backup_relation = load_cached_relation(backup_relation) -%}\n   -- grab current tables grants config for comparision later on\n  {% set grant_config = config.get('grants') %}\n  {{ drop_relation_if_exists(preexisting_intermediate_relation) }}\n  {{ drop_relation_if_exists(preexisting_backup_relation) }}\n\n  {{ run_hooks(pre_hooks, inside_transaction=False) }}\n\n  -- `BEGIN` happens here:\n  {{ run_hooks(pre_hooks, inside_transaction=True) }}\n\n  {% set to_drop = [] %}\n\n  {% if existing_relation is none %}\n      {% set build_sql = get_create_table_as_sql(False, target_relation, sql) %}\n  {% elif full_refresh_mode %}\n      {% set build_sql = get_create_table_as_sql(False, intermediate_relation, sql) %}\n      {% set need_swap = true %}\n  {% else %}\n    {% do run_query(get_create_table_as_sql(True, temp_relation, sql)) %}\n    {% do adapter.expand_target_column_types(\n             from_relation=temp_relation,\n             to_relation=target_relation) %}\n    {#-- Process schema changes. Returns dict of changes if successful. Use source columns for upserting/merging --#}\n    {% set dest_columns = process_schema_changes(on_schema_change, temp_relation, existing_relation) %}\n    {% if not dest_columns %}\n      {% set dest_columns = adapter.get_columns_in_relation(existing_relation) %}\n    {% endif %}\n\n    {#-- Get the incremental_strategy, the macro to use for the strategy, and build the sql --#}\n    {% set incremental_strategy = config.get('incremental_strategy') or 'default' %}\n    {% set incremental_predicates = config.get('predicates', none) or config.get('incremental_predicates', none) %}\n    {% set strategy_sql_macro_func = adapter.get_incremental_strategy_macro(context, incremental_strategy) %}\n    {% set strategy_arg_dict = ({'target_relation': target_relation, 'temp_relation': temp_relation, 'unique_key': unique_key, 'dest_columns': dest_columns, 'incremental_predicates': incremental_predicates }) %}\n    {% set build_sql = strategy_sql_macro_func(strategy_arg_dict) %}\n\n  {% endif %}\n\n  {% call statement(\"main\") %}\n      {{ build_sql }}\n  {% endcall %}\n\n  {% if need_swap %}\n      {% do adapter.rename_relation(target_relation, backup_relation) %}\n      {% do adapter.rename_relation(intermediate_relation, target_relation) %}\n      {% do to_drop.append(backup_relation) %}\n  {% endif %}\n\n  {% set should_revoke = should_revoke(existing_relation, full_refresh_mode) %}\n  {% do apply_grants(target_relation, grant_config, should_revoke=should_revoke) %}\n\n  {% do persist_docs(target_relation, model) %}\n\n  {% if existing_relation is none or existing_relation.is_view or should_full_refresh() %}\n    {% do create_indexes(target_relation) %}\n  {% endif %}\n\n  {{ run_hooks(post_hooks, inside_transaction=True) }}\n\n  -- `COMMIT` happens here\n  {% do adapter.commit() %}\n\n  {% for rel in to_drop %}\n      {% do adapter.drop_relation(rel) %}\n  {% endfor %}\n\n  {{ run_hooks(post_hooks, inside_transaction=False) }}\n\n  {{ return({'relations': [target_relation]}) }}\n\n{%- endmaterialization %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.load_cached_relation",
+              "macro.dbt.make_temp_relation",
+              "macro.dbt.make_intermediate_relation",
+              "macro.dbt.make_backup_relation",
+              "macro.dbt.should_full_refresh",
+              "macro.dbt.incremental_validate_on_schema_change",
+              "macro.dbt.drop_relation_if_exists",
+              "macro.dbt.run_hooks",
+              "macro.dbt.get_create_table_as_sql",
+              "macro.dbt.run_query",
+              "macro.dbt.process_schema_changes",
+              "macro.dbt.statement",
+              "macro.dbt.should_revoke",
+              "macro.dbt.apply_grants",
+              "macro.dbt.persist_docs",
+              "macro.dbt.create_indexes"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.0728068,
+          "supported_languages": [
+            "sql"
+          ]
+        },
+        "macro.dbt.incremental_validate_on_schema_change": {
+          "name": "incremental_validate_on_schema_change",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/materializations/models/incremental/on_schema_change.sql",
+          "original_file_path": "macros/materializations/models/incremental/on_schema_change.sql",
+          "unique_id": "macro.dbt.incremental_validate_on_schema_change",
+          "macro_sql": "{% macro incremental_validate_on_schema_change(on_schema_change, default='ignore') %}\n\n   {% if on_schema_change not in ['sync_all_columns', 'append_new_columns', 'fail', 'ignore'] %}\n\n     {% set log_message = 'Invalid value for on_schema_change (%s) specified. Setting default value of %s.' % (on_schema_change, default) %}\n     {% do log(log_message) %}\n\n     {{ return(default) }}\n\n   {% else %}\n\n     {{ return(on_schema_change) }}\n\n   {% endif %}\n\n{% endmacro %}",
+          "depends_on": {
+            "macros": []
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.078635
+        },
+        "macro.dbt.check_for_schema_changes": {
+          "name": "check_for_schema_changes",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/materializations/models/incremental/on_schema_change.sql",
+          "original_file_path": "macros/materializations/models/incremental/on_schema_change.sql",
+          "unique_id": "macro.dbt.check_for_schema_changes",
+          "macro_sql": "{% macro check_for_schema_changes(source_relation, target_relation) %}\n\n  {% set schema_changed = False %}\n\n  {%- set source_columns = adapter.get_columns_in_relation(source_relation) -%}\n  {%- set target_columns = adapter.get_columns_in_relation(target_relation) -%}\n  {%- set source_not_in_target = diff_columns(source_columns, target_columns) -%}\n  {%- set target_not_in_source = diff_columns(target_columns, source_columns) -%}\n\n  {% set new_target_types = diff_column_data_types(source_columns, target_columns) %}\n\n  {% if source_not_in_target != [] %}\n    {% set schema_changed = True %}\n  {% elif target_not_in_source != [] or new_target_types != [] %}\n    {% set schema_changed = True %}\n  {% elif new_target_types != [] %}\n    {% set schema_changed = True %}\n  {% endif %}\n\n  {% set changes_dict = {\n    'schema_changed': schema_changed,\n    'source_not_in_target': source_not_in_target,\n    'target_not_in_source': target_not_in_source,\n    'source_columns': source_columns,\n    'target_columns': target_columns,\n    'new_target_types': new_target_types\n  } %}\n\n  {% set msg %}\n    In {{ target_relation }}:\n        Schema changed: {{ schema_changed }}\n        Source columns not in target: {{ source_not_in_target }}\n        Target columns not in source: {{ target_not_in_source }}\n        New column types: {{ new_target_types }}\n  {% endset %}\n\n  {% do log(msg) %}\n\n  {{ return(changes_dict) }}\n\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.diff_columns",
+              "macro.dbt.diff_column_data_types"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.079801
+        },
+        "macro.dbt.sync_column_schemas": {
+          "name": "sync_column_schemas",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/materializations/models/incremental/on_schema_change.sql",
+          "original_file_path": "macros/materializations/models/incremental/on_schema_change.sql",
+          "unique_id": "macro.dbt.sync_column_schemas",
+          "macro_sql": "{% macro sync_column_schemas(on_schema_change, target_relation, schema_changes_dict) %}\n\n  {%- set add_to_target_arr = schema_changes_dict['source_not_in_target'] -%}\n\n  {%- if on_schema_change == 'append_new_columns'-%}\n     {%- if add_to_target_arr | length > 0 -%}\n       {%- do alter_relation_add_remove_columns(target_relation, add_to_target_arr, none) -%}\n     {%- endif -%}\n\n  {% elif on_schema_change == 'sync_all_columns' %}\n     {%- set remove_from_target_arr = schema_changes_dict['target_not_in_source'] -%}\n     {%- set new_target_types = schema_changes_dict['new_target_types'] -%}\n\n     {% if add_to_target_arr | length > 0 or remove_from_target_arr | length > 0 %}\n       {%- do alter_relation_add_remove_columns(target_relation, add_to_target_arr, remove_from_target_arr) -%}\n     {% endif %}\n\n     {% if new_target_types != [] %}\n       {% for ntt in new_target_types %}\n         {% set column_name = ntt['column_name'] %}\n         {% set new_type = ntt['new_type'] %}\n         {% do alter_column_type(target_relation, column_name, new_type) %}\n       {% endfor %}\n     {% endif %}\n\n  {% endif %}\n\n  {% set schema_change_message %}\n    In {{ target_relation }}:\n        Schema change approach: {{ on_schema_change }}\n        Columns added: {{ add_to_target_arr }}\n        Columns removed: {{ remove_from_target_arr }}\n        Data types changed: {{ new_target_types }}\n  {% endset %}\n\n  {% do log(schema_change_message) %}\n\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.alter_relation_add_remove_columns",
+              "macro.dbt.alter_column_type"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.080996
+        },
+        "macro.dbt.process_schema_changes": {
+          "name": "process_schema_changes",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/materializations/models/incremental/on_schema_change.sql",
+          "original_file_path": "macros/materializations/models/incremental/on_schema_change.sql",
+          "unique_id": "macro.dbt.process_schema_changes",
+          "macro_sql": "{% macro process_schema_changes(on_schema_change, source_relation, target_relation) %}\n\n    {% if on_schema_change == 'ignore' %}\n\n     {{ return({}) }}\n\n    {% else %}\n\n      {% set schema_changes_dict = check_for_schema_changes(source_relation, target_relation) %}\n\n      {% if schema_changes_dict['schema_changed'] %}\n\n        {% if on_schema_change == 'fail' %}\n\n          {% set fail_msg %}\n              The source and target schemas on this incremental model are out of sync!\n              They can be reconciled in several ways:\n                - set the `on_schema_change` config to either append_new_columns or sync_all_columns, depending on your situation.\n                - Re-run the incremental model with `full_refresh: True` to update the target schema.\n                - update the schema manually and re-run the process.\n\n              Additional troubleshooting context:\n                 Source columns not in target: {{ schema_changes_dict['source_not_in_target'] }}\n                 Target columns not in source: {{ schema_changes_dict['target_not_in_source'] }}\n                 New column types: {{ schema_changes_dict['new_target_types'] }}\n          {% endset %}\n\n          {% do exceptions.raise_compiler_error(fail_msg) %}\n\n        {# -- unless we ignore, run the sync operation per the config #}\n        {% else %}\n\n          {% do sync_column_schemas(on_schema_change, target_relation, schema_changes_dict) %}\n\n        {% endif %}\n\n      {% endif %}\n\n      {{ return(schema_changes_dict['source_columns']) }}\n\n    {% endif %}\n\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.check_for_schema_changes",
+              "macro.dbt.sync_column_schemas"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.081813
+        },
+        "macro.dbt.get_table_columns_and_constraints": {
+          "name": "get_table_columns_and_constraints",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/materializations/models/table/columns_spec_ddl.sql",
+          "original_file_path": "macros/materializations/models/table/columns_spec_ddl.sql",
+          "unique_id": "macro.dbt.get_table_columns_and_constraints",
+          "macro_sql": "{%- macro get_table_columns_and_constraints() -%}\n  {{ adapter.dispatch('get_table_columns_and_constraints', 'dbt')() }}\n{%- endmacro -%}\n\n",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.default__get_table_columns_and_constraints"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.0827699
+        },
+        "macro.dbt.default__get_table_columns_and_constraints": {
+          "name": "default__get_table_columns_and_constraints",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/materializations/models/table/columns_spec_ddl.sql",
+          "original_file_path": "macros/materializations/models/table/columns_spec_ddl.sql",
+          "unique_id": "macro.dbt.default__get_table_columns_and_constraints",
+          "macro_sql": "{% macro default__get_table_columns_and_constraints() -%}\n  {{ return(table_columns_and_constraints()) }}\n{%- endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.table_columns_and_constraints"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.0828831
+        },
+        "macro.dbt.table_columns_and_constraints": {
+          "name": "table_columns_and_constraints",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/materializations/models/table/columns_spec_ddl.sql",
+          "original_file_path": "macros/materializations/models/table/columns_spec_ddl.sql",
+          "unique_id": "macro.dbt.table_columns_and_constraints",
+          "macro_sql": "{% macro table_columns_and_constraints() %}\n  {# loop through user_provided_columns to create DDL with data types and constraints #}\n    {%- set raw_column_constraints = adapter.render_raw_columns_constraints(raw_columns=model['columns']) -%}\n    {%- set raw_model_constraints = adapter.render_raw_model_constraints(raw_constraints=model['constraints']) -%}\n    (\n    {% for c in raw_column_constraints -%}\n      {{ c }}{{ \",\" if not loop.last or raw_model_constraints }}\n    {% endfor %}\n    {% for c in raw_model_constraints -%}\n        {{ c }}{{ \",\" if not loop.last }}\n    {% endfor -%}\n    )\n{% endmacro %}",
+          "depends_on": {
+            "macros": []
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.08338
+        },
+        "macro.dbt.get_assert_columns_equivalent": {
+          "name": "get_assert_columns_equivalent",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/materializations/models/table/columns_spec_ddl.sql",
+          "original_file_path": "macros/materializations/models/table/columns_spec_ddl.sql",
+          "unique_id": "macro.dbt.get_assert_columns_equivalent",
+          "macro_sql": "\n\n{%- macro get_assert_columns_equivalent(sql) -%}\n  {{ adapter.dispatch('get_assert_columns_equivalent', 'dbt')(sql) }}\n{%- endmacro -%}\n\n",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.default__get_assert_columns_equivalent"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.083554
+        },
+        "macro.dbt.default__get_assert_columns_equivalent": {
+          "name": "default__get_assert_columns_equivalent",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/materializations/models/table/columns_spec_ddl.sql",
+          "original_file_path": "macros/materializations/models/table/columns_spec_ddl.sql",
+          "unique_id": "macro.dbt.default__get_assert_columns_equivalent",
+          "macro_sql": "{% macro default__get_assert_columns_equivalent(sql) -%}\n  {{ return(assert_columns_equivalent(sql)) }}\n{%- endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.assert_columns_equivalent"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.083681
+        },
+        "macro.dbt.assert_columns_equivalent": {
+          "name": "assert_columns_equivalent",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/materializations/models/table/columns_spec_ddl.sql",
+          "original_file_path": "macros/materializations/models/table/columns_spec_ddl.sql",
+          "unique_id": "macro.dbt.assert_columns_equivalent",
+          "macro_sql": "{% macro assert_columns_equivalent(sql) %}\n  {#-- Obtain the column schema provided by sql file. #}\n  {%- set sql_file_provided_columns = get_column_schema_from_query(sql) -%}\n  {#--Obtain the column schema provided by the schema file by generating an 'empty schema' query from the model's columns. #}\n  {%- set schema_file_provided_columns = get_column_schema_from_query(get_empty_schema_sql(model['columns'])) -%}\n\n  {#-- create dictionaries with name and formatted data type and strings for exception #}\n  {%- set sql_columns = format_columns(sql_file_provided_columns) -%}\n  {%- set yaml_columns = format_columns(schema_file_provided_columns)  -%}\n\n  {%- if sql_columns|length != yaml_columns|length -%}\n    {%- do exceptions.raise_contract_error(yaml_columns, sql_columns) -%}\n  {%- endif -%}\n\n  {%- for sql_col in sql_columns -%}\n    {%- set yaml_col = [] -%}\n    {%- for this_col in yaml_columns -%}\n      {%- if this_col['name'] == sql_col['name'] -%}\n        {%- do yaml_col.append(this_col) -%}\n        {%- break -%}\n      {%- endif -%}\n    {%- endfor -%}\n    {%- if not yaml_col -%}\n      {#-- Column with name not found in yaml #}\n      {%- do exceptions.raise_contract_error(yaml_columns, sql_columns) -%}\n    {%- endif -%}\n    {%- if sql_col['formatted'] != yaml_col[0]['formatted'] -%}\n      {#-- Column data types don't match #}\n      {%- do exceptions.raise_contract_error(yaml_columns, sql_columns) -%}\n    {%- endif -%}\n  {%- endfor -%}\n\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.get_column_schema_from_query",
+              "macro.dbt.get_empty_schema_sql",
+              "macro.dbt.format_columns"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.084694
+        },
+        "macro.dbt.format_columns": {
+          "name": "format_columns",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/materializations/models/table/columns_spec_ddl.sql",
+          "original_file_path": "macros/materializations/models/table/columns_spec_ddl.sql",
+          "unique_id": "macro.dbt.format_columns",
+          "macro_sql": "{% macro format_columns(columns) %}\n  {% set formatted_columns = [] %}\n  {% for column in columns %}\n    {%- set formatted_column = adapter.dispatch('format_column', 'dbt')(column) -%}\n    {%- do formatted_columns.append(formatted_column) -%}\n  {% endfor %}\n  {{ return(formatted_columns) }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.default__format_column"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.0850592
+        },
+        "macro.dbt.default__format_column": {
+          "name": "default__format_column",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/materializations/models/table/columns_spec_ddl.sql",
+          "original_file_path": "macros/materializations/models/table/columns_spec_ddl.sql",
+          "unique_id": "macro.dbt.default__format_column",
+          "macro_sql": "{% macro default__format_column(column) -%}\n  {% set data_type = column.dtype %}\n  {% set formatted = column.column.lower() ~ \" \" ~ data_type %}\n  {{ return({'name': column.name, 'data_type': data_type, 'formatted': formatted}) }}\n{%- endmacro -%}",
+          "depends_on": {
+            "macros": []
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.085393
+        },
+        "macro.dbt.materialization_table_default": {
+          "name": "materialization_table_default",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/materializations/models/table/table.sql",
+          "original_file_path": "macros/materializations/models/table/table.sql",
+          "unique_id": "macro.dbt.materialization_table_default",
+          "macro_sql": "{% materialization table, default %}\n\n  {%- set existing_relation = load_cached_relation(this) -%}\n  {%- set target_relation = this.incorporate(type='table') %}\n  {%- set intermediate_relation =  make_intermediate_relation(target_relation) -%}\n  -- the intermediate_relation should not already exist in the database; get_relation\n  -- will return None in that case. Otherwise, we get a relation that we can drop\n  -- later, before we try to use this name for the current operation\n  {%- set preexisting_intermediate_relation = load_cached_relation(intermediate_relation) -%}\n  /*\n      See ../view/view.sql for more information about this relation.\n  */\n  {%- set backup_relation_type = 'table' if existing_relation is none else existing_relation.type -%}\n  {%- set backup_relation = make_backup_relation(target_relation, backup_relation_type) -%}\n  -- as above, the backup_relation should not already exist\n  {%- set preexisting_backup_relation = load_cached_relation(backup_relation) -%}\n  -- grab current tables grants config for comparision later on\n  {% set grant_config = config.get('grants') %}\n\n  -- drop the temp relations if they exist already in the database\n  {{ drop_relation_if_exists(preexisting_intermediate_relation) }}\n  {{ drop_relation_if_exists(preexisting_backup_relation) }}\n\n  {{ run_hooks(pre_hooks, inside_transaction=False) }}\n\n  -- `BEGIN` happens here:\n  {{ run_hooks(pre_hooks, inside_transaction=True) }}\n\n  -- build model\n  {% call statement('main') -%}\n    {{ get_create_table_as_sql(False, intermediate_relation, sql) }}\n  {%- endcall %}\n\n  -- cleanup\n  {% if existing_relation is not none %}\n      {{ adapter.rename_relation(existing_relation, backup_relation) }}\n  {% endif %}\n\n  {{ adapter.rename_relation(intermediate_relation, target_relation) }}\n\n  {% do create_indexes(target_relation) %}\n\n  {{ run_hooks(post_hooks, inside_transaction=True) }}\n\n  {% set should_revoke = should_revoke(existing_relation, full_refresh_mode=True) %}\n  {% do apply_grants(target_relation, grant_config, should_revoke=should_revoke) %}\n\n  {% do persist_docs(target_relation, model) %}\n\n  -- `COMMIT` happens here\n  {{ adapter.commit() }}\n\n  -- finally, drop the existing/backup relation after the commit\n  {{ drop_relation_if_exists(backup_relation) }}\n\n  {{ run_hooks(post_hooks, inside_transaction=False) }}\n\n  {{ return({'relations': [target_relation]}) }}\n{% endmaterialization %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.load_cached_relation",
+              "macro.dbt.make_intermediate_relation",
+              "macro.dbt.make_backup_relation",
+              "macro.dbt.drop_relation_if_exists",
+              "macro.dbt.run_hooks",
+              "macro.dbt.statement",
+              "macro.dbt.get_create_table_as_sql",
+              "macro.dbt.create_indexes",
+              "macro.dbt.should_revoke",
+              "macro.dbt.apply_grants",
+              "macro.dbt.persist_docs"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.087969,
+          "supported_languages": [
+            "sql"
+          ]
+        },
+        "macro.dbt.get_create_table_as_sql": {
+          "name": "get_create_table_as_sql",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/materializations/models/table/create_table_as.sql",
+          "original_file_path": "macros/materializations/models/table/create_table_as.sql",
+          "unique_id": "macro.dbt.get_create_table_as_sql",
+          "macro_sql": "{% macro get_create_table_as_sql(temporary, relation, sql) -%}\n  {{ adapter.dispatch('get_create_table_as_sql', 'dbt')(temporary, relation, sql) }}\n{%- endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.default__get_create_table_as_sql"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.0888362
+        },
+        "macro.dbt.default__get_create_table_as_sql": {
+          "name": "default__get_create_table_as_sql",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/materializations/models/table/create_table_as.sql",
+          "original_file_path": "macros/materializations/models/table/create_table_as.sql",
+          "unique_id": "macro.dbt.default__get_create_table_as_sql",
+          "macro_sql": "{% macro default__get_create_table_as_sql(temporary, relation, sql) -%}\n  {{ return(create_table_as(temporary, relation, sql)) }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.create_table_as"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.08901
+        },
+        "macro.dbt.create_table_as": {
+          "name": "create_table_as",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/materializations/models/table/create_table_as.sql",
+          "original_file_path": "macros/materializations/models/table/create_table_as.sql",
+          "unique_id": "macro.dbt.create_table_as",
+          "macro_sql": "{% macro create_table_as(temporary, relation, compiled_code, language='sql') -%}\n  {# backward compatibility for create_table_as that does not support language #}\n  {% if language == \"sql\" %}\n    {{ adapter.dispatch('create_table_as', 'dbt')(temporary, relation, compiled_code)}}\n  {% else %}\n    {{ adapter.dispatch('create_table_as', 'dbt')(temporary, relation, compiled_code, language) }}\n  {% endif %}\n\n{%- endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt_duckdb.duckdb__create_table_as"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.089442
+        },
+        "macro.dbt.default__create_table_as": {
+          "name": "default__create_table_as",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/materializations/models/table/create_table_as.sql",
+          "original_file_path": "macros/materializations/models/table/create_table_as.sql",
+          "unique_id": "macro.dbt.default__create_table_as",
+          "macro_sql": "{% macro default__create_table_as(temporary, relation, sql) -%}\n  {%- set sql_header = config.get('sql_header', none) -%}\n\n  {{ sql_header if sql_header is not none }}\n\n  create {% if temporary: -%}temporary{%- endif %} table\n    {{ relation.include(database=(not temporary), schema=(not temporary)) }}\n  {% set contract_config = config.get('contract') %}\n  {% if contract_config.enforced %}\n    {{ get_assert_columns_equivalent(sql) }}\n    {{ get_table_columns_and_constraints() }}\n    {%- set sql = get_select_subquery(sql) %}\n  {% endif %}\n  as (\n    {{ sql }}\n  );\n{%- endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.get_assert_columns_equivalent",
+              "macro.dbt.get_table_columns_and_constraints",
+              "macro.dbt.get_select_subquery"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.090077
+        },
+        "macro.dbt.get_select_subquery": {
+          "name": "get_select_subquery",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/materializations/models/table/create_table_as.sql",
+          "original_file_path": "macros/materializations/models/table/create_table_as.sql",
+          "unique_id": "macro.dbt.get_select_subquery",
+          "macro_sql": "{% macro get_select_subquery(sql) %}\n  {{ return(adapter.dispatch('get_select_subquery', 'dbt')(sql)) }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.default__get_select_subquery"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.090257
+        },
+        "macro.dbt.default__get_select_subquery": {
+          "name": "default__get_select_subquery",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/materializations/models/table/create_table_as.sql",
+          "original_file_path": "macros/materializations/models/table/create_table_as.sql",
+          "unique_id": "macro.dbt.default__get_select_subquery",
+          "macro_sql": "{% macro default__get_select_subquery(sql) %}\n    select\n    {% for column in model['columns'] %}\n      {{ column }}{{ \", \" if not loop.last }}\n    {% endfor %}\n    from (\n        {{ sql }}\n    ) as model_subq\n{%- endmacro %}",
+          "depends_on": {
+            "macros": []
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.0904949
+        },
+        "macro.dbt.materialization_view_default": {
+          "name": "materialization_view_default",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/materializations/models/view/view.sql",
+          "original_file_path": "macros/materializations/models/view/view.sql",
+          "unique_id": "macro.dbt.materialization_view_default",
+          "macro_sql": "{%- materialization view, default -%}\n\n  {%- set existing_relation = load_cached_relation(this) -%}\n  {%- set target_relation = this.incorporate(type='view') -%}\n  {%- set intermediate_relation =  make_intermediate_relation(target_relation) -%}\n\n  -- the intermediate_relation should not already exist in the database; get_relation\n  -- will return None in that case. Otherwise, we get a relation that we can drop\n  -- later, before we try to use this name for the current operation\n  {%- set preexisting_intermediate_relation = load_cached_relation(intermediate_relation) -%}\n  /*\n     This relation (probably) doesn't exist yet. If it does exist, it's a leftover from\n     a previous run, and we're going to try to drop it immediately. At the end of this\n     materialization, we're going to rename the \"existing_relation\" to this identifier,\n     and then we're going to drop it. In order to make sure we run the correct one of:\n       - drop view ...\n       - drop table ...\n\n     We need to set the type of this relation to be the type of the existing_relation, if it exists,\n     or else \"view\" as a sane default if it does not. Note that if the existing_relation does not\n     exist, then there is nothing to move out of the way and subsequentally drop. In that case,\n     this relation will be effectively unused.\n  */\n  {%- set backup_relation_type = 'view' if existing_relation is none else existing_relation.type -%}\n  {%- set backup_relation = make_backup_relation(target_relation, backup_relation_type) -%}\n  -- as above, the backup_relation should not already exist\n  {%- set preexisting_backup_relation = load_cached_relation(backup_relation) -%}\n  -- grab current tables grants config for comparision later on\n  {% set grant_config = config.get('grants') %}\n\n  {{ run_hooks(pre_hooks, inside_transaction=False) }}\n\n  -- drop the temp relations if they exist already in the database\n  {{ drop_relation_if_exists(preexisting_intermediate_relation) }}\n  {{ drop_relation_if_exists(preexisting_backup_relation) }}\n\n  -- `BEGIN` happens here:\n  {{ run_hooks(pre_hooks, inside_transaction=True) }}\n\n  -- build model\n  {% call statement('main') -%}\n    {{ get_create_view_as_sql(intermediate_relation, sql) }}\n  {%- endcall %}\n\n  -- cleanup\n  -- move the existing view out of the way\n  {% if existing_relation is not none %}\n    {{ adapter.rename_relation(existing_relation, backup_relation) }}\n  {% endif %}\n  {{ adapter.rename_relation(intermediate_relation, target_relation) }}\n\n  {% set should_revoke = should_revoke(existing_relation, full_refresh_mode=True) %}\n  {% do apply_grants(target_relation, grant_config, should_revoke=should_revoke) %}\n\n  {% do persist_docs(target_relation, model) %}\n\n  {{ run_hooks(post_hooks, inside_transaction=True) }}\n\n  {{ adapter.commit() }}\n\n  {{ drop_relation_if_exists(backup_relation) }}\n\n  {{ run_hooks(post_hooks, inside_transaction=False) }}\n\n  {{ return({'relations': [target_relation]}) }}\n\n{%- endmaterialization -%}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.load_cached_relation",
+              "macro.dbt.make_intermediate_relation",
+              "macro.dbt.make_backup_relation",
+              "macro.dbt.run_hooks",
+              "macro.dbt.drop_relation_if_exists",
+              "macro.dbt.statement",
+              "macro.dbt.get_create_view_as_sql",
+              "macro.dbt.should_revoke",
+              "macro.dbt.apply_grants",
+              "macro.dbt.persist_docs"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.093049,
+          "supported_languages": [
+            "sql"
+          ]
+        },
+        "macro.dbt.handle_existing_table": {
+          "name": "handle_existing_table",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/materializations/models/view/helpers.sql",
+          "original_file_path": "macros/materializations/models/view/helpers.sql",
+          "unique_id": "macro.dbt.handle_existing_table",
+          "macro_sql": "{% macro handle_existing_table(full_refresh, old_relation) %}\n    {{ adapter.dispatch('handle_existing_table', 'dbt')(full_refresh, old_relation) }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.default__handle_existing_table"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.093347
+        },
+        "macro.dbt.default__handle_existing_table": {
+          "name": "default__handle_existing_table",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/materializations/models/view/helpers.sql",
+          "original_file_path": "macros/materializations/models/view/helpers.sql",
+          "unique_id": "macro.dbt.default__handle_existing_table",
+          "macro_sql": "{% macro default__handle_existing_table(full_refresh, old_relation) %}\n    {{ log(\"Dropping relation \" ~ old_relation ~ \" because it is of type \" ~ old_relation.type) }}\n    {{ adapter.drop_relation(old_relation) }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": []
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.093556
+        },
+        "macro.dbt.create_or_replace_view": {
+          "name": "create_or_replace_view",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/materializations/models/view/create_or_replace_view.sql",
+          "original_file_path": "macros/materializations/models/view/create_or_replace_view.sql",
+          "unique_id": "macro.dbt.create_or_replace_view",
+          "macro_sql": "{% macro create_or_replace_view() %}\n  {%- set identifier = model['alias'] -%}\n\n  {%- set old_relation = adapter.get_relation(database=database, schema=schema, identifier=identifier) -%}\n  {%- set exists_as_view = (old_relation is not none and old_relation.is_view) -%}\n\n  {%- set target_relation = api.Relation.create(\n      identifier=identifier, schema=schema, database=database,\n      type='view') -%}\n  {% set grant_config = config.get('grants') %}\n\n  {{ run_hooks(pre_hooks) }}\n\n  -- If there's a table with the same name and we weren't told to full refresh,\n  -- that's an error. If we were told to full refresh, drop it. This behavior differs\n  -- for Snowflake and BigQuery, so multiple dispatch is used.\n  {%- if old_relation is not none and old_relation.is_table -%}\n    {{ handle_existing_table(should_full_refresh(), old_relation) }}\n  {%- endif -%}\n\n  -- build model\n  {% call statement('main') -%}\n    {{ get_create_view_as_sql(target_relation, sql) }}\n  {%- endcall %}\n\n  {% set should_revoke = should_revoke(exists_as_view, full_refresh_mode=True) %}\n  {% do apply_grants(target_relation, grant_config, should_revoke=should_revoke) %}\n\n  {{ run_hooks(post_hooks) }}\n\n  {{ return({'relations': [target_relation]}) }}\n\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.run_hooks",
+              "macro.dbt.handle_existing_table",
+              "macro.dbt.should_full_refresh",
+              "macro.dbt.statement",
+              "macro.dbt.get_create_view_as_sql",
+              "macro.dbt.should_revoke",
+              "macro.dbt.apply_grants"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.095
+        },
+        "macro.dbt.get_create_view_as_sql": {
+          "name": "get_create_view_as_sql",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/materializations/models/view/create_view_as.sql",
+          "original_file_path": "macros/materializations/models/view/create_view_as.sql",
+          "unique_id": "macro.dbt.get_create_view_as_sql",
+          "macro_sql": "{% macro get_create_view_as_sql(relation, sql) -%}\n  {{ adapter.dispatch('get_create_view_as_sql', 'dbt')(relation, sql) }}\n{%- endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.default__get_create_view_as_sql"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.095447
+        },
+        "macro.dbt.default__get_create_view_as_sql": {
+          "name": "default__get_create_view_as_sql",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/materializations/models/view/create_view_as.sql",
+          "original_file_path": "macros/materializations/models/view/create_view_as.sql",
+          "unique_id": "macro.dbt.default__get_create_view_as_sql",
+          "macro_sql": "{% macro default__get_create_view_as_sql(relation, sql) -%}\n  {{ return(create_view_as(relation, sql)) }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.create_view_as"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.095602
+        },
+        "macro.dbt.create_view_as": {
+          "name": "create_view_as",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/materializations/models/view/create_view_as.sql",
+          "original_file_path": "macros/materializations/models/view/create_view_as.sql",
+          "unique_id": "macro.dbt.create_view_as",
+          "macro_sql": "{% macro create_view_as(relation, sql) -%}\n  {{ adapter.dispatch('create_view_as', 'dbt')(relation, sql) }}\n{%- endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt_duckdb.duckdb__create_view_as"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.095774
+        },
+        "macro.dbt.default__create_view_as": {
+          "name": "default__create_view_as",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/materializations/models/view/create_view_as.sql",
+          "original_file_path": "macros/materializations/models/view/create_view_as.sql",
+          "unique_id": "macro.dbt.default__create_view_as",
+          "macro_sql": "{% macro default__create_view_as(relation, sql) -%}\n  {%- set sql_header = config.get('sql_header', none) -%}\n\n  {{ sql_header if sql_header is not none }}\n  create view {{ relation }}\n    {% set contract_config = config.get('contract') %}\n    {% if contract_config.enforced %}\n      {{ get_assert_columns_equivalent(sql) }}\n    {%- endif %}\n  as (\n    {{ sql }}\n  );\n{%- endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.get_assert_columns_equivalent"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.0961769
+        },
+        "macro.dbt.materialization_seed_default": {
+          "name": "materialization_seed_default",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/materializations/seeds/seed.sql",
+          "original_file_path": "macros/materializations/seeds/seed.sql",
+          "unique_id": "macro.dbt.materialization_seed_default",
+          "macro_sql": "{% materialization seed, default %}\n\n  {%- set identifier = model['alias'] -%}\n  {%- set full_refresh_mode = (should_full_refresh()) -%}\n\n  {%- set old_relation = adapter.get_relation(database=database, schema=schema, identifier=identifier) -%}\n\n  {%- set exists_as_table = (old_relation is not none and old_relation.is_table) -%}\n  {%- set exists_as_view = (old_relation is not none and old_relation.is_view) -%}\n\n  {%- set grant_config = config.get('grants') -%}\n  {%- set agate_table = load_agate_table() -%}\n  -- grab current tables grants config for comparision later on\n\n  {%- do store_result('agate_table', response='OK', agate_table=agate_table) -%}\n\n  {{ run_hooks(pre_hooks, inside_transaction=False) }}\n\n  -- `BEGIN` happens here:\n  {{ run_hooks(pre_hooks, inside_transaction=True) }}\n\n  -- build model\n  {% set create_table_sql = \"\" %}\n  {% if exists_as_view %}\n    {{ exceptions.raise_compiler_error(\"Cannot seed to '{}', it is a view\".format(old_relation)) }}\n  {% elif exists_as_table %}\n    {% set create_table_sql = reset_csv_table(model, full_refresh_mode, old_relation, agate_table) %}\n  {% else %}\n    {% set create_table_sql = create_csv_table(model, agate_table) %}\n  {% endif %}\n\n  {% set code = 'CREATE' if full_refresh_mode else 'INSERT' %}\n  {% set rows_affected = (agate_table.rows | length) %}\n  {% set sql = load_csv_rows(model, agate_table) %}\n\n  {% call noop_statement('main', code ~ ' ' ~ rows_affected, code, rows_affected) %}\n    {{ get_csv_sql(create_table_sql, sql) }};\n  {% endcall %}\n\n  {% set target_relation = this.incorporate(type='table') %}\n\n  {% set should_revoke = should_revoke(old_relation, full_refresh_mode) %}\n  {% do apply_grants(target_relation, grant_config, should_revoke=should_revoke) %}\n\n  {% do persist_docs(target_relation, model) %}\n\n  {% if full_refresh_mode or not exists_as_table %}\n    {% do create_indexes(target_relation) %}\n  {% endif %}\n\n  {{ run_hooks(post_hooks, inside_transaction=True) }}\n\n  -- `COMMIT` happens here\n  {{ adapter.commit() }}\n\n  {{ run_hooks(post_hooks, inside_transaction=False) }}\n\n  {{ return({'relations': [target_relation]}) }}\n\n{% endmaterialization %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.should_full_refresh",
+              "macro.dbt.run_hooks",
+              "macro.dbt.reset_csv_table",
+              "macro.dbt.create_csv_table",
+              "macro.dbt.load_csv_rows",
+              "macro.dbt.noop_statement",
+              "macro.dbt.get_csv_sql",
+              "macro.dbt.should_revoke",
+              "macro.dbt.apply_grants",
+              "macro.dbt.persist_docs",
+              "macro.dbt.create_indexes"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.099391,
+          "supported_languages": [
+            "sql"
+          ]
+        },
+        "macro.dbt.create_csv_table": {
+          "name": "create_csv_table",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/materializations/seeds/helpers.sql",
+          "original_file_path": "macros/materializations/seeds/helpers.sql",
+          "unique_id": "macro.dbt.create_csv_table",
+          "macro_sql": "{% macro create_csv_table(model, agate_table) -%}\n  {{ adapter.dispatch('create_csv_table', 'dbt')(model, agate_table) }}\n{%- endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.default__create_csv_table"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.104628
+        },
+        "macro.dbt.default__create_csv_table": {
+          "name": "default__create_csv_table",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/materializations/seeds/helpers.sql",
+          "original_file_path": "macros/materializations/seeds/helpers.sql",
+          "unique_id": "macro.dbt.default__create_csv_table",
+          "macro_sql": "{% macro default__create_csv_table(model, agate_table) %}\n  {%- set column_override = model['config'].get('column_types', {}) -%}\n  {%- set quote_seed_column = model['config'].get('quote_columns', None) -%}\n\n  {% set sql %}\n    create table {{ this.render() }} (\n        {%- for col_name in agate_table.column_names -%}\n            {%- set inferred_type = adapter.convert_type(agate_table, loop.index0) -%}\n            {%- set type = column_override.get(col_name, inferred_type) -%}\n            {%- set column_name = (col_name | string) -%}\n            {{ adapter.quote_seed_column(column_name, quote_seed_column) }} {{ type }} {%- if not loop.last -%}, {%- endif -%}\n        {%- endfor -%}\n    )\n  {% endset %}\n\n  {% call statement('_') -%}\n    {{ sql }}\n  {%- endcall %}\n\n  {{ return(sql) }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.statement"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.1054878
+        },
+        "macro.dbt.reset_csv_table": {
+          "name": "reset_csv_table",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/materializations/seeds/helpers.sql",
+          "original_file_path": "macros/materializations/seeds/helpers.sql",
+          "unique_id": "macro.dbt.reset_csv_table",
+          "macro_sql": "{% macro reset_csv_table(model, full_refresh, old_relation, agate_table) -%}\n  {{ adapter.dispatch('reset_csv_table', 'dbt')(model, full_refresh, old_relation, agate_table) }}\n{%- endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.default__reset_csv_table"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.1057112
+        },
+        "macro.dbt.default__reset_csv_table": {
+          "name": "default__reset_csv_table",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/materializations/seeds/helpers.sql",
+          "original_file_path": "macros/materializations/seeds/helpers.sql",
+          "unique_id": "macro.dbt.default__reset_csv_table",
+          "macro_sql": "{% macro default__reset_csv_table(model, full_refresh, old_relation, agate_table) %}\n    {% set sql = \"\" %}\n    {% if full_refresh %}\n        {{ adapter.drop_relation(old_relation) }}\n        {% set sql = create_csv_table(model, agate_table) %}\n    {% else %}\n        {{ adapter.truncate_relation(old_relation) }}\n        {% set sql = \"truncate table \" ~ old_relation %}\n    {% endif %}\n\n    {{ return(sql) }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.create_csv_table"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.106164
+        },
+        "macro.dbt.get_csv_sql": {
+          "name": "get_csv_sql",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/materializations/seeds/helpers.sql",
+          "original_file_path": "macros/materializations/seeds/helpers.sql",
+          "unique_id": "macro.dbt.get_csv_sql",
+          "macro_sql": "{% macro get_csv_sql(create_or_truncate_sql, insert_sql) %}\n    {{ adapter.dispatch('get_csv_sql', 'dbt')(create_or_truncate_sql, insert_sql) }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.default__get_csv_sql"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.106344
+        },
+        "macro.dbt.default__get_csv_sql": {
+          "name": "default__get_csv_sql",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/materializations/seeds/helpers.sql",
+          "original_file_path": "macros/materializations/seeds/helpers.sql",
+          "unique_id": "macro.dbt.default__get_csv_sql",
+          "macro_sql": "{% macro default__get_csv_sql(create_or_truncate_sql, insert_sql) %}\n    {{ create_or_truncate_sql }};\n    -- dbt seed --\n    {{ insert_sql }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": []
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.106466
+        },
+        "macro.dbt.get_binding_char": {
+          "name": "get_binding_char",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/materializations/seeds/helpers.sql",
+          "original_file_path": "macros/materializations/seeds/helpers.sql",
+          "unique_id": "macro.dbt.get_binding_char",
+          "macro_sql": "{% macro get_binding_char() -%}\n  {{ adapter.dispatch('get_binding_char', 'dbt')() }}\n{%- endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt_duckdb.duckdb__get_binding_char"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.1065989
+        },
+        "macro.dbt.default__get_binding_char": {
+          "name": "default__get_binding_char",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/materializations/seeds/helpers.sql",
+          "original_file_path": "macros/materializations/seeds/helpers.sql",
+          "unique_id": "macro.dbt.default__get_binding_char",
+          "macro_sql": "{% macro default__get_binding_char() %}\n  {{ return('%s') }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": []
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.10671
+        },
+        "macro.dbt.get_batch_size": {
+          "name": "get_batch_size",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/materializations/seeds/helpers.sql",
+          "original_file_path": "macros/materializations/seeds/helpers.sql",
+          "unique_id": "macro.dbt.get_batch_size",
+          "macro_sql": "{% macro get_batch_size() -%}\n  {{ return(adapter.dispatch('get_batch_size', 'dbt')()) }}\n{%- endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt_duckdb.duckdb__get_batch_size"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.106869
+        },
+        "macro.dbt.default__get_batch_size": {
+          "name": "default__get_batch_size",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/materializations/seeds/helpers.sql",
+          "original_file_path": "macros/materializations/seeds/helpers.sql",
+          "unique_id": "macro.dbt.default__get_batch_size",
+          "macro_sql": "{% macro default__get_batch_size() %}\n  {{ return(10000) }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": []
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.106978
+        },
+        "macro.dbt.get_seed_column_quoted_csv": {
+          "name": "get_seed_column_quoted_csv",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/materializations/seeds/helpers.sql",
+          "original_file_path": "macros/materializations/seeds/helpers.sql",
+          "unique_id": "macro.dbt.get_seed_column_quoted_csv",
+          "macro_sql": "{% macro get_seed_column_quoted_csv(model, column_names) %}\n  {%- set quote_seed_column = model['config'].get('quote_columns', None) -%}\n    {% set quoted = [] %}\n    {% for col in column_names -%}\n        {%- do quoted.append(adapter.quote_seed_column(col, quote_seed_column)) -%}\n    {%- endfor %}\n\n    {%- set dest_cols_csv = quoted | join(', ') -%}\n    {{ return(dest_cols_csv) }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": []
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.107428
+        },
+        "macro.dbt.load_csv_rows": {
+          "name": "load_csv_rows",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/materializations/seeds/helpers.sql",
+          "original_file_path": "macros/materializations/seeds/helpers.sql",
+          "unique_id": "macro.dbt.load_csv_rows",
+          "macro_sql": "{% macro load_csv_rows(model, agate_table) -%}\n  {{ adapter.dispatch('load_csv_rows', 'dbt')(model, agate_table) }}\n{%- endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt_duckdb.duckdb__load_csv_rows"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.1076
+        },
+        "macro.dbt.default__load_csv_rows": {
+          "name": "default__load_csv_rows",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/materializations/seeds/helpers.sql",
+          "original_file_path": "macros/materializations/seeds/helpers.sql",
+          "unique_id": "macro.dbt.default__load_csv_rows",
+          "macro_sql": "{% macro default__load_csv_rows(model, agate_table) %}\n\n  {% set batch_size = get_batch_size() %}\n\n  {% set cols_sql = get_seed_column_quoted_csv(model, agate_table.column_names) %}\n  {% set bindings = [] %}\n\n  {% set statements = [] %}\n\n  {% for chunk in agate_table.rows | batch(batch_size) %}\n      {% set bindings = [] %}\n\n      {% for row in chunk %}\n          {% do bindings.extend(row) %}\n      {% endfor %}\n\n      {% set sql %}\n          insert into {{ this.render() }} ({{ cols_sql }}) values\n          {% for row in chunk -%}\n              ({%- for column in agate_table.column_names -%}\n                  {{ get_binding_char() }}\n                  {%- if not loop.last%},{%- endif %}\n              {%- endfor -%})\n              {%- if not loop.last%},{%- endif %}\n          {%- endfor %}\n      {% endset %}\n\n      {% do adapter.add_query(sql, bindings=bindings, abridge_sql_log=True) %}\n\n      {% if loop.index0 == 0 %}\n          {% do statements.append(sql) %}\n      {% endif %}\n  {% endfor %}\n\n  {# Return SQL so we can render it out into the compiled files #}\n  {{ return(statements[0]) }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.get_batch_size",
+              "macro.dbt.get_seed_column_quoted_csv",
+              "macro.dbt.get_binding_char"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.108802
+        },
+        "macro.dbt.generate_alias_name": {
+          "name": "generate_alias_name",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/get_custom_name/get_custom_alias.sql",
+          "original_file_path": "macros/get_custom_name/get_custom_alias.sql",
+          "unique_id": "macro.dbt.generate_alias_name",
+          "macro_sql": "{% macro generate_alias_name(custom_alias_name=none, node=none) -%}\n    {% do return(adapter.dispatch('generate_alias_name', 'dbt')(custom_alias_name, node)) %}\n{%- endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.default__generate_alias_name"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.109215
+        },
+        "macro.dbt.default__generate_alias_name": {
+          "name": "default__generate_alias_name",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/get_custom_name/get_custom_alias.sql",
+          "original_file_path": "macros/get_custom_name/get_custom_alias.sql",
+          "unique_id": "macro.dbt.default__generate_alias_name",
+          "macro_sql": "{% macro default__generate_alias_name(custom_alias_name=none, node=none) -%}\n\n    {%- if custom_alias_name -%}\n\n        {{ custom_alias_name | trim }}\n\n    {%- elif node.version -%}\n\n        {{ return(node.name ~ \"_v\" ~ (node.version | replace(\".\", \"_\"))) }}\n\n    {%- else -%}\n\n        {{ node.name }}\n\n    {%- endif -%}\n\n{%- endmacro %}",
+          "depends_on": {
+            "macros": []
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.109577
+        },
+        "macro.dbt.generate_schema_name": {
+          "name": "generate_schema_name",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/get_custom_name/get_custom_schema.sql",
+          "original_file_path": "macros/get_custom_name/get_custom_schema.sql",
+          "unique_id": "macro.dbt.generate_schema_name",
+          "macro_sql": "{% macro generate_schema_name(custom_schema_name=none, node=none) -%}\n    {{ return(adapter.dispatch('generate_schema_name', 'dbt')(custom_schema_name, node)) }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.default__generate_schema_name"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.110102
+        },
+        "macro.dbt.default__generate_schema_name": {
+          "name": "default__generate_schema_name",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/get_custom_name/get_custom_schema.sql",
+          "original_file_path": "macros/get_custom_name/get_custom_schema.sql",
+          "unique_id": "macro.dbt.default__generate_schema_name",
+          "macro_sql": "{% macro default__generate_schema_name(custom_schema_name, node) -%}\n\n    {%- set default_schema = target.schema -%}\n    {%- if custom_schema_name is none -%}\n\n        {{ default_schema }}\n\n    {%- else -%}\n\n        {{ default_schema }}_{{ custom_schema_name | trim }}\n\n    {%- endif -%}\n\n{%- endmacro %}",
+          "depends_on": {
+            "macros": []
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.110346
+        },
+        "macro.dbt.generate_schema_name_for_env": {
+          "name": "generate_schema_name_for_env",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/get_custom_name/get_custom_schema.sql",
+          "original_file_path": "macros/get_custom_name/get_custom_schema.sql",
+          "unique_id": "macro.dbt.generate_schema_name_for_env",
+          "macro_sql": "{% macro generate_schema_name_for_env(custom_schema_name, node) -%}\n\n    {%- set default_schema = target.schema -%}\n    {%- if target.name == 'prod' and custom_schema_name is not none -%}\n\n        {{ custom_schema_name | trim }}\n\n    {%- else -%}\n\n        {{ default_schema }}\n\n    {%- endif -%}\n\n{%- endmacro %}",
+          "depends_on": {
+            "macros": []
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.1106172
+        },
+        "macro.dbt.generate_database_name": {
+          "name": "generate_database_name",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/get_custom_name/get_custom_database.sql",
+          "original_file_path": "macros/get_custom_name/get_custom_database.sql",
+          "unique_id": "macro.dbt.generate_database_name",
+          "macro_sql": "{% macro generate_database_name(custom_database_name=none, node=none) -%}\n    {% do return(adapter.dispatch('generate_database_name', 'dbt')(custom_database_name, node)) %}\n{%- endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.default__generate_database_name"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.110998
+        },
+        "macro.dbt.default__generate_database_name": {
+          "name": "default__generate_database_name",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/get_custom_name/get_custom_database.sql",
+          "original_file_path": "macros/get_custom_name/get_custom_database.sql",
+          "unique_id": "macro.dbt.default__generate_database_name",
+          "macro_sql": "{% macro default__generate_database_name(custom_database_name=none, node=none) -%}\n    {%- set default_database = target.database -%}\n    {%- if custom_database_name is none -%}\n\n        {{ default_database }}\n\n    {%- else -%}\n\n        {{ custom_database_name }}\n\n    {%- endif -%}\n\n{%- endmacro %}",
+          "depends_on": {
+            "macros": []
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.111238
+        },
+        "macro.dbt.default__test_relationships": {
+          "name": "default__test_relationships",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/generic_test_sql/relationships.sql",
+          "original_file_path": "macros/generic_test_sql/relationships.sql",
+          "unique_id": "macro.dbt.default__test_relationships",
+          "macro_sql": "{% macro default__test_relationships(model, column_name, to, field) %}\n\nwith child as (\n    select {{ column_name }} as from_field\n    from {{ model }}\n    where {{ column_name }} is not null\n),\n\nparent as (\n    select {{ field }} as to_field\n    from {{ to }}\n)\n\nselect\n    from_field\n\nfrom child\nleft join parent\n    on child.from_field = parent.to_field\n\nwhere parent.to_field is null\n\n{% endmacro %}",
+          "depends_on": {
+            "macros": []
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.111574
+        },
+        "macro.dbt.default__test_not_null": {
+          "name": "default__test_not_null",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/generic_test_sql/not_null.sql",
+          "original_file_path": "macros/generic_test_sql/not_null.sql",
+          "unique_id": "macro.dbt.default__test_not_null",
+          "macro_sql": "{% macro default__test_not_null(model, column_name) %}\n\n{% set column_list = '*' if should_store_failures() else column_name %}\n\nselect {{ column_list }}\nfrom {{ model }}\nwhere {{ column_name }} is null\n\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.should_store_failures"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.111852
+        },
+        "macro.dbt.default__test_unique": {
+          "name": "default__test_unique",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/generic_test_sql/unique.sql",
+          "original_file_path": "macros/generic_test_sql/unique.sql",
+          "unique_id": "macro.dbt.default__test_unique",
+          "macro_sql": "{% macro default__test_unique(model, column_name) %}\n\nselect\n    {{ column_name }} as unique_field,\n    count(*) as n_records\n\nfrom {{ model }}\nwhere {{ column_name }} is not null\ngroup by {{ column_name }}\nhaving count(*) > 1\n\n{% endmacro %}",
+          "depends_on": {
+            "macros": []
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.11209
+        },
+        "macro.dbt.default__test_accepted_values": {
+          "name": "default__test_accepted_values",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/generic_test_sql/accepted_values.sql",
+          "original_file_path": "macros/generic_test_sql/accepted_values.sql",
+          "unique_id": "macro.dbt.default__test_accepted_values",
+          "macro_sql": "{% macro default__test_accepted_values(model, column_name, values, quote=True) %}\n\nwith all_values as (\n\n    select\n        {{ column_name }} as value_field,\n        count(*) as n_records\n\n    from {{ model }}\n    group by {{ column_name }}\n\n)\n\nselect *\nfrom all_values\nwhere value_field not in (\n    {% for value in values -%}\n        {% if quote -%}\n        '{{ value }}'\n        {%- else -%}\n        {{ value }}\n        {%- endif -%}\n        {%- if not loop.last -%},{%- endif %}\n    {%- endfor %}\n)\n\n{% endmacro %}",
+          "depends_on": {
+            "macros": []
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.1126568
+        },
+        "macro.dbt.statement": {
+          "name": "statement",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/etc/statement.sql",
+          "original_file_path": "macros/etc/statement.sql",
+          "unique_id": "macro.dbt.statement",
+          "macro_sql": "\n{%- macro statement(name=None, fetch_result=False, auto_begin=True, language='sql') -%}\n  {%- if execute: -%}\n    {%- set compiled_code = caller() -%}\n\n    {%- if name == 'main' -%}\n      {{ log('Writing runtime {} for node \"{}\"'.format(language, model['unique_id'])) }}\n      {{ write(compiled_code) }}\n    {%- endif -%}\n    {%- if language == 'sql'-%}\n      {%- set res, table = adapter.execute(compiled_code, auto_begin=auto_begin, fetch=fetch_result) -%}\n    {%- elif language == 'python' -%}\n      {%- set res = submit_python_job(model, compiled_code) -%}\n      {#-- TODO: What should table be for python models? --#}\n      {%- set table = None -%}\n    {%- else -%}\n      {% do exceptions.raise_compiler_error(\"statement macro didn't get supported language\") %}\n    {%- endif -%}\n\n    {%- if name is not none -%}\n      {{ store_result(name, response=res, agate_table=table) }}\n    {%- endif -%}\n\n  {%- endif -%}\n{%- endmacro %}",
+          "depends_on": {
+            "macros": []
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.11407
+        },
+        "macro.dbt.noop_statement": {
+          "name": "noop_statement",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/etc/statement.sql",
+          "original_file_path": "macros/etc/statement.sql",
+          "unique_id": "macro.dbt.noop_statement",
+          "macro_sql": "{% macro noop_statement(name=None, message=None, code=None, rows_affected=None, res=None) -%}\n  {%- set sql = caller() -%}\n\n  {%- if name == 'main' -%}\n    {{ log('Writing runtime SQL for node \"{}\"'.format(model['unique_id'])) }}\n    {{ write(sql) }}\n  {%- endif -%}\n\n  {%- if name is not none -%}\n    {{ store_raw_result(name, message=message, code=code, rows_affected=rows_affected, agate_table=res) }}\n  {%- endif -%}\n\n{%- endmacro %}",
+          "depends_on": {
+            "macros": []
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.1146848
+        },
+        "macro.dbt.run_query": {
+          "name": "run_query",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/etc/statement.sql",
+          "original_file_path": "macros/etc/statement.sql",
+          "unique_id": "macro.dbt.run_query",
+          "macro_sql": "{% macro run_query(sql) %}\n  {% call statement(\"run_query_statement\", fetch_result=true, auto_begin=false) %}\n    {{ sql }}\n  {% endcall %}\n\n  {% do return(load_result(\"run_query_statement\").table) %}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.statement"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.114964
+        },
+        "macro.dbt.convert_datetime": {
+          "name": "convert_datetime",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/etc/datetime.sql",
+          "original_file_path": "macros/etc/datetime.sql",
+          "unique_id": "macro.dbt.convert_datetime",
+          "macro_sql": "{% macro convert_datetime(date_str, date_fmt) %}\n\n  {% set error_msg -%}\n      The provided partition date '{{ date_str }}' does not match the expected format '{{ date_fmt }}'\n  {%- endset %}\n\n  {% set res = try_or_compiler_error(error_msg, modules.datetime.datetime.strptime, date_str.strip(), date_fmt) %}\n  {{ return(res) }}\n\n{% endmacro %}",
+          "depends_on": {
+            "macros": []
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.116862
+        },
+        "macro.dbt.dates_in_range": {
+          "name": "dates_in_range",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/etc/datetime.sql",
+          "original_file_path": "macros/etc/datetime.sql",
+          "unique_id": "macro.dbt.dates_in_range",
+          "macro_sql": "{% macro dates_in_range(start_date_str, end_date_str=none, in_fmt=\"%Y%m%d\", out_fmt=\"%Y%m%d\") %}\n    {% set end_date_str = start_date_str if end_date_str is none else end_date_str %}\n\n    {% set start_date = convert_datetime(start_date_str, in_fmt) %}\n    {% set end_date = convert_datetime(end_date_str, in_fmt) %}\n\n    {% set day_count = (end_date - start_date).days %}\n    {% if day_count < 0 %}\n        {% set msg -%}\n            Partiton start date is after the end date ({{ start_date }}, {{ end_date }})\n        {%- endset %}\n\n        {{ exceptions.raise_compiler_error(msg, model) }}\n    {% endif %}\n\n    {% set date_list = [] %}\n    {% for i in range(0, day_count + 1) %}\n        {% set the_date = (modules.datetime.timedelta(days=i) + start_date) %}\n        {% if not out_fmt %}\n            {% set _ = date_list.append(the_date) %}\n        {% else %}\n            {% set _ = date_list.append(the_date.strftime(out_fmt)) %}\n        {% endif %}\n    {% endfor %}\n\n    {{ return(date_list) }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.convert_datetime"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.117986
+        },
+        "macro.dbt.partition_range": {
+          "name": "partition_range",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/etc/datetime.sql",
+          "original_file_path": "macros/etc/datetime.sql",
+          "unique_id": "macro.dbt.partition_range",
+          "macro_sql": "{% macro partition_range(raw_partition_date, date_fmt='%Y%m%d') %}\n    {% set partition_range = (raw_partition_date | string).split(\",\") %}\n\n    {% if (partition_range | length) == 1 %}\n      {% set start_date = partition_range[0] %}\n      {% set end_date = none %}\n    {% elif (partition_range | length) == 2 %}\n      {% set start_date = partition_range[0] %}\n      {% set end_date = partition_range[1] %}\n    {% else %}\n      {{ exceptions.raise_compiler_error(\"Invalid partition time. Expected format: {Start Date}[,{End Date}]. Got: \" ~ raw_partition_date) }}\n    {% endif %}\n\n    {{ return(dates_in_range(start_date, end_date, in_fmt=date_fmt)) }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.dates_in_range"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.118741
+        },
+        "macro.dbt.py_current_timestring": {
+          "name": "py_current_timestring",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/etc/datetime.sql",
+          "original_file_path": "macros/etc/datetime.sql",
+          "unique_id": "macro.dbt.py_current_timestring",
+          "macro_sql": "{% macro py_current_timestring() %}\n    {% set dt = modules.datetime.datetime.now() %}\n    {% do return(dt.strftime(\"%Y%m%d%H%M%S%f\")) %}\n{% endmacro %}",
+          "depends_on": {
+            "macros": []
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.118967
+        },
+        "macro.dbt.except": {
+          "name": "except",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/utils/except.sql",
+          "original_file_path": "macros/utils/except.sql",
+          "unique_id": "macro.dbt.except",
+          "macro_sql": "{% macro except() %}\n  {{ return(adapter.dispatch('except', 'dbt')()) }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.default__except"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.119183
+        },
+        "macro.dbt.default__except": {
+          "name": "default__except",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/utils/except.sql",
+          "original_file_path": "macros/utils/except.sql",
+          "unique_id": "macro.dbt.default__except",
+          "macro_sql": "{% macro default__except() %}\n\n    except\n\n{% endmacro %}",
+          "depends_on": {
+            "macros": []
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.119253
+        },
+        "macro.dbt.replace": {
+          "name": "replace",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/utils/replace.sql",
+          "original_file_path": "macros/utils/replace.sql",
+          "unique_id": "macro.dbt.replace",
+          "macro_sql": "{% macro replace(field, old_chars, new_chars) -%}\n    {{ return(adapter.dispatch('replace', 'dbt') (field, old_chars, new_chars)) }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.default__replace"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.1195688
+        },
+        "macro.dbt.default__replace": {
+          "name": "default__replace",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/utils/replace.sql",
+          "original_file_path": "macros/utils/replace.sql",
+          "unique_id": "macro.dbt.default__replace",
+          "macro_sql": "{% macro default__replace(field, old_chars, new_chars) %}\n\n    replace(\n        {{ field }},\n        {{ old_chars }},\n        {{ new_chars }}\n    )\n\n\n{% endmacro %}",
+          "depends_on": {
+            "macros": []
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.119725
+        },
+        "macro.dbt.concat": {
+          "name": "concat",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/utils/concat.sql",
+          "original_file_path": "macros/utils/concat.sql",
+          "unique_id": "macro.dbt.concat",
+          "macro_sql": "{% macro concat(fields) -%}\n  {{ return(adapter.dispatch('concat', 'dbt')(fields)) }}\n{%- endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.default__concat"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.119958
+        },
+        "macro.dbt.default__concat": {
+          "name": "default__concat",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/utils/concat.sql",
+          "original_file_path": "macros/utils/concat.sql",
+          "unique_id": "macro.dbt.default__concat",
+          "macro_sql": "{% macro default__concat(fields) -%}\n    {{ fields|join(' || ') }}\n{%- endmacro %}",
+          "depends_on": {
+            "macros": []
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.120072
+        },
+        "macro.dbt.length": {
+          "name": "length",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/utils/length.sql",
+          "original_file_path": "macros/utils/length.sql",
+          "unique_id": "macro.dbt.length",
+          "macro_sql": "{% macro length(expression) -%}\n    {{ return(adapter.dispatch('length', 'dbt') (expression)) }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.default__length"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.12031
+        },
+        "macro.dbt.default__length": {
+          "name": "default__length",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/utils/length.sql",
+          "original_file_path": "macros/utils/length.sql",
+          "unique_id": "macro.dbt.default__length",
+          "macro_sql": "{% macro default__length(expression) %}\n\n    length(\n        {{ expression }}\n    )\n\n{%- endmacro -%}",
+          "depends_on": {
+            "macros": []
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.120407
+        },
+        "macro.dbt.dateadd": {
+          "name": "dateadd",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/utils/dateadd.sql",
+          "original_file_path": "macros/utils/dateadd.sql",
+          "unique_id": "macro.dbt.dateadd",
+          "macro_sql": "{% macro dateadd(datepart, interval, from_date_or_timestamp) %}\n  {{ return(adapter.dispatch('dateadd', 'dbt')(datepart, interval, from_date_or_timestamp)) }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt_duckdb.duckdb__dateadd"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.1207302
+        },
+        "macro.dbt.default__dateadd": {
+          "name": "default__dateadd",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/utils/dateadd.sql",
+          "original_file_path": "macros/utils/dateadd.sql",
+          "unique_id": "macro.dbt.default__dateadd",
+          "macro_sql": "{% macro default__dateadd(datepart, interval, from_date_or_timestamp) %}\n\n    dateadd(\n        {{ datepart }},\n        {{ interval }},\n        {{ from_date_or_timestamp }}\n        )\n\n{% endmacro %}",
+          "depends_on": {
+            "macros": []
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.120882
+        },
+        "macro.dbt.intersect": {
+          "name": "intersect",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/utils/intersect.sql",
+          "original_file_path": "macros/utils/intersect.sql",
+          "unique_id": "macro.dbt.intersect",
+          "macro_sql": "{% macro intersect() %}\n  {{ return(adapter.dispatch('intersect', 'dbt')()) }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.default__intersect"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.121094
+        },
+        "macro.dbt.default__intersect": {
+          "name": "default__intersect",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/utils/intersect.sql",
+          "original_file_path": "macros/utils/intersect.sql",
+          "unique_id": "macro.dbt.default__intersect",
+          "macro_sql": "{% macro default__intersect() %}\n\n    intersect\n\n{% endmacro %}",
+          "depends_on": {
+            "macros": []
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.121165
+        },
+        "macro.dbt.escape_single_quotes": {
+          "name": "escape_single_quotes",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/utils/escape_single_quotes.sql",
+          "original_file_path": "macros/utils/escape_single_quotes.sql",
+          "unique_id": "macro.dbt.escape_single_quotes",
+          "macro_sql": "{% macro escape_single_quotes(expression) %}\n      {{ return(adapter.dispatch('escape_single_quotes', 'dbt') (expression)) }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.default__escape_single_quotes"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.121435
+        },
+        "macro.dbt.default__escape_single_quotes": {
+          "name": "default__escape_single_quotes",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/utils/escape_single_quotes.sql",
+          "original_file_path": "macros/utils/escape_single_quotes.sql",
+          "unique_id": "macro.dbt.default__escape_single_quotes",
+          "macro_sql": "{% macro default__escape_single_quotes(expression) -%}\n{{ expression | replace(\"'\",\"''\") }}\n{%- endmacro %}",
+          "depends_on": {
+            "macros": []
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.121574
+        },
+        "macro.dbt.right": {
+          "name": "right",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/utils/right.sql",
+          "original_file_path": "macros/utils/right.sql",
+          "unique_id": "macro.dbt.right",
+          "macro_sql": "{% macro right(string_text, length_expression) -%}\n    {{ return(adapter.dispatch('right', 'dbt') (string_text, length_expression)) }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.default__right"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.121851
+        },
+        "macro.dbt.default__right": {
+          "name": "default__right",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/utils/right.sql",
+          "original_file_path": "macros/utils/right.sql",
+          "unique_id": "macro.dbt.default__right",
+          "macro_sql": "{% macro default__right(string_text, length_expression) %}\n\n    right(\n        {{ string_text }},\n        {{ length_expression }}\n    )\n\n{%- endmacro -%}",
+          "depends_on": {
+            "macros": []
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.12204
+        },
+        "macro.dbt.listagg": {
+          "name": "listagg",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/utils/listagg.sql",
+          "original_file_path": "macros/utils/listagg.sql",
+          "unique_id": "macro.dbt.listagg",
+          "macro_sql": "{% macro listagg(measure, delimiter_text=\"','\", order_by_clause=none, limit_num=none) -%}\n    {{ return(adapter.dispatch('listagg', 'dbt') (measure, delimiter_text, order_by_clause, limit_num)) }}\n{%- endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt_duckdb.duckdb__listagg"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.122664
+        },
+        "macro.dbt.default__listagg": {
+          "name": "default__listagg",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/utils/listagg.sql",
+          "original_file_path": "macros/utils/listagg.sql",
+          "unique_id": "macro.dbt.default__listagg",
+          "macro_sql": "{% macro default__listagg(measure, delimiter_text, order_by_clause, limit_num) -%}\n\n    {% if limit_num -%}\n    array_to_string(\n        array_slice(\n            array_agg(\n                {{ measure }}\n            ){% if order_by_clause -%}\n            within group ({{ order_by_clause }})\n            {%- endif %}\n            ,0\n            ,{{ limit_num }}\n        ),\n        {{ delimiter_text }}\n        )\n    {%- else %}\n    listagg(\n        {{ measure }},\n        {{ delimiter_text }}\n        )\n        {% if order_by_clause -%}\n        within group ({{ order_by_clause }})\n        {%- endif %}\n    {%- endif %}\n\n{%- endmacro %}",
+          "depends_on": {
+            "macros": []
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.123049
+        },
+        "macro.dbt.datediff": {
+          "name": "datediff",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/utils/datediff.sql",
+          "original_file_path": "macros/utils/datediff.sql",
+          "unique_id": "macro.dbt.datediff",
+          "macro_sql": "{% macro datediff(first_date, second_date, datepart) %}\n  {{ return(adapter.dispatch('datediff', 'dbt')(first_date, second_date, datepart)) }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt_duckdb.duckdb__datediff"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.1233869
+        },
+        "macro.dbt.default__datediff": {
+          "name": "default__datediff",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/utils/datediff.sql",
+          "original_file_path": "macros/utils/datediff.sql",
+          "unique_id": "macro.dbt.default__datediff",
+          "macro_sql": "{% macro default__datediff(first_date, second_date, datepart) -%}\n\n    datediff(\n        {{ datepart }},\n        {{ first_date }},\n        {{ second_date }}\n        )\n\n{%- endmacro %}",
+          "depends_on": {
+            "macros": []
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.123544
+        },
+        "macro.dbt.safe_cast": {
+          "name": "safe_cast",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/utils/safe_cast.sql",
+          "original_file_path": "macros/utils/safe_cast.sql",
+          "unique_id": "macro.dbt.safe_cast",
+          "macro_sql": "{% macro safe_cast(field, type) %}\n  {{ return(adapter.dispatch('safe_cast', 'dbt') (field, type)) }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.default__safe_cast"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.12382
+        },
+        "macro.dbt.default__safe_cast": {
+          "name": "default__safe_cast",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/utils/safe_cast.sql",
+          "original_file_path": "macros/utils/safe_cast.sql",
+          "unique_id": "macro.dbt.default__safe_cast",
+          "macro_sql": "{% macro default__safe_cast(field, type) %}\n    {# most databases don't support this function yet\n    so we just need to use cast #}\n    cast({{field}} as {{type}})\n{% endmacro %}",
+          "depends_on": {
+            "macros": []
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.1239522
+        },
+        "macro.dbt.hash": {
+          "name": "hash",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/utils/hash.sql",
+          "original_file_path": "macros/utils/hash.sql",
+          "unique_id": "macro.dbt.hash",
+          "macro_sql": "{% macro hash(field) -%}\n  {{ return(adapter.dispatch('hash', 'dbt') (field)) }}\n{%- endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.default__hash"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.124219
+        },
+        "macro.dbt.default__hash": {
+          "name": "default__hash",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/utils/hash.sql",
+          "original_file_path": "macros/utils/hash.sql",
+          "unique_id": "macro.dbt.default__hash",
+          "macro_sql": "{% macro default__hash(field) -%}\n    md5(cast({{ field }} as {{ api.Column.translate_type('string') }}))\n{%- endmacro %}",
+          "depends_on": {
+            "macros": []
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.124386
+        },
+        "macro.dbt.cast_bool_to_text": {
+          "name": "cast_bool_to_text",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/utils/cast_bool_to_text.sql",
+          "original_file_path": "macros/utils/cast_bool_to_text.sql",
+          "unique_id": "macro.dbt.cast_bool_to_text",
+          "macro_sql": "{% macro cast_bool_to_text(field) %}\n  {{ adapter.dispatch('cast_bool_to_text', 'dbt') (field) }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.default__cast_bool_to_text"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.1246238
+        },
+        "macro.dbt.default__cast_bool_to_text": {
+          "name": "default__cast_bool_to_text",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/utils/cast_bool_to_text.sql",
+          "original_file_path": "macros/utils/cast_bool_to_text.sql",
+          "unique_id": "macro.dbt.default__cast_bool_to_text",
+          "macro_sql": "{% macro default__cast_bool_to_text(field) %}\n    cast({{ field }} as {{ api.Column.translate_type('string') }})\n{% endmacro %}",
+          "depends_on": {
+            "macros": []
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.124772
+        },
+        "macro.dbt.any_value": {
+          "name": "any_value",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/utils/any_value.sql",
+          "original_file_path": "macros/utils/any_value.sql",
+          "unique_id": "macro.dbt.any_value",
+          "macro_sql": "{% macro any_value(expression) -%}\n    {{ return(adapter.dispatch('any_value', 'dbt') (expression)) }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt_duckdb.duckdb__any_value"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.1250088
+        },
+        "macro.dbt.default__any_value": {
+          "name": "default__any_value",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/utils/any_value.sql",
+          "original_file_path": "macros/utils/any_value.sql",
+          "unique_id": "macro.dbt.default__any_value",
+          "macro_sql": "{% macro default__any_value(expression) -%}\n\n    any_value({{ expression }})\n\n{%- endmacro %}",
+          "depends_on": {
+            "macros": []
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.125111
+        },
+        "macro.dbt.position": {
+          "name": "position",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/utils/position.sql",
+          "original_file_path": "macros/utils/position.sql",
+          "unique_id": "macro.dbt.position",
+          "macro_sql": "{% macro position(substring_text, string_text) -%}\n    {{ return(adapter.dispatch('position', 'dbt') (substring_text, string_text)) }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.default__position"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.125383
+        },
+        "macro.dbt.default__position": {
+          "name": "default__position",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/utils/position.sql",
+          "original_file_path": "macros/utils/position.sql",
+          "unique_id": "macro.dbt.default__position",
+          "macro_sql": "{% macro default__position(substring_text, string_text) %}\n\n    position(\n        {{ substring_text }} in {{ string_text }}\n    )\n\n{%- endmacro -%}",
+          "depends_on": {
+            "macros": []
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.125516
+        },
+        "macro.dbt.string_literal": {
+          "name": "string_literal",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/utils/literal.sql",
+          "original_file_path": "macros/utils/literal.sql",
+          "unique_id": "macro.dbt.string_literal",
+          "macro_sql": "{%- macro string_literal(value) -%}\n  {{ return(adapter.dispatch('string_literal', 'dbt') (value)) }}\n{%- endmacro -%}\n\n",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.default__string_literal"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.1257448
+        },
+        "macro.dbt.default__string_literal": {
+          "name": "default__string_literal",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/utils/literal.sql",
+          "original_file_path": "macros/utils/literal.sql",
+          "unique_id": "macro.dbt.default__string_literal",
+          "macro_sql": "{% macro default__string_literal(value) -%}\n    '{{ value }}'\n{%- endmacro %}",
+          "depends_on": {
+            "macros": []
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.125846
+        },
+        "macro.dbt.type_string": {
+          "name": "type_string",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/utils/data_types.sql",
+          "original_file_path": "macros/utils/data_types.sql",
+          "unique_id": "macro.dbt.type_string",
+          "macro_sql": "\n\n{%- macro type_string() -%}\n  {{ return(adapter.dispatch('type_string', 'dbt')()) }}\n{%- endmacro -%}\n\n",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.default__type_string"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.1267478
+        },
+        "macro.dbt.default__type_string": {
+          "name": "default__type_string",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/utils/data_types.sql",
+          "original_file_path": "macros/utils/data_types.sql",
+          "unique_id": "macro.dbt.default__type_string",
+          "macro_sql": "{% macro default__type_string() %}\n    {{ return(api.Column.translate_type(\"string\")) }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": []
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.1268961
+        },
+        "macro.dbt.type_timestamp": {
+          "name": "type_timestamp",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/utils/data_types.sql",
+          "original_file_path": "macros/utils/data_types.sql",
+          "unique_id": "macro.dbt.type_timestamp",
+          "macro_sql": "\n\n{%- macro type_timestamp() -%}\n  {{ return(adapter.dispatch('type_timestamp', 'dbt')()) }}\n{%- endmacro -%}\n\n",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.default__type_timestamp"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.127251
+        },
+        "macro.dbt.default__type_timestamp": {
+          "name": "default__type_timestamp",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/utils/data_types.sql",
+          "original_file_path": "macros/utils/data_types.sql",
+          "unique_id": "macro.dbt.default__type_timestamp",
+          "macro_sql": "{% macro default__type_timestamp() %}\n    {{ return(api.Column.translate_type(\"timestamp\")) }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": []
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.127396
+        },
+        "macro.dbt.type_float": {
+          "name": "type_float",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/utils/data_types.sql",
+          "original_file_path": "macros/utils/data_types.sql",
+          "unique_id": "macro.dbt.type_float",
+          "macro_sql": "\n\n{%- macro type_float() -%}\n  {{ return(adapter.dispatch('type_float', 'dbt')()) }}\n{%- endmacro -%}\n\n",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.default__type_float"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.1275468
+        },
+        "macro.dbt.default__type_float": {
+          "name": "default__type_float",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/utils/data_types.sql",
+          "original_file_path": "macros/utils/data_types.sql",
+          "unique_id": "macro.dbt.default__type_float",
+          "macro_sql": "{% macro default__type_float() %}\n    {{ return(api.Column.translate_type(\"float\")) }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": []
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.127687
+        },
+        "macro.dbt.type_numeric": {
+          "name": "type_numeric",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/utils/data_types.sql",
+          "original_file_path": "macros/utils/data_types.sql",
+          "unique_id": "macro.dbt.type_numeric",
+          "macro_sql": "\n\n{%- macro type_numeric() -%}\n  {{ return(adapter.dispatch('type_numeric', 'dbt')()) }}\n{%- endmacro -%}\n\n",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.default__type_numeric"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.127841
+        },
+        "macro.dbt.default__type_numeric": {
+          "name": "default__type_numeric",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/utils/data_types.sql",
+          "original_file_path": "macros/utils/data_types.sql",
+          "unique_id": "macro.dbt.default__type_numeric",
+          "macro_sql": "{% macro default__type_numeric() %}\n    {{ return(api.Column.numeric_type(\"numeric\", 28, 6)) }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": []
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.128007
+        },
+        "macro.dbt.type_bigint": {
+          "name": "type_bigint",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/utils/data_types.sql",
+          "original_file_path": "macros/utils/data_types.sql",
+          "unique_id": "macro.dbt.type_bigint",
+          "macro_sql": "\n\n{%- macro type_bigint() -%}\n  {{ return(adapter.dispatch('type_bigint', 'dbt')()) }}\n{%- endmacro -%}\n\n",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.default__type_bigint"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.1281579
+        },
+        "macro.dbt.default__type_bigint": {
+          "name": "default__type_bigint",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/utils/data_types.sql",
+          "original_file_path": "macros/utils/data_types.sql",
+          "unique_id": "macro.dbt.default__type_bigint",
+          "macro_sql": "{% macro default__type_bigint() %}\n    {{ return(api.Column.translate_type(\"bigint\")) }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": []
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.128302
+        },
+        "macro.dbt.type_int": {
+          "name": "type_int",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/utils/data_types.sql",
+          "original_file_path": "macros/utils/data_types.sql",
+          "unique_id": "macro.dbt.type_int",
+          "macro_sql": "\n\n{%- macro type_int() -%}\n  {{ return(adapter.dispatch('type_int', 'dbt')()) }}\n{%- endmacro -%}\n\n",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.default__type_int"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.128452
+        },
+        "macro.dbt.default__type_int": {
+          "name": "default__type_int",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/utils/data_types.sql",
+          "original_file_path": "macros/utils/data_types.sql",
+          "unique_id": "macro.dbt.default__type_int",
+          "macro_sql": "{%- macro default__type_int() -%}\n  {{ return(api.Column.translate_type(\"integer\")) }}\n{%- endmacro -%}\n\n",
+          "depends_on": {
+            "macros": []
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.128593
+        },
+        "macro.dbt.type_boolean": {
+          "name": "type_boolean",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/utils/data_types.sql",
+          "original_file_path": "macros/utils/data_types.sql",
+          "unique_id": "macro.dbt.type_boolean",
+          "macro_sql": "\n\n{%- macro type_boolean() -%}\n  {{ return(adapter.dispatch('type_boolean', 'dbt')()) }}\n{%- endmacro -%}\n\n",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.default__type_boolean"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.128744
+        },
+        "macro.dbt.default__type_boolean": {
+          "name": "default__type_boolean",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/utils/data_types.sql",
+          "original_file_path": "macros/utils/data_types.sql",
+          "unique_id": "macro.dbt.default__type_boolean",
+          "macro_sql": "{%- macro default__type_boolean() -%}\n  {{ return(api.Column.translate_type(\"boolean\")) }}\n{%- endmacro -%}\n\n",
+          "depends_on": {
+            "macros": []
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.128884
+        },
+        "macro.dbt.array_concat": {
+          "name": "array_concat",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/utils/array_concat.sql",
+          "original_file_path": "macros/utils/array_concat.sql",
+          "unique_id": "macro.dbt.array_concat",
+          "macro_sql": "{% macro array_concat(array_1, array_2) -%}\n  {{ return(adapter.dispatch('array_concat', 'dbt')(array_1, array_2)) }}\n{%- endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.default__array_concat"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.129153
+        },
+        "macro.dbt.default__array_concat": {
+          "name": "default__array_concat",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/utils/array_concat.sql",
+          "original_file_path": "macros/utils/array_concat.sql",
+          "unique_id": "macro.dbt.default__array_concat",
+          "macro_sql": "{% macro default__array_concat(array_1, array_2) -%}\n    array_cat({{ array_1 }}, {{ array_2 }})\n{%- endmacro %}",
+          "depends_on": {
+            "macros": []
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.129279
+        },
+        "macro.dbt.bool_or": {
+          "name": "bool_or",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/utils/bool_or.sql",
+          "original_file_path": "macros/utils/bool_or.sql",
+          "unique_id": "macro.dbt.bool_or",
+          "macro_sql": "{% macro bool_or(expression) -%}\n    {{ return(adapter.dispatch('bool_or', 'dbt') (expression)) }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.default__bool_or"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.129515
+        },
+        "macro.dbt.default__bool_or": {
+          "name": "default__bool_or",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/utils/bool_or.sql",
+          "original_file_path": "macros/utils/bool_or.sql",
+          "unique_id": "macro.dbt.default__bool_or",
+          "macro_sql": "{% macro default__bool_or(expression) -%}\n\n    bool_or({{ expression }})\n\n{%- endmacro %}",
+          "depends_on": {
+            "macros": []
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.129612
+        },
+        "macro.dbt.last_day": {
+          "name": "last_day",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/utils/last_day.sql",
+          "original_file_path": "macros/utils/last_day.sql",
+          "unique_id": "macro.dbt.last_day",
+          "macro_sql": "{% macro last_day(date, datepart) %}\n  {{ return(adapter.dispatch('last_day', 'dbt') (date, datepart)) }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt_duckdb.duckdb__last_day"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.129942
+        },
+        "macro.dbt.default_last_day": {
+          "name": "default_last_day",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/utils/last_day.sql",
+          "original_file_path": "macros/utils/last_day.sql",
+          "unique_id": "macro.dbt.default_last_day",
+          "macro_sql": "\n\n{%- macro default_last_day(date, datepart) -%}\n    cast(\n        {{dbt.dateadd('day', '-1',\n        dbt.dateadd(datepart, '1', dbt.date_trunc(datepart, date))\n        )}}\n        as date)\n{%- endmacro -%}\n\n",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.dateadd",
+              "macro.dbt.date_trunc"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.130228
+        },
+        "macro.dbt.default__last_day": {
+          "name": "default__last_day",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/utils/last_day.sql",
+          "original_file_path": "macros/utils/last_day.sql",
+          "unique_id": "macro.dbt.default__last_day",
+          "macro_sql": "{% macro default__last_day(date, datepart) -%}\n    {{dbt.default_last_day(date, datepart)}}\n{%- endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.default_last_day"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.130378
+        },
+        "macro.dbt.split_part": {
+          "name": "split_part",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/utils/split_part.sql",
+          "original_file_path": "macros/utils/split_part.sql",
+          "unique_id": "macro.dbt.split_part",
+          "macro_sql": "{% macro split_part(string_text, delimiter_text, part_number) %}\n  {{ return(adapter.dispatch('split_part', 'dbt') (string_text, delimiter_text, part_number)) }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt_duckdb.duckdb__split_part"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.1309261
+        },
+        "macro.dbt.default__split_part": {
+          "name": "default__split_part",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/utils/split_part.sql",
+          "original_file_path": "macros/utils/split_part.sql",
+          "unique_id": "macro.dbt.default__split_part",
+          "macro_sql": "{% macro default__split_part(string_text, delimiter_text, part_number) %}\n\n    split_part(\n        {{ string_text }},\n        {{ delimiter_text }},\n        {{ part_number }}\n        )\n\n{% endmacro %}",
+          "depends_on": {
+            "macros": []
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.1311638
+        },
+        "macro.dbt._split_part_negative": {
+          "name": "_split_part_negative",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/utils/split_part.sql",
+          "original_file_path": "macros/utils/split_part.sql",
+          "unique_id": "macro.dbt._split_part_negative",
+          "macro_sql": "{% macro _split_part_negative(string_text, delimiter_text, part_number) %}\n\n    split_part(\n        {{ string_text }},\n        {{ delimiter_text }},\n          length({{ string_text }})\n          - length(\n              replace({{ string_text }},  {{ delimiter_text }}, '')\n          ) + 2 {{ part_number }}\n        )\n\n{% endmacro %}",
+          "depends_on": {
+            "macros": []
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.131479
+        },
+        "macro.dbt.date_trunc": {
+          "name": "date_trunc",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/utils/date_trunc.sql",
+          "original_file_path": "macros/utils/date_trunc.sql",
+          "unique_id": "macro.dbt.date_trunc",
+          "macro_sql": "{% macro date_trunc(datepart, date) -%}\n  {{ return(adapter.dispatch('date_trunc', 'dbt') (datepart, date)) }}\n{%- endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.default__date_trunc"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.131798
+        },
+        "macro.dbt.default__date_trunc": {
+          "name": "default__date_trunc",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/utils/date_trunc.sql",
+          "original_file_path": "macros/utils/date_trunc.sql",
+          "unique_id": "macro.dbt.default__date_trunc",
+          "macro_sql": "{% macro default__date_trunc(datepart, date) -%}\n    date_trunc('{{datepart}}', {{date}})\n{%- endmacro %}",
+          "depends_on": {
+            "macros": []
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.131932
+        },
+        "macro.dbt.array_construct": {
+          "name": "array_construct",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/utils/array_construct.sql",
+          "original_file_path": "macros/utils/array_construct.sql",
+          "unique_id": "macro.dbt.array_construct",
+          "macro_sql": "{% macro array_construct(inputs=[], data_type=api.Column.translate_type('integer')) -%}\n  {{ return(adapter.dispatch('array_construct', 'dbt')(inputs, data_type)) }}\n{%- endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.default__array_construct"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.132318
+        },
+        "macro.dbt.default__array_construct": {
+          "name": "default__array_construct",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/utils/array_construct.sql",
+          "original_file_path": "macros/utils/array_construct.sql",
+          "unique_id": "macro.dbt.default__array_construct",
+          "macro_sql": "{% macro default__array_construct(inputs, data_type) -%}\n    {% if inputs|length > 0 %}\n    array[ {{ inputs|join(' , ') }} ]\n    {% else %}\n    array[]::{{data_type}}[]\n    {% endif %}\n{%- endmacro %}",
+          "depends_on": {
+            "macros": []
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.132564
+        },
+        "macro.dbt.array_append": {
+          "name": "array_append",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/utils/array_append.sql",
+          "original_file_path": "macros/utils/array_append.sql",
+          "unique_id": "macro.dbt.array_append",
+          "macro_sql": "{% macro array_append(array, new_element) -%}\n  {{ return(adapter.dispatch('array_append', 'dbt')(array, new_element)) }}\n{%- endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.default__array_append"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.132857
+        },
+        "macro.dbt.default__array_append": {
+          "name": "default__array_append",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/utils/array_append.sql",
+          "original_file_path": "macros/utils/array_append.sql",
+          "unique_id": "macro.dbt.default__array_append",
+          "macro_sql": "{% macro default__array_append(array, new_element) -%}\n    array_append({{ array }}, {{ new_element }})\n{%- endmacro %}",
+          "depends_on": {
+            "macros": []
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.133044
+        },
+        "macro.dbt.create_schema": {
+          "name": "create_schema",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/adapters/schema.sql",
+          "original_file_path": "macros/adapters/schema.sql",
+          "unique_id": "macro.dbt.create_schema",
+          "macro_sql": "{% macro create_schema(relation) -%}\n  {{ adapter.dispatch('create_schema', 'dbt')(relation) }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt_duckdb.duckdb__create_schema"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.133421
+        },
+        "macro.dbt.default__create_schema": {
+          "name": "default__create_schema",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/adapters/schema.sql",
+          "original_file_path": "macros/adapters/schema.sql",
+          "unique_id": "macro.dbt.default__create_schema",
+          "macro_sql": "{% macro default__create_schema(relation) -%}\n  {%- call statement('create_schema') -%}\n    create schema if not exists {{ relation.without_identifier() }}\n  {% endcall %}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.statement"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.133607
+        },
+        "macro.dbt.drop_schema": {
+          "name": "drop_schema",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/adapters/schema.sql",
+          "original_file_path": "macros/adapters/schema.sql",
+          "unique_id": "macro.dbt.drop_schema",
+          "macro_sql": "{% macro drop_schema(relation) -%}\n  {{ adapter.dispatch('drop_schema', 'dbt')(relation) }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt_duckdb.duckdb__drop_schema"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.133766
+        },
+        "macro.dbt.default__drop_schema": {
+          "name": "default__drop_schema",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/adapters/schema.sql",
+          "original_file_path": "macros/adapters/schema.sql",
+          "unique_id": "macro.dbt.default__drop_schema",
+          "macro_sql": "{% macro default__drop_schema(relation) -%}\n  {%- call statement('drop_schema') -%}\n    drop schema if exists {{ relation.without_identifier() }} cascade\n  {% endcall %}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.statement"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.133943
+        },
+        "macro.dbt.current_timestamp": {
+          "name": "current_timestamp",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/adapters/timestamps.sql",
+          "original_file_path": "macros/adapters/timestamps.sql",
+          "unique_id": "macro.dbt.current_timestamp",
+          "macro_sql": "{%- macro current_timestamp() -%}\n    {{ adapter.dispatch('current_timestamp', 'dbt')() }}\n{%- endmacro -%}\n\n",
+          "depends_on": {
+            "macros": [
+              "macro.dbt_duckdb.duckdb__current_timestamp"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.13443
+        },
+        "macro.dbt.default__current_timestamp": {
+          "name": "default__current_timestamp",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/adapters/timestamps.sql",
+          "original_file_path": "macros/adapters/timestamps.sql",
+          "unique_id": "macro.dbt.default__current_timestamp",
+          "macro_sql": "{% macro default__current_timestamp() -%}\n  {{ exceptions.raise_not_implemented(\n    'current_timestamp macro not implemented for adapter ' + adapter.type()) }}\n{%- endmacro %}",
+          "depends_on": {
+            "macros": []
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.1345768
+        },
+        "macro.dbt.snapshot_get_time": {
+          "name": "snapshot_get_time",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/adapters/timestamps.sql",
+          "original_file_path": "macros/adapters/timestamps.sql",
+          "unique_id": "macro.dbt.snapshot_get_time",
+          "macro_sql": "\n\n{%- macro snapshot_get_time() -%}\n    {{ adapter.dispatch('snapshot_get_time', 'dbt')() }}\n{%- endmacro -%}\n\n",
+          "depends_on": {
+            "macros": [
+              "macro.dbt_duckdb.duckdb__snapshot_get_time"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.134718
+        },
+        "macro.dbt.default__snapshot_get_time": {
+          "name": "default__snapshot_get_time",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/adapters/timestamps.sql",
+          "original_file_path": "macros/adapters/timestamps.sql",
+          "unique_id": "macro.dbt.default__snapshot_get_time",
+          "macro_sql": "{% macro default__snapshot_get_time() %}\n    {{ current_timestamp() }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.current_timestamp"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.13483
+        },
+        "macro.dbt.current_timestamp_backcompat": {
+          "name": "current_timestamp_backcompat",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/adapters/timestamps.sql",
+          "original_file_path": "macros/adapters/timestamps.sql",
+          "unique_id": "macro.dbt.current_timestamp_backcompat",
+          "macro_sql": "{% macro current_timestamp_backcompat() %}\n    {{ return(adapter.dispatch('current_timestamp_backcompat', 'dbt')()) }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.default__current_timestamp_backcompat"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.134997
+        },
+        "macro.dbt.default__current_timestamp_backcompat": {
+          "name": "default__current_timestamp_backcompat",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/adapters/timestamps.sql",
+          "original_file_path": "macros/adapters/timestamps.sql",
+          "unique_id": "macro.dbt.default__current_timestamp_backcompat",
+          "macro_sql": "{% macro default__current_timestamp_backcompat() %}\n    current_timestamp::timestamp\n{% endmacro %}",
+          "depends_on": {
+            "macros": []
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.135071
+        },
+        "macro.dbt.current_timestamp_in_utc_backcompat": {
+          "name": "current_timestamp_in_utc_backcompat",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/adapters/timestamps.sql",
+          "original_file_path": "macros/adapters/timestamps.sql",
+          "unique_id": "macro.dbt.current_timestamp_in_utc_backcompat",
+          "macro_sql": "{% macro current_timestamp_in_utc_backcompat() %}\n    {{ return(adapter.dispatch('current_timestamp_in_utc_backcompat', 'dbt')()) }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.default__current_timestamp_in_utc_backcompat"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.135234
+        },
+        "macro.dbt.default__current_timestamp_in_utc_backcompat": {
+          "name": "default__current_timestamp_in_utc_backcompat",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/adapters/timestamps.sql",
+          "original_file_path": "macros/adapters/timestamps.sql",
+          "unique_id": "macro.dbt.default__current_timestamp_in_utc_backcompat",
+          "macro_sql": "{% macro default__current_timestamp_in_utc_backcompat() %}\n    {{ return(adapter.dispatch('current_timestamp_backcompat', 'dbt')()) }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.current_timestamp_backcompat",
+              "macro.dbt.default__current_timestamp_backcompat"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.135489
+        },
+        "macro.dbt.get_create_index_sql": {
+          "name": "get_create_index_sql",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/adapters/indexes.sql",
+          "original_file_path": "macros/adapters/indexes.sql",
+          "unique_id": "macro.dbt.get_create_index_sql",
+          "macro_sql": "{% macro get_create_index_sql(relation, index_dict) -%}\n  {{ return(adapter.dispatch('get_create_index_sql', 'dbt')(relation, index_dict)) }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.default__get_create_index_sql"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.135968
+        },
+        "macro.dbt.default__get_create_index_sql": {
+          "name": "default__get_create_index_sql",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/adapters/indexes.sql",
+          "original_file_path": "macros/adapters/indexes.sql",
+          "unique_id": "macro.dbt.default__get_create_index_sql",
+          "macro_sql": "{% macro default__get_create_index_sql(relation, index_dict) -%}\n  {% do return(None) %}\n{% endmacro %}",
+          "depends_on": {
+            "macros": []
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.136103
+        },
+        "macro.dbt.create_indexes": {
+          "name": "create_indexes",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/adapters/indexes.sql",
+          "original_file_path": "macros/adapters/indexes.sql",
+          "unique_id": "macro.dbt.create_indexes",
+          "macro_sql": "{% macro create_indexes(relation) -%}\n  {{ adapter.dispatch('create_indexes', 'dbt')(relation) }}\n{%- endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.default__create_indexes"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.136265
+        },
+        "macro.dbt.default__create_indexes": {
+          "name": "default__create_indexes",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/adapters/indexes.sql",
+          "original_file_path": "macros/adapters/indexes.sql",
+          "unique_id": "macro.dbt.default__create_indexes",
+          "macro_sql": "{% macro default__create_indexes(relation) -%}\n  {%- set _indexes = config.get('indexes', default=[]) -%}\n\n  {% for _index_dict in _indexes %}\n    {% set create_index_sql = get_create_index_sql(relation, _index_dict) %}\n    {% if create_index_sql %}\n      {% do run_query(create_index_sql) %}\n    {% endif %}\n  {% endfor %}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.get_create_index_sql",
+              "macro.dbt.run_query"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.136665
+        },
+        "macro.dbt.make_intermediate_relation": {
+          "name": "make_intermediate_relation",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/adapters/relation.sql",
+          "original_file_path": "macros/adapters/relation.sql",
+          "unique_id": "macro.dbt.make_intermediate_relation",
+          "macro_sql": "{% macro make_intermediate_relation(base_relation, suffix='__dbt_tmp') %}\n  {{ return(adapter.dispatch('make_intermediate_relation', 'dbt')(base_relation, suffix)) }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.default__make_intermediate_relation"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.14022
+        },
+        "macro.dbt.default__make_intermediate_relation": {
+          "name": "default__make_intermediate_relation",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/adapters/relation.sql",
+          "original_file_path": "macros/adapters/relation.sql",
+          "unique_id": "macro.dbt.default__make_intermediate_relation",
+          "macro_sql": "{% macro default__make_intermediate_relation(base_relation, suffix) %}\n    {{ return(default__make_temp_relation(base_relation, suffix)) }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.default__make_temp_relation"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.1403918
+        },
+        "macro.dbt.make_temp_relation": {
+          "name": "make_temp_relation",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/adapters/relation.sql",
+          "original_file_path": "macros/adapters/relation.sql",
+          "unique_id": "macro.dbt.make_temp_relation",
+          "macro_sql": "{% macro make_temp_relation(base_relation, suffix='__dbt_tmp') %}\n  {{ return(adapter.dispatch('make_temp_relation', 'dbt')(base_relation, suffix)) }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt_duckdb.duckdb__make_temp_relation"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.140617
+        },
+        "macro.dbt.default__make_temp_relation": {
+          "name": "default__make_temp_relation",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/adapters/relation.sql",
+          "original_file_path": "macros/adapters/relation.sql",
+          "unique_id": "macro.dbt.default__make_temp_relation",
+          "macro_sql": "{% macro default__make_temp_relation(base_relation, suffix) %}\n    {%- set temp_identifier = base_relation.identifier ~ suffix -%}\n    {%- set temp_relation = base_relation.incorporate(\n                                path={\"identifier\": temp_identifier}) -%}\n\n    {{ return(temp_relation) }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": []
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.140904
+        },
+        "macro.dbt.make_backup_relation": {
+          "name": "make_backup_relation",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/adapters/relation.sql",
+          "original_file_path": "macros/adapters/relation.sql",
+          "unique_id": "macro.dbt.make_backup_relation",
+          "macro_sql": "{% macro make_backup_relation(base_relation, backup_relation_type, suffix='__dbt_backup') %}\n    {{ return(adapter.dispatch('make_backup_relation', 'dbt')(base_relation, backup_relation_type, suffix)) }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.default__make_backup_relation"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.141141
+        },
+        "macro.dbt.default__make_backup_relation": {
+          "name": "default__make_backup_relation",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/adapters/relation.sql",
+          "original_file_path": "macros/adapters/relation.sql",
+          "unique_id": "macro.dbt.default__make_backup_relation",
+          "macro_sql": "{% macro default__make_backup_relation(base_relation, backup_relation_type, suffix) %}\n    {%- set backup_identifier = base_relation.identifier ~ suffix -%}\n    {%- set backup_relation = base_relation.incorporate(\n                                  path={\"identifier\": backup_identifier},\n                                  type=backup_relation_type\n    ) -%}\n    {{ return(backup_relation) }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": []
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.141548
+        },
+        "macro.dbt.drop_relation": {
+          "name": "drop_relation",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/adapters/relation.sql",
+          "original_file_path": "macros/adapters/relation.sql",
+          "unique_id": "macro.dbt.drop_relation",
+          "macro_sql": "{% macro drop_relation(relation) -%}\n  {{ return(adapter.dispatch('drop_relation', 'dbt')(relation)) }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt_duckdb.duckdb__drop_relation"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.141799
+        },
+        "macro.dbt.default__drop_relation": {
+          "name": "default__drop_relation",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/adapters/relation.sql",
+          "original_file_path": "macros/adapters/relation.sql",
+          "unique_id": "macro.dbt.default__drop_relation",
+          "macro_sql": "{% macro default__drop_relation(relation) -%}\n  {% call statement('drop_relation', auto_begin=False) -%}\n    drop {{ relation.type }} if exists {{ relation }} cascade\n  {%- endcall %}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.statement"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.14202
+        },
+        "macro.dbt.truncate_relation": {
+          "name": "truncate_relation",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/adapters/relation.sql",
+          "original_file_path": "macros/adapters/relation.sql",
+          "unique_id": "macro.dbt.truncate_relation",
+          "macro_sql": "{% macro truncate_relation(relation) -%}\n  {{ return(adapter.dispatch('truncate_relation', 'dbt')(relation)) }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt_duckdb.duckdb__truncate_relation"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.1422012
+        },
+        "macro.dbt.default__truncate_relation": {
+          "name": "default__truncate_relation",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/adapters/relation.sql",
+          "original_file_path": "macros/adapters/relation.sql",
+          "unique_id": "macro.dbt.default__truncate_relation",
+          "macro_sql": "{% macro default__truncate_relation(relation) -%}\n  {% call statement('truncate_relation') -%}\n    truncate table {{ relation }}\n  {%- endcall %}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.statement"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.142354
+        },
+        "macro.dbt.rename_relation": {
+          "name": "rename_relation",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/adapters/relation.sql",
+          "original_file_path": "macros/adapters/relation.sql",
+          "unique_id": "macro.dbt.rename_relation",
+          "macro_sql": "{% macro rename_relation(from_relation, to_relation) -%}\n  {{ return(adapter.dispatch('rename_relation', 'dbt')(from_relation, to_relation)) }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt_duckdb.duckdb__rename_relation"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.142555
+        },
+        "macro.dbt.default__rename_relation": {
+          "name": "default__rename_relation",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/adapters/relation.sql",
+          "original_file_path": "macros/adapters/relation.sql",
+          "unique_id": "macro.dbt.default__rename_relation",
+          "macro_sql": "{% macro default__rename_relation(from_relation, to_relation) -%}\n  {% set target_name = adapter.quote_as_configured(to_relation.identifier, 'identifier') %}\n  {% call statement('rename_relation') -%}\n    alter table {{ from_relation }} rename to {{ target_name }}\n  {%- endcall %}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.statement"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.142842
+        },
+        "macro.dbt.get_or_create_relation": {
+          "name": "get_or_create_relation",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/adapters/relation.sql",
+          "original_file_path": "macros/adapters/relation.sql",
+          "unique_id": "macro.dbt.get_or_create_relation",
+          "macro_sql": "{% macro get_or_create_relation(database, schema, identifier, type) -%}\n  {{ return(adapter.dispatch('get_or_create_relation', 'dbt')(database, schema, identifier, type)) }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.default__get_or_create_relation"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.1431758
+        },
+        "macro.dbt.default__get_or_create_relation": {
+          "name": "default__get_or_create_relation",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/adapters/relation.sql",
+          "original_file_path": "macros/adapters/relation.sql",
+          "unique_id": "macro.dbt.default__get_or_create_relation",
+          "macro_sql": "{% macro default__get_or_create_relation(database, schema, identifier, type) %}\n  {%- set target_relation = adapter.get_relation(database=database, schema=schema, identifier=identifier) %}\n\n  {% if target_relation %}\n    {% do return([true, target_relation]) %}\n  {% endif %}\n\n  {%- set new_relation = api.Relation.create(\n      database=database,\n      schema=schema,\n      identifier=identifier,\n      type=type\n  ) -%}\n  {% do return([false, new_relation]) %}\n{% endmacro %}",
+          "depends_on": {
+            "macros": []
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.14372
+        },
+        "macro.dbt.load_cached_relation": {
+          "name": "load_cached_relation",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/adapters/relation.sql",
+          "original_file_path": "macros/adapters/relation.sql",
+          "unique_id": "macro.dbt.load_cached_relation",
+          "macro_sql": "{% macro load_cached_relation(relation) %}\n  {% do return(adapter.get_relation(\n    database=relation.database,\n    schema=relation.schema,\n    identifier=relation.identifier\n  )) -%}\n{% endmacro %}",
+          "depends_on": {
+            "macros": []
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.1439402
+        },
+        "macro.dbt.load_relation": {
+          "name": "load_relation",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/adapters/relation.sql",
+          "original_file_path": "macros/adapters/relation.sql",
+          "unique_id": "macro.dbt.load_relation",
+          "macro_sql": "{% macro load_relation(relation) %}\n    {{ return(load_cached_relation(relation)) }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.load_cached_relation"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.1440718
+        },
+        "macro.dbt.drop_relation_if_exists": {
+          "name": "drop_relation_if_exists",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/adapters/relation.sql",
+          "original_file_path": "macros/adapters/relation.sql",
+          "unique_id": "macro.dbt.drop_relation_if_exists",
+          "macro_sql": "{% macro drop_relation_if_exists(relation) %}\n  {% if relation is not none %}\n    {{ adapter.drop_relation(relation) }}\n  {% endif %}\n{% endmacro %}",
+          "depends_on": {
+            "macros": []
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.1442611
+        },
+        "macro.dbt.collect_freshness": {
+          "name": "collect_freshness",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/adapters/freshness.sql",
+          "original_file_path": "macros/adapters/freshness.sql",
+          "unique_id": "macro.dbt.collect_freshness",
+          "macro_sql": "{% macro collect_freshness(source, loaded_at_field, filter) %}\n  {{ return(adapter.dispatch('collect_freshness', 'dbt')(source, loaded_at_field, filter))}}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.default__collect_freshness"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.1447601
+        },
+        "macro.dbt.default__collect_freshness": {
+          "name": "default__collect_freshness",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/adapters/freshness.sql",
+          "original_file_path": "macros/adapters/freshness.sql",
+          "unique_id": "macro.dbt.default__collect_freshness",
+          "macro_sql": "{% macro default__collect_freshness(source, loaded_at_field, filter) %}\n  {% call statement('collect_freshness', fetch_result=True, auto_begin=False) -%}\n    select\n      max({{ loaded_at_field }}) as max_loaded_at,\n      {{ current_timestamp() }} as snapshotted_at\n    from {{ source }}\n    {% if filter %}\n    where {{ filter }}\n    {% endif %}\n  {% endcall %}\n  {{ return(load_result('collect_freshness')) }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.statement",
+              "macro.dbt.current_timestamp"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.145154
+        },
+        "macro.dbt.copy_grants": {
+          "name": "copy_grants",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/adapters/apply_grants.sql",
+          "original_file_path": "macros/adapters/apply_grants.sql",
+          "unique_id": "macro.dbt.copy_grants",
+          "macro_sql": "{% macro copy_grants() %}\n    {{ return(adapter.dispatch('copy_grants', 'dbt')()) }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.default__copy_grants"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.14688
+        },
+        "macro.dbt.default__copy_grants": {
+          "name": "default__copy_grants",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/adapters/apply_grants.sql",
+          "original_file_path": "macros/adapters/apply_grants.sql",
+          "unique_id": "macro.dbt.default__copy_grants",
+          "macro_sql": "{% macro default__copy_grants() %}\n    {{ return(True) }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": []
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.1469939
+        },
+        "macro.dbt.support_multiple_grantees_per_dcl_statement": {
+          "name": "support_multiple_grantees_per_dcl_statement",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/adapters/apply_grants.sql",
+          "original_file_path": "macros/adapters/apply_grants.sql",
+          "unique_id": "macro.dbt.support_multiple_grantees_per_dcl_statement",
+          "macro_sql": "{% macro support_multiple_grantees_per_dcl_statement() %}\n    {{ return(adapter.dispatch('support_multiple_grantees_per_dcl_statement', 'dbt')()) }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.default__support_multiple_grantees_per_dcl_statement"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.1471539
+        },
+        "macro.dbt.default__support_multiple_grantees_per_dcl_statement": {
+          "name": "default__support_multiple_grantees_per_dcl_statement",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/adapters/apply_grants.sql",
+          "original_file_path": "macros/adapters/apply_grants.sql",
+          "unique_id": "macro.dbt.default__support_multiple_grantees_per_dcl_statement",
+          "macro_sql": "\n\n{%- macro default__support_multiple_grantees_per_dcl_statement() -%}\n    {{ return(True) }}\n{%- endmacro -%}\n\n\n",
+          "depends_on": {
+            "macros": []
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.1472619
+        },
+        "macro.dbt.should_revoke": {
+          "name": "should_revoke",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/adapters/apply_grants.sql",
+          "original_file_path": "macros/adapters/apply_grants.sql",
+          "unique_id": "macro.dbt.should_revoke",
+          "macro_sql": "{% macro should_revoke(existing_relation, full_refresh_mode=True) %}\n\n    {% if not existing_relation %}\n        {#-- The table doesn't already exist, so no grants to copy over --#}\n        {{ return(False) }}\n    {% elif full_refresh_mode %}\n        {#-- The object is being REPLACED -- whether grants are copied over depends on the value of user config --#}\n        {{ return(copy_grants()) }}\n    {% else %}\n        {#-- The table is being merged/upserted/inserted -- grants will be carried over --#}\n        {{ return(True) }}\n    {% endif %}\n\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.copy_grants"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.1476119
+        },
+        "macro.dbt.get_show_grant_sql": {
+          "name": "get_show_grant_sql",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/adapters/apply_grants.sql",
+          "original_file_path": "macros/adapters/apply_grants.sql",
+          "unique_id": "macro.dbt.get_show_grant_sql",
+          "macro_sql": "{% macro get_show_grant_sql(relation) %}\n    {{ return(adapter.dispatch(\"get_show_grant_sql\", \"dbt\")(relation)) }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.default__get_show_grant_sql"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.1477928
+        },
+        "macro.dbt.default__get_show_grant_sql": {
+          "name": "default__get_show_grant_sql",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/adapters/apply_grants.sql",
+          "original_file_path": "macros/adapters/apply_grants.sql",
+          "unique_id": "macro.dbt.default__get_show_grant_sql",
+          "macro_sql": "{% macro default__get_show_grant_sql(relation) %}\n    show grants on {{ relation }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": []
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.1478882
+        },
+        "macro.dbt.get_grant_sql": {
+          "name": "get_grant_sql",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/adapters/apply_grants.sql",
+          "original_file_path": "macros/adapters/apply_grants.sql",
+          "unique_id": "macro.dbt.get_grant_sql",
+          "macro_sql": "{% macro get_grant_sql(relation, privilege, grantees) %}\n    {{ return(adapter.dispatch('get_grant_sql', 'dbt')(relation, privilege, grantees)) }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.default__get_grant_sql"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.148101
+        },
+        "macro.dbt.default__get_grant_sql": {
+          "name": "default__get_grant_sql",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/adapters/apply_grants.sql",
+          "original_file_path": "macros/adapters/apply_grants.sql",
+          "unique_id": "macro.dbt.default__get_grant_sql",
+          "macro_sql": "\n\n{%- macro default__get_grant_sql(relation, privilege, grantees) -%}\n    grant {{ privilege }} on {{ relation }} to {{ grantees | join(', ') }}\n{%- endmacro -%}\n\n\n",
+          "depends_on": {
+            "macros": []
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.148294
+        },
+        "macro.dbt.get_revoke_sql": {
+          "name": "get_revoke_sql",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/adapters/apply_grants.sql",
+          "original_file_path": "macros/adapters/apply_grants.sql",
+          "unique_id": "macro.dbt.get_revoke_sql",
+          "macro_sql": "{% macro get_revoke_sql(relation, privilege, grantees) %}\n    {{ return(adapter.dispatch('get_revoke_sql', 'dbt')(relation, privilege, grantees)) }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.default__get_revoke_sql"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.1485162
+        },
+        "macro.dbt.default__get_revoke_sql": {
+          "name": "default__get_revoke_sql",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/adapters/apply_grants.sql",
+          "original_file_path": "macros/adapters/apply_grants.sql",
+          "unique_id": "macro.dbt.default__get_revoke_sql",
+          "macro_sql": "\n\n{%- macro default__get_revoke_sql(relation, privilege, grantees) -%}\n    revoke {{ privilege }} on {{ relation }} from {{ grantees | join(', ') }}\n{%- endmacro -%}\n\n\n",
+          "depends_on": {
+            "macros": []
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.148698
+        },
+        "macro.dbt.get_dcl_statement_list": {
+          "name": "get_dcl_statement_list",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/adapters/apply_grants.sql",
+          "original_file_path": "macros/adapters/apply_grants.sql",
+          "unique_id": "macro.dbt.get_dcl_statement_list",
+          "macro_sql": "{% macro get_dcl_statement_list(relation, grant_config, get_dcl_macro) %}\n    {{ return(adapter.dispatch('get_dcl_statement_list', 'dbt')(relation, grant_config, get_dcl_macro)) }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.default__get_dcl_statement_list"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.1489239
+        },
+        "macro.dbt.default__get_dcl_statement_list": {
+          "name": "default__get_dcl_statement_list",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/adapters/apply_grants.sql",
+          "original_file_path": "macros/adapters/apply_grants.sql",
+          "unique_id": "macro.dbt.default__get_dcl_statement_list",
+          "macro_sql": "\n\n{%- macro default__get_dcl_statement_list(relation, grant_config, get_dcl_macro) -%}\n    {#\n      -- Unpack grant_config into specific privileges and the set of users who need them granted/revoked.\n      -- Depending on whether this database supports multiple grantees per statement, pass in the list of\n      -- all grantees per privilege, or (if not) template one statement per privilege-grantee pair.\n      -- `get_dcl_macro` will be either `get_grant_sql` or `get_revoke_sql`\n    #}\n    {%- set dcl_statements = [] -%}\n    {%- for privilege, grantees in grant_config.items() %}\n        {%- if support_multiple_grantees_per_dcl_statement() and grantees -%}\n          {%- set dcl = get_dcl_macro(relation, privilege, grantees) -%}\n          {%- do dcl_statements.append(dcl) -%}\n        {%- else -%}\n          {%- for grantee in grantees -%}\n              {% set dcl = get_dcl_macro(relation, privilege, [grantee]) %}\n              {%- do dcl_statements.append(dcl) -%}\n          {% endfor -%}\n        {%- endif -%}\n    {%- endfor -%}\n    {{ return(dcl_statements) }}\n{%- endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.support_multiple_grantees_per_dcl_statement"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.149632
+        },
+        "macro.dbt.call_dcl_statements": {
+          "name": "call_dcl_statements",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/adapters/apply_grants.sql",
+          "original_file_path": "macros/adapters/apply_grants.sql",
+          "unique_id": "macro.dbt.call_dcl_statements",
+          "macro_sql": "{% macro call_dcl_statements(dcl_statement_list) %}\n    {{ return(adapter.dispatch(\"call_dcl_statements\", \"dbt\")(dcl_statement_list)) }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.default__call_dcl_statements"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.1498141
+        },
+        "macro.dbt.default__call_dcl_statements": {
+          "name": "default__call_dcl_statements",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/adapters/apply_grants.sql",
+          "original_file_path": "macros/adapters/apply_grants.sql",
+          "unique_id": "macro.dbt.default__call_dcl_statements",
+          "macro_sql": "{% macro default__call_dcl_statements(dcl_statement_list) %}\n    {#\n      -- By default, supply all grant + revoke statements in a single semicolon-separated block,\n      -- so that they're all processed together.\n\n      -- Some databases do not support this. Those adapters will need to override this macro\n      -- to run each statement individually.\n    #}\n    {% call statement('grants') %}\n        {% for dcl_statement in dcl_statement_list %}\n            {{ dcl_statement }};\n        {% endfor %}\n    {% endcall %}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.statement"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.1500459
+        },
+        "macro.dbt.apply_grants": {
+          "name": "apply_grants",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/adapters/apply_grants.sql",
+          "original_file_path": "macros/adapters/apply_grants.sql",
+          "unique_id": "macro.dbt.apply_grants",
+          "macro_sql": "{% macro apply_grants(relation, grant_config, should_revoke) %}\n    {{ return(adapter.dispatch(\"apply_grants\", \"dbt\")(relation, grant_config, should_revoke)) }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.default__apply_grants"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.1503308
+        },
+        "macro.dbt.default__apply_grants": {
+          "name": "default__apply_grants",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/adapters/apply_grants.sql",
+          "original_file_path": "macros/adapters/apply_grants.sql",
+          "unique_id": "macro.dbt.default__apply_grants",
+          "macro_sql": "{% macro default__apply_grants(relation, grant_config, should_revoke=True) %}\n    {#-- If grant_config is {} or None, this is a no-op --#}\n    {% if grant_config %}\n        {% if should_revoke %}\n            {#-- We think previous grants may have carried over --#}\n            {#-- Show current grants and calculate diffs --#}\n            {% set current_grants_table = run_query(get_show_grant_sql(relation)) %}\n            {% set current_grants_dict = adapter.standardize_grants_dict(current_grants_table) %}\n            {% set needs_granting = diff_of_two_dicts(grant_config, current_grants_dict) %}\n            {% set needs_revoking = diff_of_two_dicts(current_grants_dict, grant_config) %}\n            {% if not (needs_granting or needs_revoking) %}\n                {{ log('On ' ~ relation ~': All grants are in place, no revocation or granting needed.')}}\n            {% endif %}\n        {% else %}\n            {#-- We don't think there's any chance of previous grants having carried over. --#}\n            {#-- Jump straight to granting what the user has configured. --#}\n            {% set needs_revoking = {} %}\n            {% set needs_granting = grant_config %}\n        {% endif %}\n        {% if needs_granting or needs_revoking %}\n            {% set revoke_statement_list = get_dcl_statement_list(relation, needs_revoking, get_revoke_sql) %}\n            {% set grant_statement_list = get_dcl_statement_list(relation, needs_granting, get_grant_sql) %}\n            {% set dcl_statement_list = revoke_statement_list + grant_statement_list %}\n            {% if dcl_statement_list %}\n                {{ call_dcl_statements(dcl_statement_list) }}\n            {% endif %}\n        {% endif %}\n    {% endif %}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.run_query",
+              "macro.dbt.get_show_grant_sql",
+              "macro.dbt.get_dcl_statement_list",
+              "macro.dbt.call_dcl_statements"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.151485
+        },
+        "macro.dbt.alter_column_comment": {
+          "name": "alter_column_comment",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/adapters/persist_docs.sql",
+          "original_file_path": "macros/adapters/persist_docs.sql",
+          "unique_id": "macro.dbt.alter_column_comment",
+          "macro_sql": "{% macro alter_column_comment(relation, column_dict) -%}\n  {{ return(adapter.dispatch('alter_column_comment', 'dbt')(relation, column_dict)) }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.default__alter_column_comment"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.1521769
+        },
+        "macro.dbt.default__alter_column_comment": {
+          "name": "default__alter_column_comment",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/adapters/persist_docs.sql",
+          "original_file_path": "macros/adapters/persist_docs.sql",
+          "unique_id": "macro.dbt.default__alter_column_comment",
+          "macro_sql": "{% macro default__alter_column_comment(relation, column_dict) -%}\n  {{ exceptions.raise_not_implemented(\n    'alter_column_comment macro not implemented for adapter '+adapter.type()) }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": []
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.1523478
+        },
+        "macro.dbt.alter_relation_comment": {
+          "name": "alter_relation_comment",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/adapters/persist_docs.sql",
+          "original_file_path": "macros/adapters/persist_docs.sql",
+          "unique_id": "macro.dbt.alter_relation_comment",
+          "macro_sql": "{% macro alter_relation_comment(relation, relation_comment) -%}\n  {{ return(adapter.dispatch('alter_relation_comment', 'dbt')(relation, relation_comment)) }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.default__alter_relation_comment"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.1525471
+        },
+        "macro.dbt.default__alter_relation_comment": {
+          "name": "default__alter_relation_comment",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/adapters/persist_docs.sql",
+          "original_file_path": "macros/adapters/persist_docs.sql",
+          "unique_id": "macro.dbt.default__alter_relation_comment",
+          "macro_sql": "{% macro default__alter_relation_comment(relation, relation_comment) -%}\n  {{ exceptions.raise_not_implemented(\n    'alter_relation_comment macro not implemented for adapter '+adapter.type()) }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": []
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.152711
+        },
+        "macro.dbt.persist_docs": {
+          "name": "persist_docs",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/adapters/persist_docs.sql",
+          "original_file_path": "macros/adapters/persist_docs.sql",
+          "unique_id": "macro.dbt.persist_docs",
+          "macro_sql": "{% macro persist_docs(relation, model, for_relation=true, for_columns=true) -%}\n  {{ return(adapter.dispatch('persist_docs', 'dbt')(relation, model, for_relation, for_columns)) }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.default__persist_docs"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.152971
+        },
+        "macro.dbt.default__persist_docs": {
+          "name": "default__persist_docs",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/adapters/persist_docs.sql",
+          "original_file_path": "macros/adapters/persist_docs.sql",
+          "unique_id": "macro.dbt.default__persist_docs",
+          "macro_sql": "{% macro default__persist_docs(relation, model, for_relation, for_columns) -%}\n  {% if for_relation and config.persist_relation_docs() and model.description %}\n    {% do run_query(alter_relation_comment(relation, model.description)) %}\n  {% endif %}\n\n  {% if for_columns and config.persist_column_docs() and model.columns %}\n    {% do run_query(alter_column_comment(relation, model.columns)) %}\n  {% endif %}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.run_query",
+              "macro.dbt.alter_relation_comment",
+              "macro.dbt.alter_column_comment"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.1534562
+        },
+        "macro.dbt.get_catalog": {
+          "name": "get_catalog",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/adapters/metadata.sql",
+          "original_file_path": "macros/adapters/metadata.sql",
+          "unique_id": "macro.dbt.get_catalog",
+          "macro_sql": "{% macro get_catalog(information_schema, schemas) -%}\n  {{ return(adapter.dispatch('get_catalog', 'dbt')(information_schema, schemas)) }}\n{%- endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt_duckdb.duckdb__get_catalog"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.154967
+        },
+        "macro.dbt.default__get_catalog": {
+          "name": "default__get_catalog",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/adapters/metadata.sql",
+          "original_file_path": "macros/adapters/metadata.sql",
+          "unique_id": "macro.dbt.default__get_catalog",
+          "macro_sql": "{% macro default__get_catalog(information_schema, schemas) -%}\n\n  {% set typename = adapter.type() %}\n  {% set msg -%}\n    get_catalog not implemented for {{ typename }}\n  {%- endset %}\n\n  {{ exceptions.raise_compiler_error(msg) }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": []
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.15522
+        },
+        "macro.dbt.information_schema_name": {
+          "name": "information_schema_name",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/adapters/metadata.sql",
+          "original_file_path": "macros/adapters/metadata.sql",
+          "unique_id": "macro.dbt.information_schema_name",
+          "macro_sql": "{% macro information_schema_name(database) %}\n  {{ return(adapter.dispatch('information_schema_name', 'dbt')(database)) }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.default__information_schema_name"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.155396
+        },
+        "macro.dbt.default__information_schema_name": {
+          "name": "default__information_schema_name",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/adapters/metadata.sql",
+          "original_file_path": "macros/adapters/metadata.sql",
+          "unique_id": "macro.dbt.default__information_schema_name",
+          "macro_sql": "{% macro default__information_schema_name(database) -%}\n  {%- if database -%}\n    {{ database }}.INFORMATION_SCHEMA\n  {%- else -%}\n    INFORMATION_SCHEMA\n  {%- endif -%}\n{%- endmacro %}",
+          "depends_on": {
+            "macros": []
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.155543
+        },
+        "macro.dbt.list_schemas": {
+          "name": "list_schemas",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/adapters/metadata.sql",
+          "original_file_path": "macros/adapters/metadata.sql",
+          "unique_id": "macro.dbt.list_schemas",
+          "macro_sql": "{% macro list_schemas(database) -%}\n  {{ return(adapter.dispatch('list_schemas', 'dbt')(database)) }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt_duckdb.duckdb__list_schemas"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.155714
+        },
+        "macro.dbt.default__list_schemas": {
+          "name": "default__list_schemas",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/adapters/metadata.sql",
+          "original_file_path": "macros/adapters/metadata.sql",
+          "unique_id": "macro.dbt.default__list_schemas",
+          "macro_sql": "{% macro default__list_schemas(database) -%}\n  {% set sql %}\n    select distinct schema_name\n    from {{ information_schema_name(database) }}.SCHEMATA\n    where catalog_name ilike '{{ database }}'\n  {% endset %}\n  {{ return(run_query(sql)) }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.information_schema_name",
+              "macro.dbt.run_query"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.155945
+        },
+        "macro.dbt.check_schema_exists": {
+          "name": "check_schema_exists",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/adapters/metadata.sql",
+          "original_file_path": "macros/adapters/metadata.sql",
+          "unique_id": "macro.dbt.check_schema_exists",
+          "macro_sql": "{% macro check_schema_exists(information_schema, schema) -%}\n  {{ return(adapter.dispatch('check_schema_exists', 'dbt')(information_schema, schema)) }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt_duckdb.duckdb__check_schema_exists"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.156168
+        },
+        "macro.dbt.default__check_schema_exists": {
+          "name": "default__check_schema_exists",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/adapters/metadata.sql",
+          "original_file_path": "macros/adapters/metadata.sql",
+          "unique_id": "macro.dbt.default__check_schema_exists",
+          "macro_sql": "{% macro default__check_schema_exists(information_schema, schema) -%}\n  {% set sql -%}\n        select count(*)\n        from {{ information_schema.replace(information_schema_view='SCHEMATA') }}\n        where catalog_name='{{ information_schema.database }}'\n          and schema_name='{{ schema }}'\n  {%- endset %}\n  {{ return(run_query(sql)) }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.replace",
+              "macro.dbt.run_query"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.1564732
+        },
+        "macro.dbt.list_relations_without_caching": {
+          "name": "list_relations_without_caching",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/adapters/metadata.sql",
+          "original_file_path": "macros/adapters/metadata.sql",
+          "unique_id": "macro.dbt.list_relations_without_caching",
+          "macro_sql": "{% macro list_relations_without_caching(schema_relation) %}\n  {{ return(adapter.dispatch('list_relations_without_caching', 'dbt')(schema_relation)) }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt_duckdb.duckdb__list_relations_without_caching"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.15665
+        },
+        "macro.dbt.default__list_relations_without_caching": {
+          "name": "default__list_relations_without_caching",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/adapters/metadata.sql",
+          "original_file_path": "macros/adapters/metadata.sql",
+          "unique_id": "macro.dbt.default__list_relations_without_caching",
+          "macro_sql": "{% macro default__list_relations_without_caching(schema_relation) %}\n  {{ exceptions.raise_not_implemented(\n    'list_relations_without_caching macro not implemented for adapter '+adapter.type()) }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": []
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.156801
+        },
+        "macro.dbt.get_columns_in_relation": {
+          "name": "get_columns_in_relation",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/adapters/columns.sql",
+          "original_file_path": "macros/adapters/columns.sql",
+          "unique_id": "macro.dbt.get_columns_in_relation",
+          "macro_sql": "{% macro get_columns_in_relation(relation) -%}\n  {{ return(adapter.dispatch('get_columns_in_relation', 'dbt')(relation)) }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt_duckdb.duckdb__get_columns_in_relation"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.158918
+        },
+        "macro.dbt.default__get_columns_in_relation": {
+          "name": "default__get_columns_in_relation",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/adapters/columns.sql",
+          "original_file_path": "macros/adapters/columns.sql",
+          "unique_id": "macro.dbt.default__get_columns_in_relation",
+          "macro_sql": "{% macro default__get_columns_in_relation(relation) -%}\n  {{ exceptions.raise_not_implemented(\n    'get_columns_in_relation macro not implemented for adapter '+adapter.type()) }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": []
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.159154
+        },
+        "macro.dbt.sql_convert_columns_in_relation": {
+          "name": "sql_convert_columns_in_relation",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/adapters/columns.sql",
+          "original_file_path": "macros/adapters/columns.sql",
+          "unique_id": "macro.dbt.sql_convert_columns_in_relation",
+          "macro_sql": "{% macro sql_convert_columns_in_relation(table) -%}\n  {% set columns = [] %}\n  {% for row in table %}\n    {% do columns.append(api.Column(*row)) %}\n  {% endfor %}\n  {{ return(columns) }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": []
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.1594481
+        },
+        "macro.dbt.get_empty_subquery_sql": {
+          "name": "get_empty_subquery_sql",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/adapters/columns.sql",
+          "original_file_path": "macros/adapters/columns.sql",
+          "unique_id": "macro.dbt.get_empty_subquery_sql",
+          "macro_sql": "{% macro get_empty_subquery_sql(select_sql) -%}\n  {{ return(adapter.dispatch('get_empty_subquery_sql', 'dbt')(select_sql)) }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.default__get_empty_subquery_sql"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.159623
+        },
+        "macro.dbt.default__get_empty_subquery_sql": {
+          "name": "default__get_empty_subquery_sql",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/adapters/columns.sql",
+          "original_file_path": "macros/adapters/columns.sql",
+          "unique_id": "macro.dbt.default__get_empty_subquery_sql",
+          "macro_sql": "{% macro default__get_empty_subquery_sql(select_sql) %}\n    select * from (\n        {{ select_sql }}\n    ) as __dbt_sbq\n    where false\n    limit 0\n{% endmacro %}",
+          "depends_on": {
+            "macros": []
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.159723
+        },
+        "macro.dbt.get_empty_schema_sql": {
+          "name": "get_empty_schema_sql",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/adapters/columns.sql",
+          "original_file_path": "macros/adapters/columns.sql",
+          "unique_id": "macro.dbt.get_empty_schema_sql",
+          "macro_sql": "{% macro get_empty_schema_sql(columns) -%}\n  {{ return(adapter.dispatch('get_empty_schema_sql', 'dbt')(columns)) }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.default__get_empty_schema_sql"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.159894
+        },
+        "macro.dbt.default__get_empty_schema_sql": {
+          "name": "default__get_empty_schema_sql",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/adapters/columns.sql",
+          "original_file_path": "macros/adapters/columns.sql",
+          "unique_id": "macro.dbt.default__get_empty_schema_sql",
+          "macro_sql": "{% macro default__get_empty_schema_sql(columns) %}\n    {%- set col_err = [] -%}\n    select\n    {% for i in columns %}\n      {%- set col = columns[i] -%}\n      {%- if col['data_type'] is not defined -%}\n        {{ col_err.append(col['name']) }}\n      {%- endif -%}\n      cast(null as {{ col['data_type'] }}) as {{ col['name'] }}{{ \", \" if not loop.last }}\n    {%- endfor -%}\n    {%- if (col_err | length) > 0 -%}\n      {{ exceptions.column_type_missing(column_names=col_err) }}\n    {%- endif -%}\n{% endmacro %}",
+          "depends_on": {
+            "macros": []
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.1605172
+        },
+        "macro.dbt.get_column_schema_from_query": {
+          "name": "get_column_schema_from_query",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/adapters/columns.sql",
+          "original_file_path": "macros/adapters/columns.sql",
+          "unique_id": "macro.dbt.get_column_schema_from_query",
+          "macro_sql": "{% macro get_column_schema_from_query(select_sql) -%}\n    {% set columns = [] %}\n    {# -- Using an 'empty subquery' here to get the same schema as the given select_sql statement, without necessitating a data scan.#}\n    {% set sql = get_empty_subquery_sql(select_sql) %}\n    {% set column_schema = adapter.get_column_schema_from_query(sql) %}\n    {{ return(column_schema) }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.get_empty_subquery_sql"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.160814
+        },
+        "macro.dbt.get_columns_in_query": {
+          "name": "get_columns_in_query",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/adapters/columns.sql",
+          "original_file_path": "macros/adapters/columns.sql",
+          "unique_id": "macro.dbt.get_columns_in_query",
+          "macro_sql": "{% macro get_columns_in_query(select_sql) -%}\n  {{ return(adapter.dispatch('get_columns_in_query', 'dbt')(select_sql)) }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.default__get_columns_in_query"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.160984
+        },
+        "macro.dbt.default__get_columns_in_query": {
+          "name": "default__get_columns_in_query",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/adapters/columns.sql",
+          "original_file_path": "macros/adapters/columns.sql",
+          "unique_id": "macro.dbt.default__get_columns_in_query",
+          "macro_sql": "{% macro default__get_columns_in_query(select_sql) %}\n    {% call statement('get_columns_in_query', fetch_result=True, auto_begin=False) -%}\n        {{ get_empty_subquery_sql(select_sql) }}\n    {% endcall %}\n    {{ return(load_result('get_columns_in_query').table.columns | map(attribute='name') | list) }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.statement",
+              "macro.dbt.get_empty_subquery_sql"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.16132
+        },
+        "macro.dbt.alter_column_type": {
+          "name": "alter_column_type",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/adapters/columns.sql",
+          "original_file_path": "macros/adapters/columns.sql",
+          "unique_id": "macro.dbt.alter_column_type",
+          "macro_sql": "{% macro alter_column_type(relation, column_name, new_column_type) -%}\n  {{ return(adapter.dispatch('alter_column_type', 'dbt')(relation, column_name, new_column_type)) }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.default__alter_column_type"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.1615412
+        },
+        "macro.dbt.default__alter_column_type": {
+          "name": "default__alter_column_type",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/adapters/columns.sql",
+          "original_file_path": "macros/adapters/columns.sql",
+          "unique_id": "macro.dbt.default__alter_column_type",
+          "macro_sql": "{% macro default__alter_column_type(relation, column_name, new_column_type) -%}\n  {#\n    1. Create a new column (w/ temp name and correct type)\n    2. Copy data over to it\n    3. Drop the existing column (cascade!)\n    4. Rename the new column to existing column\n  #}\n  {%- set tmp_column = column_name + \"__dbt_alter\" -%}\n\n  {% call statement('alter_column_type') %}\n    alter table {{ relation }} add column {{ adapter.quote(tmp_column) }} {{ new_column_type }};\n    update {{ relation }} set {{ adapter.quote(tmp_column) }} = {{ adapter.quote(column_name) }};\n    alter table {{ relation }} drop column {{ adapter.quote(column_name) }} cascade;\n    alter table {{ relation }} rename column {{ adapter.quote(tmp_column) }} to {{ adapter.quote(column_name) }}\n  {% endcall %}\n\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.statement"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.162125
+        },
+        "macro.dbt.alter_relation_add_remove_columns": {
+          "name": "alter_relation_add_remove_columns",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/adapters/columns.sql",
+          "original_file_path": "macros/adapters/columns.sql",
+          "unique_id": "macro.dbt.alter_relation_add_remove_columns",
+          "macro_sql": "{% macro alter_relation_add_remove_columns(relation, add_columns = none, remove_columns = none) -%}\n  {{ return(adapter.dispatch('alter_relation_add_remove_columns', 'dbt')(relation, add_columns, remove_columns)) }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.default__alter_relation_add_remove_columns"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.162375
+        },
+        "macro.dbt.default__alter_relation_add_remove_columns": {
+          "name": "default__alter_relation_add_remove_columns",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/adapters/columns.sql",
+          "original_file_path": "macros/adapters/columns.sql",
+          "unique_id": "macro.dbt.default__alter_relation_add_remove_columns",
+          "macro_sql": "{% macro default__alter_relation_add_remove_columns(relation, add_columns, remove_columns) %}\n\n  {% if add_columns is none %}\n    {% set add_columns = [] %}\n  {% endif %}\n  {% if remove_columns is none %}\n    {% set remove_columns = [] %}\n  {% endif %}\n\n  {% set sql -%}\n\n     alter {{ relation.type }} {{ relation }}\n\n            {% for column in add_columns %}\n               add column {{ column.name }} {{ column.data_type }}{{ ',' if not loop.last }}\n            {% endfor %}{{ ',' if add_columns and remove_columns }}\n\n            {% for column in remove_columns %}\n                drop column {{ column.name }}{{ ',' if not loop.last }}\n            {% endfor %}\n\n  {%- endset -%}\n\n  {% do run_query(sql) %}\n\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.run_query"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.163116
+        },
+        "macro.dbt.resolve_model_name": {
+          "name": "resolve_model_name",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/python_model/python.sql",
+          "original_file_path": "macros/python_model/python.sql",
+          "unique_id": "macro.dbt.resolve_model_name",
+          "macro_sql": "{% macro resolve_model_name(input_model_name) %}\n    {{ return(adapter.dispatch('resolve_model_name', 'dbt')(input_model_name)) }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.default__resolve_model_name"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.164803
+        },
+        "macro.dbt.default__resolve_model_name": {
+          "name": "default__resolve_model_name",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/python_model/python.sql",
+          "original_file_path": "macros/python_model/python.sql",
+          "unique_id": "macro.dbt.default__resolve_model_name",
+          "macro_sql": "\n\n{%- macro default__resolve_model_name(input_model_name) -%}\n    {{  input_model_name | string | replace('\"', '\\\"') }}\n{%- endmacro -%}\n\n",
+          "depends_on": {
+            "macros": []
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.164953
+        },
+        "macro.dbt.build_ref_function": {
+          "name": "build_ref_function",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/python_model/python.sql",
+          "original_file_path": "macros/python_model/python.sql",
+          "unique_id": "macro.dbt.build_ref_function",
+          "macro_sql": "{% macro build_ref_function(model) %}\n\n    {%- set ref_dict = {} -%}\n    {%- for _ref in model.refs -%}\n        {% set _ref_args = [_ref.get('package'), _ref['name']] if _ref.get('package') else [_ref['name'],] %}\n        {%- set resolved = ref(*_ref_args, v=_ref.get('version')) -%}\n        {%- if _ref.get('version') -%}\n            {% do _ref_args.extend([\"v\" ~ _ref['version']]) %}\n        {%- endif -%}\n       {%- do ref_dict.update({_ref_args | join('.'): resolve_model_name(resolved)}) -%}\n    {%- endfor -%}\n\ndef ref(*args, **kwargs):\n    refs = {{ ref_dict | tojson }}\n    key = '.'.join(args)\n    version = kwargs.get(\"v\") or kwargs.get(\"version\")\n    if version:\n        key += f\".v{version}\"\n    dbt_load_df_function = kwargs.get(\"dbt_load_df_function\")\n    return dbt_load_df_function(refs[key])\n\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.resolve_model_name"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.165733
+        },
+        "macro.dbt.build_source_function": {
+          "name": "build_source_function",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/python_model/python.sql",
+          "original_file_path": "macros/python_model/python.sql",
+          "unique_id": "macro.dbt.build_source_function",
+          "macro_sql": "{% macro build_source_function(model) %}\n\n    {%- set source_dict = {} -%}\n    {%- for _source in model.sources -%}\n        {%- set resolved = source(*_source) -%}\n        {%- do source_dict.update({_source | join('.'): resolve_model_name(resolved)}) -%}\n    {%- endfor -%}\n\ndef source(*args, dbt_load_df_function):\n    sources = {{ source_dict | tojson }}\n    key = '.'.join(args)\n    return dbt_load_df_function(sources[key])\n\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.resolve_model_name"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.166198
+        },
+        "macro.dbt.build_config_dict": {
+          "name": "build_config_dict",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/python_model/python.sql",
+          "original_file_path": "macros/python_model/python.sql",
+          "unique_id": "macro.dbt.build_config_dict",
+          "macro_sql": "{% macro build_config_dict(model) %}\n    {%- set config_dict = {} -%}\n    {% set config_dbt_used = zip(model.config.config_keys_used, model.config.config_keys_defaults) | list %}\n    {%- for key, default in config_dbt_used -%}\n        {# weird type testing with enum, would be much easier to write this logic in Python! #}\n        {%- if key == \"language\" -%}\n          {%- set value = \"python\" -%}\n        {%- endif -%}\n        {%- set value = model.config.get(key, default) -%}\n        {%- do config_dict.update({key: value}) -%}\n    {%- endfor -%}\nconfig_dict = {{ config_dict }}\n{% endmacro %}",
+          "depends_on": {
+            "macros": []
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.166751
+        },
+        "macro.dbt.py_script_postfix": {
+          "name": "py_script_postfix",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/python_model/python.sql",
+          "original_file_path": "macros/python_model/python.sql",
+          "unique_id": "macro.dbt.py_script_postfix",
+          "macro_sql": "{% macro py_script_postfix(model) %}\n# This part is user provided model code\n# you will need to copy the next section to run the code\n# COMMAND ----------\n# this part is dbt logic for get ref work, do not modify\n\n{{ build_ref_function(model ) }}\n{{ build_source_function(model ) }}\n{{ build_config_dict(model) }}\n\nclass config:\n    def __init__(self, *args, **kwargs):\n        pass\n\n    @staticmethod\n    def get(key, default=None):\n        return config_dict.get(key, default)\n\nclass this:\n    \"\"\"dbt.this() or dbt.this.identifier\"\"\"\n    database = \"{{ this.database }}\"\n    schema = \"{{ this.schema }}\"\n    identifier = \"{{ this.identifier }}\"\n    {% set this_relation_name = resolve_model_name(this) %}\n    def __repr__(self):\n        return '{{ this_relation_name  }}'\n\n\nclass dbtObj:\n    def __init__(self, load_df_function) -> None:\n        self.source = lambda *args: source(*args, dbt_load_df_function=load_df_function)\n        self.ref = lambda *args, **kwargs: ref(*args, **kwargs, dbt_load_df_function=load_df_function)\n        self.config = config\n        self.this = this()\n        self.is_incremental = {{ is_incremental() }}\n\n# COMMAND ----------\n{{py_script_comment()}}\n{% endmacro %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.build_ref_function",
+              "macro.dbt.build_source_function",
+              "macro.dbt.build_config_dict",
+              "macro.dbt.resolve_model_name",
+              "macro.dbt.is_incremental",
+              "macro.dbt.py_script_comment"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.1672058
+        },
+        "macro.dbt.py_script_comment": {
+          "name": "py_script_comment",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "macros/python_model/python.sql",
+          "original_file_path": "macros/python_model/python.sql",
+          "unique_id": "macro.dbt.py_script_comment",
+          "macro_sql": "{%macro py_script_comment()%}\n{%endmacro%}",
+          "depends_on": {
+            "macros": []
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.167277
+        },
+        "macro.dbt.test_unique": {
+          "name": "test_unique",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "tests/generic/builtin.sql",
+          "original_file_path": "tests/generic/builtin.sql",
+          "unique_id": "macro.dbt.test_unique",
+          "macro_sql": "{% test unique(model, column_name) %}\n    {% set macro = adapter.dispatch('test_unique', 'dbt') %}\n    {{ macro(model, column_name) }}\n{% endtest %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.default__test_unique"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.167781
+        },
+        "macro.dbt.test_not_null": {
+          "name": "test_not_null",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "tests/generic/builtin.sql",
+          "original_file_path": "tests/generic/builtin.sql",
+          "unique_id": "macro.dbt.test_not_null",
+          "macro_sql": "{% test not_null(model, column_name) %}\n    {% set macro = adapter.dispatch('test_not_null', 'dbt') %}\n    {{ macro(model, column_name) }}\n{% endtest %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.default__test_not_null"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.1679978
+        },
+        "macro.dbt.test_accepted_values": {
+          "name": "test_accepted_values",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "tests/generic/builtin.sql",
+          "original_file_path": "tests/generic/builtin.sql",
+          "unique_id": "macro.dbt.test_accepted_values",
+          "macro_sql": "{% test accepted_values(model, column_name, values, quote=True) %}\n    {% set macro = adapter.dispatch('test_accepted_values', 'dbt') %}\n    {{ macro(model, column_name, values, quote) }}\n{% endtest %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.default__test_accepted_values"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.168274
+        },
+        "macro.dbt.test_relationships": {
+          "name": "test_relationships",
+          "resource_type": "macro",
+          "package_name": "dbt",
+          "path": "tests/generic/builtin.sql",
+          "original_file_path": "tests/generic/builtin.sql",
+          "unique_id": "macro.dbt.test_relationships",
+          "macro_sql": "{% test relationships(model, column_name, to, field) %}\n    {% set macro = adapter.dispatch('test_relationships', 'dbt') %}\n    {{ macro(model, column_name, to, field) }}\n{% endtest %}",
+          "depends_on": {
+            "macros": [
+              "macro.dbt.default__test_relationships"
+            ]
+          },
+          "description": "",
+          "meta": {},
+          "docs": {
+            "show": true
+          },
+          "arguments": [],
+          "created_at": 1687240841.168533
+        }
+      },
+      "docs": {
+        "doc.jaffle_shop.__overview__": {
+          "name": "__overview__",
+          "resource_type": "doc",
+          "package_name": "jaffle_shop",
+          "path": "overview.md",
+          "original_file_path": "models/overview.md",
+          "unique_id": "doc.jaffle_shop.__overview__",
+          "block_contents": "## Data Documentation for Jaffle Shop\n\n`jaffle_shop` is a fictional ecommerce store.\n\nThis [dbt](https://www.getdbt.com/) project is for testing out code.\n\nThe source code can be found [here](https://github.com/clrcrl/jaffle_shop)."
+        },
+        "doc.jaffle_shop.orders_status": {
+          "name": "orders_status",
+          "resource_type": "doc",
+          "package_name": "jaffle_shop",
+          "path": "marts/docs.md",
+          "original_file_path": "models/marts/docs.md",
+          "unique_id": "doc.jaffle_shop.orders_status",
+          "block_contents": "Orders can be one of the following statuses:\n\n| status         | description                                                                                                            |\n|----------------|------------------------------------------------------------------------------------------------------------------------|\n| placed         | The order has been placed but has not yet left the warehouse                                                           |\n| shipped        | The order has ben shipped to the customer and is currently in transit                                                  |\n| completed      | The order has been received by the customer                                                                            |\n| return_pending | The customer has indicated that they would like to return the order, but it has not yet been received at the warehouse |\n| returned       | The order has been returned by the customer and received at the warehouse                                              |"
+        },
+        "doc.dbt.__overview__": {
+          "name": "__overview__",
+          "resource_type": "doc",
+          "package_name": "dbt",
+          "path": "overview.md",
+          "original_file_path": "docs/overview.md",
+          "unique_id": "doc.dbt.__overview__",
+          "block_contents": "### Welcome!\n\nWelcome to the auto-generated documentation for your dbt project!\n\n### Navigation\n\nYou can use the `Project` and `Database` navigation tabs on the left side of the window to explore the models\nin your project.\n\n#### Project Tab\nThe `Project` tab mirrors the directory structure of your dbt project. In this tab, you can see all of the\nmodels defined in your dbt project, as well as models imported from dbt packages.\n\n#### Database Tab\nThe `Database` tab also exposes your models, but in a format that looks more like a database explorer. This view\nshows relations (tables and views) grouped into database schemas. Note that ephemeral models are _not_ shown\nin this interface, as they do not exist in the database.\n\n### Graph Exploration\nYou can click the blue icon on the bottom-right corner of the page to view the lineage graph of your models.\n\nOn model pages, you'll see the immediate parents and children of the model you're exploring. By clicking the `Expand`\nbutton at the top-right of this lineage pane, you'll be able to see all of the models that are used to build,\nor are built from, the model you're exploring.\n\nOnce expanded, you'll be able to use the `--select` and `--exclude` model selection syntax to filter the\nmodels in the graph. For more information on model selection, check out the [dbt docs](https://docs.getdbt.com/docs/model-selection-syntax).\n\nNote that you can also right-click on models to interactively filter and explore the graph.\n\n---\n\n### More information\n\n- [What is dbt](https://docs.getdbt.com/docs/introduction)?\n- Read the [dbt viewpoint](https://docs.getdbt.com/docs/viewpoint)\n- [Installation](https://docs.getdbt.com/docs/installation)\n- Join the [dbt Community](https://www.getdbt.com/community/) for questions and discussion"
+        }
+      },
+      "exposures": {},
+      "metrics": {
+        "metric.jaffle_shop.expenses": {
+          "name": "expenses",
+          "resource_type": "metric",
+          "package_name": "jaffle_shop",
+          "path": "marts/expenses.yml",
+          "original_file_path": "models/marts/expenses.yml",
+          "unique_id": "metric.jaffle_shop.expenses",
+          "fqn": [
+            "jaffle_shop",
+            "marts",
+            "expenses"
+          ],
+          "description": "The total expenses of our jaffle business",
+          "label": "Expenses",
+          "calculation_method": "sum",
+          "expression": "amount / 4",
+          "filters": [
+            {
+              "field": "status",
+              "operator": "=",
+              "value": "'completed'"
+            }
+          ],
+          "time_grains": [
+            "day",
+            "week",
+            "month",
+            "year"
+          ],
+          "dimensions": [],
+          "timestamp": "order_date",
+          "model": "ref('orders')",
+          "meta": {},
+          "tags": [
+            "piperider"
+          ],
+          "config": {
+            "enabled": true
+          },
+          "unrendered_config": {},
+          "sources": [],
+          "depends_on": {
+            "macros": [],
+            "nodes": [
+              "model.jaffle_shop.orders"
+            ]
+          },
+          "refs": [
+            {
+              "name": "orders"
+            }
+          ],
+          "metrics": [],
+          "created_at": 1687240841.4225512
+        },
+        "metric.jaffle_shop.average_order_amount": {
+          "name": "average_order_amount",
+          "resource_type": "metric",
+          "package_name": "jaffle_shop",
+          "path": "marts/average_order_amount.yml",
+          "original_file_path": "models/marts/average_order_amount.yml",
+          "unique_id": "metric.jaffle_shop.average_order_amount",
+          "fqn": [
+            "jaffle_shop",
+            "marts",
+            "average_order_amount"
+          ],
+          "description": "The average size of a jaffle order",
+          "label": "Average Order Amount",
+          "calculation_method": "average",
+          "expression": "amount",
+          "filters": [],
+          "time_grains": [
+            "day",
+            "week",
+            "month"
+          ],
+          "dimensions": [],
+          "timestamp": "order_date",
+          "model": "ref('orders')",
+          "meta": {},
+          "tags": [
+            "piperider"
+          ],
+          "config": {
+            "enabled": true
+          },
+          "unrendered_config": {},
+          "sources": [],
+          "depends_on": {
+            "macros": [],
+            "nodes": [
+              "model.jaffle_shop.orders"
+            ]
+          },
+          "refs": [
+            {
+              "name": "orders"
+            }
+          ],
+          "metrics": [],
+          "created_at": 1687240841.4414458
+        },
+        "metric.jaffle_shop.revenue": {
+          "name": "revenue",
+          "resource_type": "metric",
+          "package_name": "jaffle_shop",
+          "path": "marts/revenue.yml",
+          "original_file_path": "models/marts/revenue.yml",
+          "unique_id": "metric.jaffle_shop.revenue",
+          "fqn": [
+            "jaffle_shop",
+            "marts",
+            "revenue"
+          ],
+          "description": "The total revenue of our jaffle business",
+          "label": "Revenue",
+          "calculation_method": "sum",
+          "expression": "amount",
+          "filters": [
+            {
+              "field": "status",
+              "operator": "=",
+              "value": "'completed'"
+            }
+          ],
+          "time_grains": [
+            "day",
+            "week",
+            "month",
+            "year"
+          ],
+          "dimensions": [],
+          "timestamp": "order_date",
+          "model": "ref('orders')",
+          "meta": {},
+          "tags": [
+            "piperider"
+          ],
+          "config": {
+            "enabled": true
+          },
+          "unrendered_config": {},
+          "sources": [],
+          "depends_on": {
+            "macros": [],
+            "nodes": [
+              "model.jaffle_shop.orders"
+            ]
+          },
+          "refs": [
+            {
+              "name": "orders"
+            }
+          ],
+          "metrics": [],
+          "created_at": 1687240841.443864
+        },
+        "metric.jaffle_shop.profit": {
+          "name": "profit",
+          "resource_type": "metric",
+          "package_name": "jaffle_shop",
+          "path": "marts/profit.yml",
+          "original_file_path": "models/marts/profit.yml",
+          "unique_id": "metric.jaffle_shop.profit",
+          "fqn": [
+            "jaffle_shop",
+            "marts",
+            "profit"
+          ],
+          "description": "The total money we get to take home from our jaffle business",
+          "label": "Profit",
+          "calculation_method": "derived",
+          "expression": "revenue - expenses",
+          "filters": [],
+          "time_grains": [
+            "hour",
+            "day",
+            "week",
+            "month",
+            "year"
+          ],
+          "dimensions": [],
+          "timestamp": "order_date",
+          "meta": {},
+          "tags": [
+            "piperider"
+          ],
+          "config": {
+            "enabled": true
+          },
+          "unrendered_config": {},
+          "sources": [],
+          "depends_on": {
+            "macros": [],
+            "nodes": [
+              "metric.jaffle_shop.revenue",
+              "metric.jaffle_shop.expenses"
+            ]
+          },
+          "refs": [],
+          "metrics": [
+            [
+              "revenue"
+            ],
+            [
+              "expenses"
+            ]
+          ],
+          "created_at": 1687240841.44575
+        }
+      },
+      "groups": {},
+      "selectors": {},
+      "disabled": {},
+      "parent_map": {
+        "model.jaffle_shop.int_order_payments_pivoted": [
+          "model.jaffle_shop.stg_orders",
+          "model.jaffle_shop.stg_payments"
+        ],
+        "model.jaffle_shop.int_customer_order_history_joined": [
+          "model.jaffle_shop.stg_customers",
+          "model.jaffle_shop.stg_orders",
+          "model.jaffle_shop.stg_payments"
+        ],
+        "model.jaffle_shop.stg_customers": [
+          "seed.jaffle_shop.raw_customers"
+        ],
+        "model.jaffle_shop.stg_payments": [
+          "seed.jaffle_shop.raw_payments"
+        ],
+        "model.jaffle_shop.stg_orders": [
+          "seed.jaffle_shop.raw_orders"
+        ],
+        "model.jaffle_shop.orders": [
+          "model.jaffle_shop.int_customer_order_history_joined",
+          "model.jaffle_shop.int_order_payments_pivoted"
+        ],
+        "seed.jaffle_shop.raw_customers": [],
+        "seed.jaffle_shop.raw_orders": [],
+        "seed.jaffle_shop.raw_payments": [],
+        "test.jaffle_shop.unique_int_customer_order_history_joined_customer_id.995635f7d9": [
+          "model.jaffle_shop.int_customer_order_history_joined"
+        ],
+        "test.jaffle_shop.not_null_int_customer_order_history_joined_customer_id.5eeb8cdf92": [
+          "model.jaffle_shop.int_customer_order_history_joined"
+        ],
+        "test.jaffle_shop.unique_int_order_payments_pivoted_order_id.34a0f3307d": [
+          "model.jaffle_shop.int_order_payments_pivoted"
+        ],
+        "test.jaffle_shop.not_null_int_order_payments_pivoted_order_id.787ba994a8": [
+          "model.jaffle_shop.int_order_payments_pivoted"
+        ],
+        "test.jaffle_shop.not_null_int_order_payments_pivoted_customer_id.3db59c6de4": [
+          "model.jaffle_shop.int_order_payments_pivoted"
+        ],
+        "test.jaffle_shop.relationships_int_order_payments_pivoted_customer_id__customer_id__ref_int_customer_order_history_joined_.654a1aa35d": [
+          "model.jaffle_shop.int_customer_order_history_joined",
+          "model.jaffle_shop.int_order_payments_pivoted"
+        ],
+        "test.jaffle_shop.accepted_values_int_order_payments_pivoted_status__placed__shipped__completed__return_pending__returned.0ccdff53e8": [
+          "model.jaffle_shop.int_order_payments_pivoted"
+        ],
+        "test.jaffle_shop.not_null_int_order_payments_pivoted_amount.b7598e0e3b": [
+          "model.jaffle_shop.int_order_payments_pivoted"
+        ],
+        "test.jaffle_shop.not_null_int_order_payments_pivoted_credit_card_amount.ae9c42d967": [
+          "model.jaffle_shop.int_order_payments_pivoted"
+        ],
+        "test.jaffle_shop.not_null_int_order_payments_pivoted_coupon_amount.2532b538c2": [
+          "model.jaffle_shop.int_order_payments_pivoted"
+        ],
+        "test.jaffle_shop.not_null_int_order_payments_pivoted_bank_transfer_amount.1a9e62933b": [
+          "model.jaffle_shop.int_order_payments_pivoted"
+        ],
+        "test.jaffle_shop.not_null_int_order_payments_pivoted_gift_card_amount.710d789cc0": [
+          "model.jaffle_shop.int_order_payments_pivoted"
+        ],
+        "test.jaffle_shop.unique_stg_customers_customer_id.c7614daada": [
+          "model.jaffle_shop.stg_customers"
+        ],
+        "test.jaffle_shop.not_null_stg_customers_customer_id.e2cfb1f9aa": [
+          "model.jaffle_shop.stg_customers"
+        ],
+        "test.jaffle_shop.unique_stg_orders_order_id.e3b841c71a": [
+          "model.jaffle_shop.stg_orders"
+        ],
+        "test.jaffle_shop.not_null_stg_orders_order_id.81cfe2fe64": [
+          "model.jaffle_shop.stg_orders"
+        ],
+        "test.jaffle_shop.accepted_values_stg_orders_status__placed__shipped__completed__return_pending__returned.080fb20aad": [
+          "model.jaffle_shop.stg_orders"
+        ],
+        "test.jaffle_shop.unique_stg_payments_payment_id.3744510712": [
+          "model.jaffle_shop.stg_payments"
+        ],
+        "test.jaffle_shop.not_null_stg_payments_payment_id.c19cc50075": [
+          "model.jaffle_shop.stg_payments"
+        ],
+        "test.jaffle_shop.accepted_values_stg_payments_payment_method__credit_card__coupon__bank_transfer__gift_card.3c3820f278": [
+          "model.jaffle_shop.stg_payments"
+        ],
+        "test.jaffle_shop.unique_orders_order_id.fed79b3a6e": [
+          "model.jaffle_shop.orders"
+        ],
+        "test.jaffle_shop.not_null_orders_order_id.cf6c17daed": [
+          "model.jaffle_shop.orders"
+        ],
+        "test.jaffle_shop.not_null_orders_customer_id.c5f02694af": [
+          "model.jaffle_shop.orders"
+        ],
+        "test.jaffle_shop.accepted_values_orders_status__placed__shipped__completed__return_pending__returned.be6b5b5ec3": [
+          "model.jaffle_shop.orders"
+        ],
+        "test.jaffle_shop.not_null_orders_amount.106140f9fd": [
+          "model.jaffle_shop.orders"
+        ],
+        "test.jaffle_shop.not_null_orders_credit_card_amount.d3ca593b59": [
+          "model.jaffle_shop.orders"
+        ],
+        "test.jaffle_shop.not_null_orders_coupon_amount.ab90c90625": [
+          "model.jaffle_shop.orders"
+        ],
+        "test.jaffle_shop.not_null_orders_bank_transfer_amount.7743500c49": [
+          "model.jaffle_shop.orders"
+        ],
+        "test.jaffle_shop.not_null_orders_gift_card_amount.413a0d2d7a": [
+          "model.jaffle_shop.orders"
+        ],
+        "metric.jaffle_shop.expenses": [
+          "model.jaffle_shop.orders"
+        ],
+        "metric.jaffle_shop.average_order_amount": [
+          "model.jaffle_shop.orders"
+        ],
+        "metric.jaffle_shop.revenue": [
+          "model.jaffle_shop.orders"
+        ],
+        "metric.jaffle_shop.profit": [
+          "metric.jaffle_shop.expenses",
+          "metric.jaffle_shop.revenue"
+        ]
+      },
+      "child_map": {
+        "model.jaffle_shop.int_order_payments_pivoted": [
+          "model.jaffle_shop.orders",
+          "test.jaffle_shop.accepted_values_int_order_payments_pivoted_status__placed__shipped__completed__return_pending__returned.0ccdff53e8",
+          "test.jaffle_shop.not_null_int_order_payments_pivoted_amount.b7598e0e3b",
+          "test.jaffle_shop.not_null_int_order_payments_pivoted_bank_transfer_amount.1a9e62933b",
+          "test.jaffle_shop.not_null_int_order_payments_pivoted_coupon_amount.2532b538c2",
+          "test.jaffle_shop.not_null_int_order_payments_pivoted_credit_card_amount.ae9c42d967",
+          "test.jaffle_shop.not_null_int_order_payments_pivoted_customer_id.3db59c6de4",
+          "test.jaffle_shop.not_null_int_order_payments_pivoted_gift_card_amount.710d789cc0",
+          "test.jaffle_shop.not_null_int_order_payments_pivoted_order_id.787ba994a8",
+          "test.jaffle_shop.relationships_int_order_payments_pivoted_customer_id__customer_id__ref_int_customer_order_history_joined_.654a1aa35d",
+          "test.jaffle_shop.unique_int_order_payments_pivoted_order_id.34a0f3307d"
+        ],
+        "model.jaffle_shop.int_customer_order_history_joined": [
+          "model.jaffle_shop.orders",
+          "test.jaffle_shop.not_null_int_customer_order_history_joined_customer_id.5eeb8cdf92",
+          "test.jaffle_shop.relationships_int_order_payments_pivoted_customer_id__customer_id__ref_int_customer_order_history_joined_.654a1aa35d",
+          "test.jaffle_shop.unique_int_customer_order_history_joined_customer_id.995635f7d9"
+        ],
+        "model.jaffle_shop.stg_customers": [
+          "model.jaffle_shop.int_customer_order_history_joined",
+          "test.jaffle_shop.not_null_stg_customers_customer_id.e2cfb1f9aa",
+          "test.jaffle_shop.unique_stg_customers_customer_id.c7614daada"
+        ],
+        "model.jaffle_shop.stg_payments": [
+          "model.jaffle_shop.int_customer_order_history_joined",
+          "model.jaffle_shop.int_order_payments_pivoted",
+          "test.jaffle_shop.accepted_values_stg_payments_payment_method__credit_card__coupon__bank_transfer__gift_card.3c3820f278",
+          "test.jaffle_shop.not_null_stg_payments_payment_id.c19cc50075",
+          "test.jaffle_shop.unique_stg_payments_payment_id.3744510712"
+        ],
+        "model.jaffle_shop.stg_orders": [
+          "model.jaffle_shop.int_customer_order_history_joined",
+          "model.jaffle_shop.int_order_payments_pivoted",
+          "test.jaffle_shop.accepted_values_stg_orders_status__placed__shipped__completed__return_pending__returned.080fb20aad",
+          "test.jaffle_shop.not_null_stg_orders_order_id.81cfe2fe64",
+          "test.jaffle_shop.unique_stg_orders_order_id.e3b841c71a"
+        ],
+        "model.jaffle_shop.orders": [
+          "metric.jaffle_shop.average_order_amount",
+          "metric.jaffle_shop.expenses",
+          "metric.jaffle_shop.revenue",
+          "test.jaffle_shop.accepted_values_orders_status__placed__shipped__completed__return_pending__returned.be6b5b5ec3",
+          "test.jaffle_shop.not_null_orders_amount.106140f9fd",
+          "test.jaffle_shop.not_null_orders_bank_transfer_amount.7743500c49",
+          "test.jaffle_shop.not_null_orders_coupon_amount.ab90c90625",
+          "test.jaffle_shop.not_null_orders_credit_card_amount.d3ca593b59",
+          "test.jaffle_shop.not_null_orders_customer_id.c5f02694af",
+          "test.jaffle_shop.not_null_orders_gift_card_amount.413a0d2d7a",
+          "test.jaffle_shop.not_null_orders_order_id.cf6c17daed",
+          "test.jaffle_shop.unique_orders_order_id.fed79b3a6e"
+        ],
+        "seed.jaffle_shop.raw_customers": [
+          "model.jaffle_shop.stg_customers"
+        ],
+        "seed.jaffle_shop.raw_orders": [
+          "model.jaffle_shop.stg_orders"
+        ],
+        "seed.jaffle_shop.raw_payments": [
+          "model.jaffle_shop.stg_payments"
+        ],
+        "test.jaffle_shop.unique_int_customer_order_history_joined_customer_id.995635f7d9": [],
+        "test.jaffle_shop.not_null_int_customer_order_history_joined_customer_id.5eeb8cdf92": [],
+        "test.jaffle_shop.unique_int_order_payments_pivoted_order_id.34a0f3307d": [],
+        "test.jaffle_shop.not_null_int_order_payments_pivoted_order_id.787ba994a8": [],
+        "test.jaffle_shop.not_null_int_order_payments_pivoted_customer_id.3db59c6de4": [],
+        "test.jaffle_shop.relationships_int_order_payments_pivoted_customer_id__customer_id__ref_int_customer_order_history_joined_.654a1aa35d": [],
+        "test.jaffle_shop.accepted_values_int_order_payments_pivoted_status__placed__shipped__completed__return_pending__returned.0ccdff53e8": [],
+        "test.jaffle_shop.not_null_int_order_payments_pivoted_amount.b7598e0e3b": [],
+        "test.jaffle_shop.not_null_int_order_payments_pivoted_credit_card_amount.ae9c42d967": [],
+        "test.jaffle_shop.not_null_int_order_payments_pivoted_coupon_amount.2532b538c2": [],
+        "test.jaffle_shop.not_null_int_order_payments_pivoted_bank_transfer_amount.1a9e62933b": [],
+        "test.jaffle_shop.not_null_int_order_payments_pivoted_gift_card_amount.710d789cc0": [],
+        "test.jaffle_shop.unique_stg_customers_customer_id.c7614daada": [],
+        "test.jaffle_shop.not_null_stg_customers_customer_id.e2cfb1f9aa": [],
+        "test.jaffle_shop.unique_stg_orders_order_id.e3b841c71a": [],
+        "test.jaffle_shop.not_null_stg_orders_order_id.81cfe2fe64": [],
+        "test.jaffle_shop.accepted_values_stg_orders_status__placed__shipped__completed__return_pending__returned.080fb20aad": [],
+        "test.jaffle_shop.unique_stg_payments_payment_id.3744510712": [],
+        "test.jaffle_shop.not_null_stg_payments_payment_id.c19cc50075": [],
+        "test.jaffle_shop.accepted_values_stg_payments_payment_method__credit_card__coupon__bank_transfer__gift_card.3c3820f278": [],
+        "test.jaffle_shop.unique_orders_order_id.fed79b3a6e": [],
+        "test.jaffle_shop.not_null_orders_order_id.cf6c17daed": [],
+        "test.jaffle_shop.not_null_orders_customer_id.c5f02694af": [],
+        "test.jaffle_shop.accepted_values_orders_status__placed__shipped__completed__return_pending__returned.be6b5b5ec3": [],
+        "test.jaffle_shop.not_null_orders_amount.106140f9fd": [],
+        "test.jaffle_shop.not_null_orders_credit_card_amount.d3ca593b59": [],
+        "test.jaffle_shop.not_null_orders_coupon_amount.ab90c90625": [],
+        "test.jaffle_shop.not_null_orders_bank_transfer_amount.7743500c49": [],
+        "test.jaffle_shop.not_null_orders_gift_card_amount.413a0d2d7a": [],
+        "metric.jaffle_shop.expenses": [
+          "metric.jaffle_shop.profit"
+        ],
+        "metric.jaffle_shop.average_order_amount": [],
+        "metric.jaffle_shop.revenue": [
+          "metric.jaffle_shop.profit"
+        ],
+        "metric.jaffle_shop.profit": []
+      },
+      "group_map": {}
+    },
+    "run_results": {
+      "metadata": {
+        "dbt_schema_version": "https://schemas.getdbt.com/dbt/run-results/v4.json",
+        "dbt_version": "1.5.1",
+        "generated_at": "2023-06-20T06:00:42.455141Z",
+        "invocation_id": "a454c6bb-9f51-4874-8327-2f98c751a665",
+        "env": {}
+      },
+      "results": [
+        {
+          "status": "success",
+          "timing": [
+            {
+              "name": "compile",
+              "started_at": "2023-06-20T06:00:41.513831Z",
+              "completed_at": "2023-06-20T06:00:41.513833Z"
+            },
+            {
+              "name": "execute",
+              "started_at": "2023-06-20T06:00:41.514269Z",
+              "completed_at": "2023-06-20T06:00:41.620845Z"
+            }
+          ],
+          "thread_id": "Thread-1 (worker)",
+          "execution_time": 0.11179542541503906,
+          "adapter_response": {
+            "_message": "INSERT 100",
+            "code": "INSERT",
+            "rows_affected": 100
+          },
+          "message": "INSERT 100",
+          "unique_id": "seed.jaffle_shop.raw_customers"
+        },
+        {
+          "status": "success",
+          "timing": [
+            {
+              "name": "compile",
+              "started_at": "2023-06-20T06:00:41.627337Z",
+              "completed_at": "2023-06-20T06:00:41.627338Z"
+            },
+            {
+              "name": "execute",
+              "started_at": "2023-06-20T06:00:41.627764Z",
+              "completed_at": "2023-06-20T06:00:41.721979Z"
+            }
+          ],
+          "thread_id": "Thread-1 (worker)",
+          "execution_time": 0.09859514236450195,
+          "adapter_response": {
+            "_message": "INSERT 99",
+            "code": "INSERT",
+            "rows_affected": 99
+          },
+          "message": "INSERT 99",
+          "unique_id": "seed.jaffle_shop.raw_orders"
+        },
+        {
+          "status": "success",
+          "timing": [
+            {
+              "name": "compile",
+              "started_at": "2023-06-20T06:00:41.727508Z",
+              "completed_at": "2023-06-20T06:00:41.727509Z"
+            },
+            {
+              "name": "execute",
+              "started_at": "2023-06-20T06:00:41.727934Z",
+              "completed_at": "2023-06-20T06:00:41.832966Z"
+            }
+          ],
+          "thread_id": "Thread-1 (worker)",
+          "execution_time": 0.10959410667419434,
+          "adapter_response": {
+            "_message": "INSERT 113",
+            "code": "INSERT",
+            "rows_affected": 113
+          },
+          "message": "INSERT 113",
+          "unique_id": "seed.jaffle_shop.raw_payments"
+        },
+        {
+          "status": "success",
+          "timing": [
+            {
+              "name": "compile",
+              "started_at": "2023-06-20T06:00:41.838795Z",
+              "completed_at": "2023-06-20T06:00:41.840575Z"
+            },
+            {
+              "name": "execute",
+              "started_at": "2023-06-20T06:00:41.841025Z",
+              "completed_at": "2023-06-20T06:00:41.875146Z"
+            }
+          ],
+          "thread_id": "Thread-1 (worker)",
+          "execution_time": 0.03893923759460449,
+          "adapter_response": {
+            "_message": "OK"
+          },
+          "message": "OK",
+          "unique_id": "model.jaffle_shop.stg_customers"
+        },
+        {
+          "status": "success",
+          "timing": [
+            {
+              "name": "compile",
+              "started_at": "2023-06-20T06:00:41.879422Z",
+              "completed_at": "2023-06-20T06:00:41.881122Z"
+            },
+            {
+              "name": "execute",
+              "started_at": "2023-06-20T06:00:41.881572Z",
+              "completed_at": "2023-06-20T06:00:41.897352Z"
+            }
+          ],
+          "thread_id": "Thread-1 (worker)",
+          "execution_time": 0.02028203010559082,
+          "adapter_response": {
+            "_message": "OK"
+          },
+          "message": "OK",
+          "unique_id": "model.jaffle_shop.stg_orders"
+        },
+        {
+          "status": "success",
+          "timing": [
+            {
+              "name": "compile",
+              "started_at": "2023-06-20T06:00:41.901339Z",
+              "completed_at": "2023-06-20T06:00:41.903019Z"
+            },
+            {
+              "name": "execute",
+              "started_at": "2023-06-20T06:00:41.903484Z",
+              "completed_at": "2023-06-20T06:00:41.919626Z"
+            }
+          ],
+          "thread_id": "Thread-1 (worker)",
+          "execution_time": 0.021030902862548828,
+          "adapter_response": {
+            "_message": "OK"
+          },
+          "message": "OK",
+          "unique_id": "model.jaffle_shop.stg_payments"
+        },
+        {
+          "status": "pass",
+          "timing": [
+            {
+              "name": "compile",
+              "started_at": "2023-06-20T06:00:41.924271Z",
+              "completed_at": "2023-06-20T06:00:41.929487Z"
+            },
+            {
+              "name": "execute",
+              "started_at": "2023-06-20T06:00:41.929995Z",
+              "completed_at": "2023-06-20T06:00:41.942854Z"
+            }
+          ],
+          "thread_id": "Thread-1 (worker)",
+          "execution_time": 0.020743846893310547,
+          "adapter_response": {
+            "_message": "OK"
+          },
+          "failures": 0,
+          "unique_id": "test.jaffle_shop.not_null_stg_customers_customer_id.e2cfb1f9aa"
+        },
+        {
+          "status": "pass",
+          "timing": [
+            {
+              "name": "compile",
+              "started_at": "2023-06-20T06:00:41.946284Z",
+              "completed_at": "2023-06-20T06:00:41.950044Z"
+            },
+            {
+              "name": "execute",
+              "started_at": "2023-06-20T06:00:41.950555Z",
+              "completed_at": "2023-06-20T06:00:41.956873Z"
+            }
+          ],
+          "thread_id": "Thread-1 (worker)",
+          "execution_time": 0.012626886367797852,
+          "adapter_response": {
+            "_message": "OK"
+          },
+          "failures": 0,
+          "unique_id": "test.jaffle_shop.unique_stg_customers_customer_id.c7614daada"
+        },
+        {
+          "status": "pass",
+          "timing": [
+            {
+              "name": "compile",
+              "started_at": "2023-06-20T06:00:41.960184Z",
+              "completed_at": "2023-06-20T06:00:41.963995Z"
+            },
+            {
+              "name": "execute",
+              "started_at": "2023-06-20T06:00:41.964506Z",
+              "completed_at": "2023-06-20T06:00:41.972640Z"
+            }
+          ],
+          "thread_id": "Thread-1 (worker)",
+          "execution_time": 0.01471400260925293,
+          "adapter_response": {
+            "_message": "OK"
+          },
+          "failures": 0,
+          "unique_id": "test.jaffle_shop.accepted_values_stg_orders_status__placed__shipped__completed__return_pending__returned.080fb20aad"
+        },
+        {
+          "status": "pass",
+          "timing": [
+            {
+              "name": "compile",
+              "started_at": "2023-06-20T06:00:41.976314Z",
+              "completed_at": "2023-06-20T06:00:41.979009Z"
+            },
+            {
+              "name": "execute",
+              "started_at": "2023-06-20T06:00:41.979479Z",
+              "completed_at": "2023-06-20T06:00:41.986335Z"
+            }
+          ],
+          "thread_id": "Thread-1 (worker)",
+          "execution_time": 0.012190818786621094,
+          "adapter_response": {
+            "_message": "OK"
+          },
+          "failures": 0,
+          "unique_id": "test.jaffle_shop.not_null_stg_orders_order_id.81cfe2fe64"
+        },
+        {
+          "status": "pass",
+          "timing": [
+            {
+              "name": "compile",
+              "started_at": "2023-06-20T06:00:41.989737Z",
+              "completed_at": "2023-06-20T06:00:41.992362Z"
+            },
+            {
+              "name": "execute",
+              "started_at": "2023-06-20T06:00:41.992854Z",
+              "completed_at": "2023-06-20T06:00:41.999254Z"
+            }
+          ],
+          "thread_id": "Thread-1 (worker)",
+          "execution_time": 0.011632204055786133,
+          "adapter_response": {
+            "_message": "OK"
+          },
+          "failures": 0,
+          "unique_id": "test.jaffle_shop.unique_stg_orders_order_id.e3b841c71a"
+        },
+        {
+          "status": "pass",
+          "timing": [
+            {
+              "name": "compile",
+              "started_at": "2023-06-20T06:00:42.002689Z",
+              "completed_at": "2023-06-20T06:00:42.006479Z"
+            },
+            {
+              "name": "execute",
+              "started_at": "2023-06-20T06:00:42.006983Z",
+              "completed_at": "2023-06-20T06:00:42.013807Z"
+            }
+          ],
+          "thread_id": "Thread-1 (worker)",
+          "execution_time": 0.013315916061401367,
+          "adapter_response": {
+            "_message": "OK"
+          },
+          "failures": 0,
+          "unique_id": "test.jaffle_shop.accepted_values_stg_payments_payment_method__credit_card__coupon__bank_transfer__gift_card.3c3820f278"
+        },
+        {
+          "status": "pass",
+          "timing": [
+            {
+              "name": "compile",
+              "started_at": "2023-06-20T06:00:42.017621Z",
+              "completed_at": "2023-06-20T06:00:42.020668Z"
+            },
+            {
+              "name": "execute",
+              "started_at": "2023-06-20T06:00:42.021176Z",
+              "completed_at": "2023-06-20T06:00:42.027645Z"
+            }
+          ],
+          "thread_id": "Thread-1 (worker)",
+          "execution_time": 0.01217794418334961,
+          "adapter_response": {
+            "_message": "OK"
+          },
+          "failures": 0,
+          "unique_id": "test.jaffle_shop.not_null_stg_payments_payment_id.c19cc50075"
+        },
+        {
+          "status": "pass",
+          "timing": [
+            {
+              "name": "compile",
+              "started_at": "2023-06-20T06:00:42.031019Z",
+              "completed_at": "2023-06-20T06:00:42.034649Z"
+            },
+            {
+              "name": "execute",
+              "started_at": "2023-06-20T06:00:42.035303Z",
+              "completed_at": "2023-06-20T06:00:42.042660Z"
+            }
+          ],
+          "thread_id": "Thread-1 (worker)",
+          "execution_time": 0.013917922973632812,
+          "adapter_response": {
+            "_message": "OK"
+          },
+          "failures": 0,
+          "unique_id": "test.jaffle_shop.unique_stg_payments_payment_id.3744510712"
+        },
+        {
+          "status": "success",
+          "timing": [
+            {
+              "name": "compile",
+              "started_at": "2023-06-20T06:00:42.046737Z",
+              "completed_at": "2023-06-20T06:00:42.048988Z"
+            },
+            {
+              "name": "execute",
+              "started_at": "2023-06-20T06:00:42.049463Z",
+              "completed_at": "2023-06-20T06:00:42.079788Z"
+            }
+          ],
+          "thread_id": "Thread-1 (worker)",
+          "execution_time": 0.03649711608886719,
+          "adapter_response": {
+            "_message": "OK"
+          },
+          "message": "OK",
+          "unique_id": "model.jaffle_shop.int_customer_order_history_joined"
+        },
+        {
+          "status": "success",
+          "timing": [
+            {
+              "name": "compile",
+              "started_at": "2023-06-20T06:00:42.085158Z",
+              "completed_at": "2023-06-20T06:00:42.088139Z"
+            },
+            {
+              "name": "execute",
+              "started_at": "2023-06-20T06:00:42.088673Z",
+              "completed_at": "2023-06-20T06:00:42.109292Z"
+            }
+          ],
+          "thread_id": "Thread-1 (worker)",
+          "execution_time": 0.027539968490600586,
+          "adapter_response": {
+            "_message": "OK"
+          },
+          "message": "OK",
+          "unique_id": "model.jaffle_shop.int_order_payments_pivoted"
+        },
+        {
+          "status": "pass",
+          "timing": [
+            {
+              "name": "compile",
+              "started_at": "2023-06-20T06:00:42.114432Z",
+              "completed_at": "2023-06-20T06:00:42.117328Z"
+            },
+            {
+              "name": "execute",
+              "started_at": "2023-06-20T06:00:42.117836Z",
+              "completed_at": "2023-06-20T06:00:42.124726Z"
+            }
+          ],
+          "thread_id": "Thread-1 (worker)",
+          "execution_time": 0.012521982192993164,
+          "adapter_response": {
+            "_message": "OK"
+          },
+          "failures": 0,
+          "unique_id": "test.jaffle_shop.not_null_int_customer_order_history_joined_customer_id.5eeb8cdf92"
+        },
+        {
+          "status": "pass",
+          "timing": [
+            {
+              "name": "compile",
+              "started_at": "2023-06-20T06:00:42.128240Z",
+              "completed_at": "2023-06-20T06:00:42.130947Z"
+            },
+            {
+              "name": "execute",
+              "started_at": "2023-06-20T06:00:42.131485Z",
+              "completed_at": "2023-06-20T06:00:42.138691Z"
+            }
+          ],
+          "thread_id": "Thread-1 (worker)",
+          "execution_time": 0.012792110443115234,
+          "adapter_response": {
+            "_message": "OK"
+          },
+          "failures": 0,
+          "unique_id": "test.jaffle_shop.unique_int_customer_order_history_joined_customer_id.995635f7d9"
+        },
+        {
+          "status": "pass",
+          "timing": [
+            {
+              "name": "compile",
+              "started_at": "2023-06-20T06:00:42.142462Z",
+              "completed_at": "2023-06-20T06:00:42.146830Z"
+            },
+            {
+              "name": "execute",
+              "started_at": "2023-06-20T06:00:42.147361Z",
+              "completed_at": "2023-06-20T06:00:42.155869Z"
+            }
+          ],
+          "thread_id": "Thread-1 (worker)",
+          "execution_time": 0.015681982040405273,
+          "adapter_response": {
+            "_message": "OK"
+          },
+          "failures": 0,
+          "unique_id": "test.jaffle_shop.accepted_values_int_order_payments_pivoted_status__placed__shipped__completed__return_pending__returned.0ccdff53e8"
+        },
+        {
+          "status": "pass",
+          "timing": [
+            {
+              "name": "compile",
+              "started_at": "2023-06-20T06:00:42.159553Z",
+              "completed_at": "2023-06-20T06:00:42.162521Z"
+            },
+            {
+              "name": "execute",
+              "started_at": "2023-06-20T06:00:42.162998Z",
+              "completed_at": "2023-06-20T06:00:42.169742Z"
+            }
+          ],
+          "thread_id": "Thread-1 (worker)",
+          "execution_time": 0.012515783309936523,
+          "adapter_response": {
+            "_message": "OK"
+          },
+          "failures": 0,
+          "unique_id": "test.jaffle_shop.not_null_int_order_payments_pivoted_amount.b7598e0e3b"
+        },
+        {
+          "status": "pass",
+          "timing": [
+            {
+              "name": "compile",
+              "started_at": "2023-06-20T06:00:42.173495Z",
+              "completed_at": "2023-06-20T06:00:42.176592Z"
+            },
+            {
+              "name": "execute",
+              "started_at": "2023-06-20T06:00:42.177148Z",
+              "completed_at": "2023-06-20T06:00:42.184885Z"
+            }
+          ],
+          "thread_id": "Thread-1 (worker)",
+          "execution_time": 0.013748884201049805,
+          "adapter_response": {
+            "_message": "OK"
+          },
+          "failures": 0,
+          "unique_id": "test.jaffle_shop.not_null_int_order_payments_pivoted_bank_transfer_amount.1a9e62933b"
+        },
+        {
+          "status": "pass",
+          "timing": [
+            {
+              "name": "compile",
+              "started_at": "2023-06-20T06:00:42.188756Z",
+              "completed_at": "2023-06-20T06:00:42.191984Z"
+            },
+            {
+              "name": "execute",
+              "started_at": "2023-06-20T06:00:42.192498Z",
+              "completed_at": "2023-06-20T06:00:42.199514Z"
+            }
+          ],
+          "thread_id": "Thread-1 (worker)",
+          "execution_time": 0.01320195198059082,
+          "adapter_response": {
+            "_message": "OK"
+          },
+          "failures": 0,
+          "unique_id": "test.jaffle_shop.not_null_int_order_payments_pivoted_coupon_amount.2532b538c2"
+        },
+        {
+          "status": "pass",
+          "timing": [
+            {
+              "name": "compile",
+              "started_at": "2023-06-20T06:00:42.203494Z",
+              "completed_at": "2023-06-20T06:00:42.206560Z"
+            },
+            {
+              "name": "execute",
+              "started_at": "2023-06-20T06:00:42.207117Z",
+              "completed_at": "2023-06-20T06:00:42.214027Z"
+            }
+          ],
+          "thread_id": "Thread-1 (worker)",
+          "execution_time": 0.012942790985107422,
+          "adapter_response": {
+            "_message": "OK"
+          },
+          "failures": 0,
+          "unique_id": "test.jaffle_shop.not_null_int_order_payments_pivoted_credit_card_amount.ae9c42d967"
+        },
+        {
+          "status": "pass",
+          "timing": [
+            {
+              "name": "compile",
+              "started_at": "2023-06-20T06:00:42.217957Z",
+              "completed_at": "2023-06-20T06:00:42.222249Z"
+            },
+            {
+              "name": "execute",
+              "started_at": "2023-06-20T06:00:42.222798Z",
+              "completed_at": "2023-06-20T06:00:42.229511Z"
+            }
+          ],
+          "thread_id": "Thread-1 (worker)",
+          "execution_time": 0.013923883438110352,
+          "adapter_response": {
+            "_message": "OK"
+          },
+          "failures": 0,
+          "unique_id": "test.jaffle_shop.not_null_int_order_payments_pivoted_customer_id.3db59c6de4"
+        },
+        {
+          "status": "pass",
+          "timing": [
+            {
+              "name": "compile",
+              "started_at": "2023-06-20T06:00:42.233071Z",
+              "completed_at": "2023-06-20T06:00:42.236226Z"
+            },
+            {
+              "name": "execute",
+              "started_at": "2023-06-20T06:00:42.236729Z",
+              "completed_at": "2023-06-20T06:00:42.244237Z"
+            }
+          ],
+          "thread_id": "Thread-1 (worker)",
+          "execution_time": 0.01344919204711914,
+          "adapter_response": {
+            "_message": "OK"
+          },
+          "failures": 0,
+          "unique_id": "test.jaffle_shop.not_null_int_order_payments_pivoted_gift_card_amount.710d789cc0"
+        },
+        {
+          "status": "pass",
+          "timing": [
+            {
+              "name": "compile",
+              "started_at": "2023-06-20T06:00:42.248051Z",
+              "completed_at": "2023-06-20T06:00:42.251073Z"
+            },
+            {
+              "name": "execute",
+              "started_at": "2023-06-20T06:00:42.251589Z",
+              "completed_at": "2023-06-20T06:00:42.258432Z"
+            }
+          ],
+          "thread_id": "Thread-1 (worker)",
+          "execution_time": 0.012742996215820312,
+          "adapter_response": {
+            "_message": "OK"
+          },
+          "failures": 0,
+          "unique_id": "test.jaffle_shop.not_null_int_order_payments_pivoted_order_id.787ba994a8"
+        },
+        {
+          "status": "pass",
+          "timing": [
+            {
+              "name": "compile",
+              "started_at": "2023-06-20T06:00:42.262285Z",
+              "completed_at": "2023-06-20T06:00:42.266205Z"
+            },
+            {
+              "name": "execute",
+              "started_at": "2023-06-20T06:00:42.266737Z",
+              "completed_at": "2023-06-20T06:00:42.274186Z"
+            }
+          ],
+          "thread_id": "Thread-1 (worker)",
+          "execution_time": 0.014360904693603516,
+          "adapter_response": {
+            "_message": "OK"
+          },
+          "failures": 0,
+          "unique_id": "test.jaffle_shop.relationships_int_order_payments_pivoted_customer_id__customer_id__ref_int_customer_order_history_joined_.654a1aa35d"
+        },
+        {
+          "status": "pass",
+          "timing": [
+            {
+              "name": "compile",
+              "started_at": "2023-06-20T06:00:42.277935Z",
+              "completed_at": "2023-06-20T06:00:42.280698Z"
+            },
+            {
+              "name": "execute",
+              "started_at": "2023-06-20T06:00:42.281156Z",
+              "completed_at": "2023-06-20T06:00:42.289217Z"
+            }
+          ],
+          "thread_id": "Thread-1 (worker)",
+          "execution_time": 0.013521909713745117,
+          "adapter_response": {
+            "_message": "OK"
+          },
+          "failures": 0,
+          "unique_id": "test.jaffle_shop.unique_int_order_payments_pivoted_order_id.34a0f3307d"
+        },
+        {
+          "status": "success",
+          "timing": [
+            {
+              "name": "compile",
+              "started_at": "2023-06-20T06:00:42.293074Z",
+              "completed_at": "2023-06-20T06:00:42.295001Z"
+            },
+            {
+              "name": "execute",
+              "started_at": "2023-06-20T06:00:42.295463Z",
+              "completed_at": "2023-06-20T06:00:42.312685Z"
+            }
+          ],
+          "thread_id": "Thread-1 (worker)",
+          "execution_time": 0.023708105087280273,
+          "adapter_response": {
+            "_message": "OK"
+          },
+          "message": "OK",
+          "unique_id": "model.jaffle_shop.orders"
+        },
+        {
+          "status": "pass",
+          "timing": [
+            {
+              "name": "compile",
+              "started_at": "2023-06-20T06:00:42.318870Z",
+              "completed_at": "2023-06-20T06:00:42.323175Z"
+            },
+            {
+              "name": "execute",
+              "started_at": "2023-06-20T06:00:42.323735Z",
+              "completed_at": "2023-06-20T06:00:42.330726Z"
+            }
+          ],
+          "thread_id": "Thread-1 (worker)",
+          "execution_time": 0.014119863510131836,
+          "adapter_response": {
+            "_message": "OK"
+          },
+          "failures": 0,
+          "unique_id": "test.jaffle_shop.accepted_values_orders_status__placed__shipped__completed__return_pending__returned.be6b5b5ec3"
+        },
+        {
+          "status": "pass",
+          "timing": [
+            {
+              "name": "compile",
+              "started_at": "2023-06-20T06:00:42.334435Z",
+              "completed_at": "2023-06-20T06:00:42.337625Z"
+            },
+            {
+              "name": "execute",
+              "started_at": "2023-06-20T06:00:42.338134Z",
+              "completed_at": "2023-06-20T06:00:42.346571Z"
+            }
+          ],
+          "thread_id": "Thread-1 (worker)",
+          "execution_time": 0.014544963836669922,
+          "adapter_response": {
+            "_message": "OK"
+          },
+          "failures": 0,
+          "unique_id": "test.jaffle_shop.not_null_orders_amount.106140f9fd"
+        },
+        {
+          "status": "pass",
+          "timing": [
+            {
+              "name": "compile",
+              "started_at": "2023-06-20T06:00:42.350369Z",
+              "completed_at": "2023-06-20T06:00:42.353413Z"
+            },
+            {
+              "name": "execute",
+              "started_at": "2023-06-20T06:00:42.353901Z",
+              "completed_at": "2023-06-20T06:00:42.360342Z"
+            }
+          ],
+          "thread_id": "Thread-1 (worker)",
+          "execution_time": 0.012104988098144531,
+          "adapter_response": {
+            "_message": "OK"
+          },
+          "failures": 0,
+          "unique_id": "test.jaffle_shop.not_null_orders_bank_transfer_amount.7743500c49"
+        },
+        {
+          "status": "pass",
+          "timing": [
+            {
+              "name": "compile",
+              "started_at": "2023-06-20T06:00:42.363778Z",
+              "completed_at": "2023-06-20T06:00:42.366578Z"
+            },
+            {
+              "name": "execute",
+              "started_at": "2023-06-20T06:00:42.367092Z",
+              "completed_at": "2023-06-20T06:00:42.373481Z"
+            }
+          ],
+          "thread_id": "Thread-1 (worker)",
+          "execution_time": 0.012151241302490234,
+          "adapter_response": {
+            "_message": "OK"
+          },
+          "failures": 0,
+          "unique_id": "test.jaffle_shop.not_null_orders_coupon_amount.ab90c90625"
+        },
+        {
+          "status": "pass",
+          "timing": [
+            {
+              "name": "compile",
+              "started_at": "2023-06-20T06:00:42.377177Z",
+              "completed_at": "2023-06-20T06:00:42.380143Z"
+            },
+            {
+              "name": "execute",
+              "started_at": "2023-06-20T06:00:42.380695Z",
+              "completed_at": "2023-06-20T06:00:42.387875Z"
+            }
+          ],
+          "thread_id": "Thread-1 (worker)",
+          "execution_time": 0.013041019439697266,
+          "adapter_response": {
+            "_message": "OK"
+          },
+          "failures": 0,
+          "unique_id": "test.jaffle_shop.not_null_orders_credit_card_amount.d3ca593b59"
+        },
+        {
+          "status": "pass",
+          "timing": [
+            {
+              "name": "compile",
+              "started_at": "2023-06-20T06:00:42.391431Z",
+              "completed_at": "2023-06-20T06:00:42.394229Z"
+            },
+            {
+              "name": "execute",
+              "started_at": "2023-06-20T06:00:42.394711Z",
+              "completed_at": "2023-06-20T06:00:42.401423Z"
+            }
+          ],
+          "thread_id": "Thread-1 (worker)",
+          "execution_time": 0.012210369110107422,
+          "adapter_response": {
+            "_message": "OK"
+          },
+          "failures": 0,
+          "unique_id": "test.jaffle_shop.not_null_orders_customer_id.c5f02694af"
+        },
+        {
+          "status": "pass",
+          "timing": [
+            {
+              "name": "compile",
+              "started_at": "2023-06-20T06:00:42.405026Z",
+              "completed_at": "2023-06-20T06:00:42.409171Z"
+            },
+            {
+              "name": "execute",
+              "started_at": "2023-06-20T06:00:42.409668Z",
+              "completed_at": "2023-06-20T06:00:42.416845Z"
+            }
+          ],
+          "thread_id": "Thread-1 (worker)",
+          "execution_time": 0.014241933822631836,
+          "adapter_response": {
+            "_message": "OK"
+          },
+          "failures": 0,
+          "unique_id": "test.jaffle_shop.not_null_orders_gift_card_amount.413a0d2d7a"
+        },
+        {
+          "status": "pass",
+          "timing": [
+            {
+              "name": "compile",
+              "started_at": "2023-06-20T06:00:42.420718Z",
+              "completed_at": "2023-06-20T06:00:42.423936Z"
+            },
+            {
+              "name": "execute",
+              "started_at": "2023-06-20T06:00:42.424445Z",
+              "completed_at": "2023-06-20T06:00:42.431211Z"
+            }
+          ],
+          "thread_id": "Thread-1 (worker)",
+          "execution_time": 0.012844085693359375,
+          "adapter_response": {
+            "_message": "OK"
+          },
+          "failures": 0,
+          "unique_id": "test.jaffle_shop.not_null_orders_order_id.cf6c17daed"
+        },
+        {
+          "status": "pass",
+          "timing": [
+            {
+              "name": "compile",
+              "started_at": "2023-06-20T06:00:42.435187Z",
+              "completed_at": "2023-06-20T06:00:42.438078Z"
+            },
+            {
+              "name": "execute",
+              "started_at": "2023-06-20T06:00:42.438533Z",
+              "completed_at": "2023-06-20T06:00:42.445353Z"
+            }
+          ],
+          "thread_id": "Thread-1 (worker)",
+          "execution_time": 0.012583017349243164,
+          "adapter_response": {
+            "_message": "OK"
+          },
+          "failures": 0,
+          "unique_id": "test.jaffle_shop.unique_orders_order_id.fed79b3a6e"
+        }
+      ],
+      "elapsed_time": 0.9824488162994385,
+      "args": {
+        "printer_width": 80,
+        "populate_cache": true,
+        "partial_parse": true,
+        "quiet": false,
+        "favor_state": false,
+        "log_format_file": "debug",
+        "introspect": true,
+        "use_colors": true,
+        "send_anonymous_usage_stats": true,
+        "log_path": "/Users/popcorny/Documents/infuseai/repo/jaffle_shop/logs",
+        "log_level_file": "debug",
+        "log_format": "default",
+        "show": false,
+        "version_check": true,
+        "static_parser": true,
+        "write_json": true,
+        "resource_types": [],
+        "select": [],
+        "which": "build",
+        "cache_selected_only": false,
+        "log_level": "info",
+        "strict_mode": false,
+        "project_dir": "/Users/popcorny/Documents/infuseai/repo/jaffle_shop",
+        "profiles_dir": "/Users/popcorny/Documents/infuseai/repo/jaffle_shop",
+        "use_colors_file": true,
+        "vars": {},
+        "warn_error_options": {
+          "include": [],
+          "exclude": []
+        },
+        "enable_legacy_logger": false,
+        "defer": false,
+        "print": true,
+        "exclude": [],
+        "indirect_selection": "eager",
+        "macro_debugging": false
+      }
+    }
+  },
+  "id": "939621537369479a8a7b3cebddc7c5ec",
+  "created_at": "2023-06-20T06:00:48.501145Z",
+  "datasource": {
+    "name": "dev",
+    "type": "duckdb"
+  },
+  "version": "0.28.0.dev",
+  "project_id": "2e470b721f5a4114aa7cf9b73eca760d",
+  "user_id": "14774b4c7d7d414990ec53cf6d35b159",
+  "metadata_version": "1971e39ce02a6dff03c3e9b149d140a4"
+}

--- a/tests/test_dbt_integeration.py
+++ b/tests/test_dbt_integeration.py
@@ -64,6 +64,12 @@ class _BaseDbtTest(TestCase):
     def target_31587_with_ref(self):
         return self.run_object("sc-31587-with-ref-input.json")
 
+    def base_31587_metrics(self):
+        return self.run_object("sc-31587-metrics-base.json")
+
+    def target_31587_metrics(self):
+        return self.run_object("sc-31587-metrics-input.json")
+
 
 class TestDbtIntegration(_BaseDbtTest):
     def setUp(self):
@@ -168,7 +174,7 @@ class TestDbtIntegration(_BaseDbtTest):
 
     @unittest.skipIf(dbt_version_obj() < version.parse('1.4'),
                      'this only works after manifests generated after the v1.4')
-    def test_list_explicit_changes2(self):
+    def test_list_explicit_changes_without_ref_ids(self):
         c = ChangeSet(self.base_31587(), self.target_31587())
 
         expected = ['model.jaffle_shop.orders',
@@ -184,14 +190,12 @@ class TestDbtIntegration(_BaseDbtTest):
         changes = c.list_explicit_changes()
         self.assertListEqual(changes, expected)
 
-        # expected_implicit = ['metric.jaffle_shop.average_order_amount']
-        # because there is no `ref_id` in the table and metric
-        expected_implicit = []
+        expected_implicit = ['metric.jaffle_shop.average_order_amount']
         self.assertListEqual(c.list_implicit_changes(), expected_implicit)
 
     @unittest.skipIf(dbt_version_obj() < version.parse('1.4'),
                      'this only works after manifests generated after the v1.4')
-    def test_list_explicit_changes3(self):
+    def test_list_explicit_changes_with_ref_ids(self):
         c = ChangeSet(self.base_31587_with_ref(), self.target_31587_with_ref())
 
         expected = ['model.jaffle_shop.orders',
@@ -209,3 +213,23 @@ class TestDbtIntegration(_BaseDbtTest):
 
         expected_implicit = ['metric.jaffle_shop.average_order_amount']
         self.assertListEqual(c.list_implicit_changes(), expected_implicit)
+
+    @unittest.skipIf(dbt_version_obj() < version.parse('1.4'),
+                     'this only works after manifests generated after the v1.4')
+    def test_list_changes_metrics_case(self):
+        c = ChangeSet(self.base_31587_metrics(), self.target_31587_metrics())
+        expected = ['model.jaffle_shop.orders',
+                    'test.jaffle_shop.accepted_values_orders_status__placed__shipped__completed__return_pending__returned.be6b5b5ec3',
+                    'test.jaffle_shop.not_null_orders_amount.106140f9fd',
+                    'test.jaffle_shop.not_null_orders_bank_transfer_amount.7743500c49',
+                    'test.jaffle_shop.not_null_orders_coupon_amount.ab90c90625',
+                    'test.jaffle_shop.not_null_orders_credit_card_amount.d3ca593b59',
+                    'test.jaffle_shop.not_null_orders_customer_id.c5f02694af',
+                    'test.jaffle_shop.not_null_orders_gift_card_amount.413a0d2d7a',
+                    'test.jaffle_shop.not_null_orders_order_id.cf6c17daed',
+                    'test.jaffle_shop.unique_orders_order_id.fed79b3a6e']
+        changes = c.list_explicit_changes()
+        self.assertListEqual(changes, expected)
+
+        changes = c.list_implicit_changes()
+        self.assertListEqual(c.list_implicit_changes(), ['metric.jaffle_shop.average_order_amount'])


### PR DESCRIPTION


**PR checklist**

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed

**What type of PR is this?**

enhancement

**What this PR does / why we need it**:

improve unique-id resolving compatibility for report data

**Which issue(s) this PR fixes**:

None

**Special notes for your reviewer**:

For the newer report, we put `ref_id` to each resource entry to make unque-id resolving easy. However, the user might compare any two reports in these cases:

1. both without ref_id
2. base wit ref_id, input without ref_id
3. base without ref_id, input with ref_id
4. both with ref_id

This PR support all resolving cases 