### PR TITLE
[Bug] Fix compare with NoneType

### DIFF
--- a/piperider_cli/dbt/utils.py
+++ b/piperider_cli/dbt/utils.py
@@ -177,7 +177,10 @@ class ChangeType(Enum):
             raise ValueError("Only modified type has display for changes")
 
         if b is None or t is None:
-            return "-"
+            if t is None:
+                return str(b)
+            else:
+                return str(t)
 
         if negative_change:
             color = "red" if t > b else "green"
@@ -186,10 +189,10 @@ class ChangeType(Enum):
         sign = "↑" if t > b else "↓"
         diff = t - b
         if math.isnan(diff):
-            if math.isnan(b):
-                return str(t)
-            else:
+            if math.isnan(t):
                 return str(b)
+            else:
+                return str(t)
 
         if t == b:
             return str(b)

--- a/piperider_cli/dbt/utils.py
+++ b/piperider_cli/dbt/utils.py
@@ -175,6 +175,10 @@ class ChangeType(Enum):
     def display_changes(self, b, t, format_text: str, *, converter: Callable = None, negative_change: bool = False):
         if self != self.MODIFIED:
             raise ValueError("Only modified type has display for changes")
+
+        if b is None or t is None:
+            return "-"
+
         if negative_change:
             color = "red" if t > b else "green"
         else:

--- a/tests/test_compare_summary_ng.py
+++ b/tests/test_compare_summary_ng.py
@@ -48,6 +48,7 @@ class TestCompareSummaryNG(TestCase):
         run2 = self.manifest_dict("sc-31587-with-ref-input.json")
 
         run1 = self.manifest_dict("sc-31723-base.json")
+        run1 = self.manifest_dict("case_base_not_profiled_1.json")
         run2 = self.manifest_dict("sc-31723-target.json")
 
         data = ComparisonData(run1, run2, None)


### PR DESCRIPTION
> ## TypeError
> '>' not supported between instances of 'NoneType' and 'float'

Get report from sentry