### PR TITLE
[Bug] sc-31833 Remove reverse_last flag when execute compare command

### DIFF
--- a/piperider_cli/cli.py
+++ b/piperider_cli/cli.py
@@ -555,7 +555,6 @@ def compare_with_recipe(**kwargs):
                                open_report=open_report,
                                project_name=project_name,
                                show_progress=True,
-                               reverse_last=True,
                                debug=debug)
     except Exception as e:
         raise e


### PR DESCRIPTION
 

<!--  Thanks for sending a pull request!  Here are some check items for you: -->

**PR checklist**

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed

**What type of PR is this?**
Bugfix

**What this PR does / why we need it**:
- We refine the compare recipe flow, the base phase will be excuted first. Don't need to set `reverse_last` flag anymore.

**Which issue(s) this PR fixes**:
sc-31833

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
