### PR TITLE
[Bug] sc-31865 Handle edge case if no manifest.json found when compare

### DIFF
--- a/piperider_cli/dbtutil.py
+++ b/piperider_cli/dbtutil.py
@@ -7,6 +7,10 @@ from pathlib import Path
 from typing import Dict, Optional, Union
 
 import inquirer
+from rich.console import Console
+from rich.table import Table
+from ruamel import yaml
+
 from piperider_cli import load_jinja_template, load_jinja_string_template
 from piperider_cli.dbt.list_task import load_manifest, list_resources_from_manifest, load_full_manifest
 from piperider_cli.error import \
@@ -15,9 +19,6 @@ from piperider_cli.error import \
     DbtProfileBigQueryAuthWithTokenUnsupportedError, DbtRunTimeError
 from piperider_cli.metrics_engine import Metric
 from piperider_cli.statistics import Statistics
-from rich.console import Console
-from rich.table import Table
-from ruamel import yaml
 
 console = Console()
 
@@ -133,6 +134,9 @@ def _get_state_run_results(dbt_state_dir: str):
 
 def _get_state_manifest(dbt_state_dir: str):
     path = os.path.join(dbt_state_dir, 'manifest.json')
+    if os.path.isabs(path) is False:
+        from piperider_cli.configuration import FileSystem
+        path = os.path.join(FileSystem.WORKING_DIRECTORY, path)
     with open(path) as f:
         manifest = json.load(f)
 
