### PR TITLE
[Chore] Ignore dbt runtime logs when reading stdin from dbt list command

### DIFF
--- a/piperider_cli/dbtutil.py
+++ b/piperider_cli/dbtutil.py
@@ -435,13 +435,17 @@ def read_dbt_resources(source: Union[str, io.TextIOWrapper, list]):
 
     metrics = []
     models = []
-    for dbt_resource in lines:
-        if dbt_resource.startswith('source:'):
+    for line in lines:
+        dbt_resource = line.rstrip()
+        if ' ' in dbt_resource:
+            # From dbt 1.5.x, `dbt list` will output runtime logs as well. Need to ignore them
+            continue
+        elif dbt_resource.startswith('source:'):
             continue
         elif dbt_resource.startswith('metric:'):
-            metrics.append(dbt_resource.rstrip().replace('metric:', 'metric.'))
+            metrics.append(dbt_resource.replace('metric:', 'metric.'))
         else:
-            models.append(dbt_resource.rstrip())
+            models.append(dbt_resource)
     return dict(metrics=metrics, models=models)
 
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some check items for you: -->

**PR checklist**

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed

**What type of PR is this?**
Chore

**What this PR does / why we need it**:
From dbt 1.5.x, `dbt list` will output runtime logs as well

dbt 1.5.2:
```
$ dbt list -s raw_payments
08:57:55  Running with dbt=1.5.2
08:57:55  Registered adapter: duckdb=1.5.2
08:57:55  Found 6 models, 20 tests, 0 snapshots, 0 analyses, 316 macros, 0 operations, 3 seed files, 0 sources, 0 exposures, 1 metric, 0 groups
jaffle_shop.raw_payments
```

dbt 1.4.6:
```
$ dbt list -s raw_payments
jaffle_shop.raw_payments
```

Actually, the runtime logs won't affect the process but it's better to ignore them from reading

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
