### PR TITLE
[Bug] sc-31865 Handle edge case if no manifest.json found when compare

### DIFF
--- a/piperider_cli/dbtutil.py
+++ b/piperider_cli/dbtutil.py
@@ -12,6 +12,7 @@ from rich.table import Table
 from ruamel import yaml
 
 from piperider_cli import load_jinja_template, load_jinja_string_template
+from piperider_cli.configuration import FileSystem
 from piperider_cli.dbt.list_task import load_manifest, list_resources_from_manifest, load_full_manifest
 from piperider_cli.error import \
     DbtProjectInvalidError, \
@@ -134,6 +135,8 @@ def _get_state_run_results(dbt_state_dir: str):
 
 def _get_state_manifest(dbt_state_dir: str):
     path = os.path.join(dbt_state_dir, 'manifest.json')
+    if os.path.isabs(path) is False:
+        path = os.path.join(FileSystem.WORKING_DIRECTORY, path)
     with open(path) as f:
         manifest = json.load(f)
 
@@ -346,7 +349,10 @@ def get_dbt_state_metrics(dbt_state_dir: str, dbt_tag: str, dbt_resources: Optio
 
 
 def check_dbt_manifest(dbt_state_dir: str) -> bool:
-    return os.path.exists(os.path.join(dbt_state_dir, 'manifest.json'))
+    path = os.path.join(dbt_state_dir, 'manifest.json')
+    if os.path.isabs(path) is False:
+        path = os.path.join(FileSystem.WORKING_DIRECTORY, path)
+    return os.path.exists(path)
 
 
 def get_dbt_manifest(dbt_state_dir: str):

--- a/piperider_cli/dbtutil.py
+++ b/piperider_cli/dbtutil.py
@@ -12,7 +12,6 @@ from rich.table import Table
 from ruamel import yaml
 
 from piperider_cli import load_jinja_template, load_jinja_string_template
-from piperider_cli.configuration import FileSystem
 from piperider_cli.dbt.list_task import load_manifest, list_resources_from_manifest, load_full_manifest
 from piperider_cli.error import \
     DbtProjectInvalidError, \
@@ -136,6 +135,7 @@ def _get_state_run_results(dbt_state_dir: str):
 def _get_state_manifest(dbt_state_dir: str):
     path = os.path.join(dbt_state_dir, 'manifest.json')
     if os.path.isabs(path) is False:
+        from piperider_cli.configuration import FileSystem
         path = os.path.join(FileSystem.WORKING_DIRECTORY, path)
     with open(path) as f:
         manifest = json.load(f)
@@ -351,6 +351,7 @@ def get_dbt_state_metrics(dbt_state_dir: str, dbt_tag: str, dbt_resources: Optio
 def check_dbt_manifest(dbt_state_dir: str) -> bool:
     path = os.path.join(dbt_state_dir, 'manifest.json')
     if os.path.isabs(path) is False:
+        from piperider_cli.configuration import FileSystem
         path = os.path.join(FileSystem.WORKING_DIRECTORY, path)
     return os.path.exists(path)
 

--- a/piperider_cli/dbtutil.py
+++ b/piperider_cli/dbtutil.py
@@ -7,6 +7,10 @@ from pathlib import Path
 from typing import Dict, Optional, Union
 
 import inquirer
+from rich.console import Console
+from rich.table import Table
+from ruamel import yaml
+
 from piperider_cli import load_jinja_template, load_jinja_string_template
 from piperider_cli.dbt.list_task import load_manifest, list_resources_from_manifest, load_full_manifest
 from piperider_cli.error import \
@@ -15,9 +19,6 @@ from piperider_cli.error import \
     DbtProfileBigQueryAuthWithTokenUnsupportedError, DbtRunTimeError
 from piperider_cli.metrics_engine import Metric
 from piperider_cli.statistics import Statistics
-from rich.console import Console
-from rich.table import Table
-from ruamel import yaml
 
 console = Console()
 
@@ -342,6 +343,10 @@ def get_dbt_state_metrics(dbt_state_dir: str, dbt_tag: str, dbt_resources: Optio
                 metric.ref_metrics.append(metric_map.get(depends_on_metric))
 
     return metrics
+
+
+def check_dbt_manifest(dbt_state_dir: str) -> bool:
+    return os.path.exists(os.path.join(dbt_state_dir, 'manifest.json'))
 
 
 def get_dbt_manifest(dbt_state_dir: str):

--- a/piperider_cli/recipes/__init__.py
+++ b/piperider_cli/recipes/__init__.py
@@ -13,7 +13,6 @@ from ruamel.yaml import CommentedSeq
 import piperider_cli.dbtutil as dbtutil
 from piperider_cli import get_run_json_path, load_jinja_template, load_json
 from piperider_cli.configuration import Configuration, FileSystem
-from piperider_cli.dbt.list_task import load_manifest, load_full_manifest
 from piperider_cli.error import RecipeConfigException
 from piperider_cli.recipes.utils import InteractiveStopException
 
@@ -273,12 +272,10 @@ def prepare_dbt_resources_candidate(cfg: RecipeConfiguration, select: tuple = No
 
     if state:
         console.print(f"Run: \[dbt list] select option '{' '.join(select)}' with state")
-        manifest = load_full_manifest(target_path)
     else:
         console.print(f"Run: \[dbt list] select option '{' '.join(select)}'")
-        manifest = load_manifest(dbtutil.get_dbt_manifest(target_path))
     console.print()
-    return tool().list_dbt_resources(manifest, select=select, state=state), state
+    return tool().list_dbt_resources(target_path, select=select, state=state), state
 
 
 def execute_recipe(model: RecipeModel, debug=False, recipe_type='base'):
@@ -337,7 +334,7 @@ def execute_dbt_compile_archive(model: RecipeModel, debug=False):
 
 def execute_dbt_compile(model: RecipeModel, project_dir: str = None, target_path: str = None):
     console.print("Run: \[dbt compile]")
-    cmd = f'dbt compile'
+    cmd = 'dbt compile'
     if project_dir:
         cmd += f' --project-dir {project_dir}'
     if target_path:

--- a/piperider_cli/recipes/utils.py
+++ b/piperider_cli/recipes/utils.py
@@ -11,7 +11,8 @@ from typing import Dict, Tuple
 from rich.console import Console
 
 from piperider_cli.configuration import FileSystem
-from piperider_cli.dbt.list_task import list_resources_from_manifest
+from piperider_cli.dbt.list_task import list_resources_from_manifest, load_full_manifest, load_manifest
+from piperider_cli.dbtutil import get_dbt_manifest
 from piperider_cli.error import PipeRiderError, RecipeException
 
 
@@ -157,7 +158,11 @@ class AbstractRecipeUtils(metaclass=abc.ABCMeta):
         if exit_code != 0:
             raise PipeRiderError("dbt is not installed", hint="Please install it first")
 
-    def list_dbt_resources(self, manifest, select=None, state=None):
+    def list_dbt_resources(self, target_path, select=None, state=None):
+        if state:
+            manifest = load_full_manifest(target_path)
+        else:
+            manifest = load_manifest(get_dbt_manifest(target_path))
         return list_resources_from_manifest(manifest, select=select, state=state)
 
 
@@ -184,7 +189,7 @@ class DryRunRecipeUtils(AbstractRecipeUtils):
         self.console.print(f"[green]:external-command:>[/green] [default]{cmd}[/default]")
         return '/path/to/tmp'
 
-    def list_dbt_resources(self, manifest, select=None, state=None):
+    def list_dbt_resources(self, target_path, select=None, state=None):
         state_msg = ''
         if state:
             state_msg = f'state: {state}'


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some check items for you: -->

**PR checklist**

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed

**What type of PR is this?**
Bugfix

**What this PR does / why we need it**:
- Execute `dbt compile` at the current working directory if there is no `target/manifest.json` file found before listing dbt resources

**Which issue(s) this PR fixes**:
sc-31865

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