@@ -342,6 +346,14 @@ def get_dbt_state_metrics(dbt_state_dir: str, dbt_tag: str, dbt_resources: Optio
                 metric.ref_metrics.append(metric_map.get(depends_on_metric))
 
     return metrics
+
+
+def check_dbt_manifest(dbt_state_dir: str) -> bool:
+    path = os.path.join(dbt_state_dir, 'manifest.json')
+    if os.path.isabs(path) is False:
+        from piperider_cli.configuration import FileSystem
+        path = os.path.join(FileSystem.WORKING_DIRECTORY, path)
+    return os.path.exists(path)
 
 
 def get_dbt_manifest(dbt_state_dir: str):

--- a/piperider_cli/recipes/__init__.py
+++ b/piperider_cli/recipes/__init__.py
@@ -13,7 +13,6 @@ from ruamel.yaml import CommentedSeq
 import piperider_cli.dbtutil as dbtutil
 from piperider_cli import get_run_json_path, load_jinja_template, load_json
 from piperider_cli.configuration import Configuration, FileSystem
-from piperider_cli.dbt.list_task import load_manifest, load_full_manifest
 from piperider_cli.error import RecipeConfigException
 from piperider_cli.recipes.utils import InteractiveStopException
 
@@ -257,24 +256,26 @@ def update_select_with_modified(select: tuple = None, modified: bool = False):
 
 def prepare_dbt_resources_candidate(cfg: RecipeConfiguration, select: tuple = None, modified: bool = False):
     config = Configuration.instance()
+    state = None
     if not select:
         select = (f'tag:{config.dbt.get("tag")}',) if config.dbt.get('tag') else ()
     select = update_select_with_modified(select, modified)
+    dbt_project = dbtutil.load_dbt_project(config.dbt.get('projectDir'))
+    target_path = dbt_project.get('target-path') if dbt_project.get('target-path') else 'target'
 
     if any('state:' in item for item in select) is True:
         execute_dbt_compile_archive(cfg.base)
+        state = cfg.base.state_path
+    elif dbtutil.check_dbt_manifest(target_path) is False:
+        # Need to compile the dbt project if the manifest file does not exist
+        execute_dbt_compile(cfg.base)
 
-    dbt_project = dbtutil.load_dbt_project(config.dbt.get('projectDir'))
-    target_path = dbt_project.get('target-path') if dbt_project.get('target-path') else 'target'
-    state = cfg.base.state_path if cfg.base.state_path else None
     if state:
         console.print(f"Run: \[dbt list] select option '{' '.join(select)}' with state")
-        manifest = load_full_manifest(target_path)
     else:
         console.print(f"Run: \[dbt list] select option '{' '.join(select)}'")
-        manifest = load_manifest(dbtutil.get_dbt_manifest(target_path))
     console.print()
-    return tool().list_dbt_resources(manifest, select=select, state=state), state
+    return tool().list_dbt_resources(target_path, select=select, state=state), state
 
 
 def execute_recipe(model: RecipeModel, debug=False, recipe_type='base'):
@@ -323,15 +324,22 @@ def execute_dbt_compile_archive(model: RecipeModel, debug=False):
     if not branch_or_commit:
         raise RecipeConfigException("Branch is not specified")
 
-    console.print("Run: \[dbt compile]")
     if model.tmp_dir_path is None:
         model.tmp_dir_path = tool().git_archive(branch_or_commit)
         model.state_path = os.path.join(model.tmp_dir_path, 'state')
 
-    project_dir = model.tmp_dir_path
-    target_path = model.state_path
-    cmd = f'dbt compile --project-dir {project_dir} --target-path {target_path}'
-    exit_code = tool().execute_command_with_showing_output(cmd, model.dbt.envs())
+    execute_dbt_compile(model, model.tmp_dir_path, model.state_path)
+    pass
+
+
+def execute_dbt_compile(model: RecipeModel, project_dir: str = None, target_path: str = None):
+    console.print("Run: \[dbt compile]")
+    cmd = 'dbt compile'
+    if project_dir:
+        cmd += f' --project-dir {project_dir}'
+    if target_path:
+        cmd += f' --target-path {target_path}'
+    exit_code = tool().execute_command_with_showing_output(cmd.strip(), model.dbt.envs())
     if exit_code != 0:
         console.print(
             f"[bold yellow]Warning: [/bold yellow] Dbt command failed: '{cmd}' with exit code: {exit_code}")

--- a/piperider_cli/recipes/utils.py
+++ b/piperider_cli/recipes/utils.py
@@ -11,7 +11,8 @@ from typing import Dict, Tuple
 from rich.console import Console
 
 from piperider_cli.configuration import FileSystem
-from piperider_cli.dbt.list_task import list_resources_from_manifest
+from piperider_cli.dbt.list_task import list_resources_from_manifest, load_full_manifest, load_manifest
+from piperider_cli.dbtutil import get_dbt_manifest
 from piperider_cli.error import PipeRiderError, RecipeException
 
 
@@ -157,7 +158,11 @@ class AbstractRecipeUtils(metaclass=abc.ABCMeta):
         if exit_code != 0:
             raise PipeRiderError("dbt is not installed", hint="Please install it first")
 
-    def list_dbt_resources(self, manifest, select=None, state=None):
+    def list_dbt_resources(self, target_path, select=None, state=None):
+        if state:
+            manifest = load_full_manifest(target_path)
+        else:
+            manifest = load_manifest(get_dbt_manifest(target_path))
         return list_resources_from_manifest(manifest, select=select, state=state)
 
 
@@ -184,7 +189,7 @@ class DryRunRecipeUtils(AbstractRecipeUtils):
         self.console.print(f"[green]:external-command:>[/green] [default]{cmd}[/default]")
         return '/path/to/tmp'
 
-    def list_dbt_resources(self, manifest, select=None, state=None):
+    def list_dbt_resources(self, target_path, select=None, state=None):
         state_msg = ''
         if state:
             state_msg = f'state: {state}'


### PR DESCRIPTION
**PR checklist**

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed

**What type of PR is this?**
Cherry-pick

**What this PR does / why we need it**:
- Execute `dbt compile` at current working directory if there is no `target/manifest.json` file found before listing dbt resources

**Which issue(s) this PR fixes**:
sc-31865

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
