### PR TITLE
[Feature] sc-31829 Use dbt build with state modified when using modified

### DIFF
--- a/piperider_cli/recipe_executor.py
+++ b/piperider_cli/recipe_executor.py
@@ -31,12 +31,10 @@ class RecipeExecutor:
                     dbt_project_path = os.path.relpath(config.dataSources[0].args.get('dbt', {}).get('projectDir'))
                 # generate a default recipe
                 console.rule("Recipe executor: generate recipe")
-                options = {}
+                options = dict(base_branch=base_branch, target_branch=target_branch)
                 if select or modified:
                     options['select'] = select
                     options['modified'] = modified
-                options['base_branch'] = base_branch
-                options['target_branch'] = target_branch
                 recipe = generate_default_recipe(overwrite_existing=False,
                                                  dbt_project_path=dbt_project_path,
                                                  options=options)

--- a/piperider_cli/recipe_executor.py
+++ b/piperider_cli/recipe_executor.py
@@ -31,13 +31,12 @@ class RecipeExecutor:
                     dbt_project_path = os.path.relpath(config.dataSources[0].args.get('dbt', {}).get('projectDir'))
                 # generate a default recipe
                 console.rule("Recipe executor: generate recipe")
-                options = None
+                options = {}
                 if select or modified:
-                    options = {}
                     options['select'] = select
                     options['modified'] = modified
-                    options['base_branch'] = base_branch
-                    options['target_branch'] = target_branch
+                options['base_branch'] = base_branch
+                options['target_branch'] = target_branch
                 recipe = generate_default_recipe(overwrite_existing=False,
                                                  dbt_project_path=dbt_project_path,
                                                  options=options)

--- a/piperider_cli/recipes/__init__.py
+++ b/piperider_cli/recipes/__init__.py
@@ -255,6 +255,12 @@ def update_select_with_modified(select: tuple = None, modified: bool = False):
     return tuple(select_list)
 
 
+def replace_commands_dbt_state_path(commands: list, dbt_state_path: str):
+    if dbt_state_path is None:
+        return commands
+    return [command.replace('<DBT_STATE_PATH>', dbt_state_path) for command in commands]
+
+
 def prepare_dbt_resources_candidate(cfg: RecipeConfiguration, select: tuple = None, modified: bool = False):
     config = Configuration.instance()
     if not select:
@@ -440,6 +446,9 @@ def execute_recipe_configuration(cfg: RecipeConfiguration, select: tuple = None,
                 console.print('Config: piperider env "PIPERIDER_DBT_RESOURCES"')
             cfg.base.piperider.environments['PIPERIDER_DBT_RESOURCES'] = '\n'.join(dbt_resources)
             cfg.target.piperider.environments['PIPERIDER_DBT_RESOURCES'] = '\n'.join(dbt_resources)
+
+        if dbt_state_path:
+            cfg.target.dbt.commands = replace_commands_dbt_state_path(cfg.target.dbt.commands, dbt_state_path)
 
         console.rule("Recipe executor: base phase")
         execute_recipe_archive(cfg.base, recipe_type='base', debug=debug)

--- a/piperider_cli/recipes/__init__.py
+++ b/piperider_cli/recipes/__init__.py
@@ -255,7 +255,7 @@ def update_select_with_modified(select: tuple = None, modified: bool = False):
     return tuple(select_list)
 
 
-def replace_commands_dbt_state_path(commands: list, dbt_state_path: str):
+def replace_commands_dbt_state_path(commands: list[str], dbt_state_path: str):
     if dbt_state_path is None:
         return commands
     return [command.replace('<DBT_STATE_PATH>', dbt_state_path) for command in commands]

--- a/piperider_cli/recipes/__init__.py
+++ b/piperider_cli/recipes/__init__.py
@@ -255,7 +255,7 @@ def update_select_with_modified(select: tuple = None, modified: bool = False):
     return tuple(select_list)
 
 
-def replace_commands_dbt_state_path(commands: list[str], dbt_state_path: str):
+def replace_commands_dbt_state_path(commands: List[str], dbt_state_path: str):
     if dbt_state_path is None:
         return commands
     return [command.replace('<DBT_STATE_PATH>', dbt_state_path) for command in commands]

--- a/piperider_cli/recipes/default_recipe_generator.py
+++ b/piperider_cli/recipes/default_recipe_generator.py
@@ -53,13 +53,17 @@ def _create_target_recipe(dbt_project_path=None, options: dict = None) -> Recipe
     Create the target recipe
     """
     target = RecipeModel()
+    select_and_state_options = ''
+
+    if options.get('modified') is True or any('state:modified' in item for item in options.get('select', ())) is True:
+        select_and_state_options = '--select state:modified+ --state <DBT_STATE_PATH>'
 
     dbt_project = _read_dbt_project_file(dbt_project_path)
     if dbt_project:
         target.dbt = RecipeDbtField({
             'commands': [
                 'dbt deps',
-                'dbt build',
+                f'dbt build {select_and_state_options}'.strip(),
             ]
         })
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some check items for you: -->

**PR checklist**

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed

**What type of PR is this?**
Feature

**What this PR does / why we need it**:
- Target phase will run dbt build with `--select state:modified+ --state <state_path>` when Piperider compare command with `--modified` options or `--select` contain `state:modified` insided.

**Which issue(s) this PR fixes**:
sc-31829

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
