### PR TITLE
[Feature] sc-31777 Add base_branch option when trigger by github action

### DIFF
--- a/piperider_cli/recipes/github_action.py
+++ b/piperider_cli/recipes/github_action.py
@@ -38,17 +38,17 @@ def run_external_command(command_line, env: Dict = None):
 
 def prepare_for_action(recipe_name: str = None):
     recipe_path = select_recipe_file(None if not recipe_name else recipe_name)
+
     if recipe_path is not None:
         cfg = RecipeConfiguration.load(recipe_path)
-
         if cfg.base.branch:
             git_switch_to(cfg.base.branch)
         if cfg.target.branch:
             git_switch_to(cfg.target.branch)
 
-    ref_name = os.environ.get('GITHUB_HEAD_REF')
-    print(f'switch to GITHUB_HEAD_REF: {ref_name}')
-    git_switch_to(ref_name)
+        ref_name = os.environ.get('GITHUB_HEAD_REF')
+        print(f'switch to GITHUB_HEAD_REF: {ref_name}')
+        git_switch_to(ref_name)
 
 
 def make_recipe_command():
@@ -74,6 +74,9 @@ def make_recipe_command():
         upload = os.environ.get("INPUT_UPLOAD", "false")
         if upload == "true":
             command_builder.append("--upload")
+
+        base_branch = os.environ.get("GITHUB_BASE_REF", 'main')
+        command_builder.append("--base-branch", base_branch)
 
     compare_command = " ".join(command_builder)
     print(compare_command)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some check items for you: -->

**PR checklist**

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed

**What type of PR is this?**
Feature

**What this PR does / why we need it**:
 - For GitHub Compare Action, support to add new option `--base-branch` when generate the compare commands
 - Don't check git branch if there is no recipe specified by GtiHub Action

**Which issue(s) this PR fixes**:
sc-31777

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
