### PR TITLE
[Bug] Handle the case that the model has no piperider profiling information

### DIFF
--- a/static_report/src/pages/CRTableDetailPage.tsx
+++ b/static_report/src/pages/CRTableDetailPage.tsx
@@ -45,6 +45,10 @@ export default function CRTableDetailPage() {
   }
 
   const [, { base, target }] = currentTableEntry;
+  const fallback = target || base;
+
+  const name = fallback?.name;
+  const description = fallback?.description || undefined;
 
   const baseDataTable = base?.__table;
   const targetDataTable = target?.__table;
@@ -154,13 +158,29 @@ export default function CRTableDetailPage() {
     }
   }
 
+  if (targetDataTable === undefined && baseDataTable === undefined) {
+    return (
+      <>
+        <TableColumnHeader
+          title={name}
+          subtitle={'Table'}
+          mb={5}
+          infoTip={description}
+        />
+        <NoData
+          text={`No schema data found. The table or view may not be available in the data source.`}
+        />
+      </>
+    );
+  }
+
   return (
     <Box>
       <TableColumnHeader
-        title={(targetDataTable || baseDataTable)?.name}
+        title={name}
         subtitle={'Table'}
         mb={5}
-        infoTip={(targetDataTable || baseDataTable)?.description}
+        infoTip={description}
       />
 
       <ComparableGridHeader />

--- a/static_report/src/pages/SRTableDetailPage.tsx
+++ b/static_report/src/pages/SRTableDetailPage.tsx
@@ -35,14 +35,33 @@ export default function SRTableDetailPage() {
   if (!currentTableEntry) {
     return <NoData text={`No data found for '${tableKey}'`} />;
   }
+
+  const name = currentTableEntry[1].base?.name;
+  const description = currentTableEntry[1].base?.description || undefined;
+
   const dataTable = currentTableEntry[1].base?.__table;
+  if (dataTable === undefined) {
+    return (
+      <>
+        <TableColumnHeader
+          title={name}
+          subtitle={'Table'}
+          infoTip={description}
+          mb={5}
+        />
+        <NoData
+          text={`No schema data found. The table or view may not be available in the data source.`}
+        />
+      </>
+    );
+  }
 
   return (
     <>
       <TableColumnHeader
-        title={dataTable!.name}
+        title={name}
         subtitle={'Table'}
-        infoTip={dataTable!.description}
+        infoTip={description}
         mb={5}
       />
       <Grid

--- a/static_report/src/utils/dbt.ts
+++ b/static_report/src/utils/dbt.ts
@@ -91,6 +91,7 @@ export const buildDbtNodes = (run?: SaferSRSchema) => {
     const uniqueId = `table.${table?.name}`;
     dbtNodes[uniqueId] = {
       name: table?.name ?? '',
+      description: table?.description ?? '',
       unique_id: uniqueId,
       resource_type: 'table',
       __table: table,


### PR DESCRIPTION
If the model is materialized as 'external' or 'ephemeral', there would be no actual table/view in the data warehouse. We should show the report without error in this case.

**PR checklist**

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed
