### PR TITLE
[Bug] Make piperider working on windows

### DIFF
--- a/.github/workflows/e2e-windows-tests.yaml
+++ b/.github/workflows/e2e-windows-tests.yaml
@@ -1,0 +1,36 @@
+name: Run dbt tests on win
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        version: [ '3.11' ]
+        dbt: [ ">=1.5" ]
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install pytest "dbt-core${{ matrix.dbt }}" "dbt-duckdb${{ matrix.dbt }}"
+          pip install '.[duckdb]'
+
+      - name: Run jaffle shop
+        run: |
+          ./e2e-jaffle-shop/run.bat
+          python ./e2e-jaffle-shop/windows-result-checker.py

--- a/e2e-jaffle-shop/run.bat
+++ b/e2e-jaffle-shop/run.bat
@@ -1,0 +1,53 @@
+:: Set Git global configurations
+git config --global user.email "dev-ci@infuseai.io"
+git config --global user.name "dev-ci"
+
+:: Move to the e2e directory
+pushd "%~dp0"
+echo Current Directory: %CD%
+
+:: Show dbt version
+dbt --version
+
+:: Reference
+:: https://docs.piperider.io/get-started/quick-start
+
+:: Step 1: Clone the repo
+git clone https://github.com/dbt-labs/jaffle_shop.git
+cd jaffle_shop
+
+:: Step 2: Create the configuration
+echo ^>^> Creating profiles.yml
+echo. > profiles.yml
+echo jaffle_shop: >> profiles.yml
+echo   target: dev >> profiles.yml
+echo   outputs: >> profiles.yml
+echo     dev: >> profiles.yml
+echo       type: duckdb >> profiles.yml
+echo       path: jaffle_shop.duckdb >> profiles.yml
+
+:: Generate seed files
+python ..\gen_seed.py
+
+:: Step 3: The first dbt build
+dbt build
+
+:: Tag models
+git apply ..\0001-apply-tags.patch
+git add .
+git commit -m "Added PipeRider tags"
+
+:: Show selected
+echo dbt list with selector
+dbt list -s tag:piperider
+
+:: Make a change to the project
+git checkout -b feature/add-average-value-per-order
+git apply ..\0002-Add-average_value_per_order-to-customers.patch
+git commit -sam "Add average_value_per_order to customers"
+
+:: Compare your branch with main
+piperider compare
+
+:: Restore previous directory
+popd

--- a/e2e-jaffle-shop/windows-result-checker.py
+++ b/e2e-jaffle-shop/windows-result-checker.py
@@ -1,0 +1,9 @@
+import os
+
+path = "e2e-jaffle-shop/jaffle_shop/.piperider/comparisons/latest/summary.md"
+
+if os.path.exists(path):
+    print(f"The path '{path}' exists.")
+else:
+    print(f"The path '{path}' does not exist.")
+    exit(1)  # Indicate error with exit code 1

--- a/piperider_cli/cloud_connector.py
+++ b/piperider_cli/cloud_connector.py
@@ -239,7 +239,7 @@ def upload_to_cloud(run: RunOutput, debug=False, project: PipeRiderProject = Non
             'run_id': run_id,
             'project_name': f'{project.workspace_name}/{project.name}'
         }
-        with open(run_path, 'w') as f:
+        with open(run_path, 'w', encoding='utf-8') as f:
             f.write(json.dumps(report, separators=(',', ':')))
 
     if response.get('success') is True:
@@ -498,7 +498,7 @@ class CloudConnector:
             summary_dir = os.path.dirname(summary_file)
             if summary_dir:
                 os.makedirs(summary_dir, exist_ok=True)
-            with open(summary_file, 'w') as f:
+            with open(summary_file, 'w', encoding='utf-8') as f:
                 f.write(response.get('summary'))
 
     @staticmethod

--- a/piperider_cli/compare_report.py
+++ b/piperider_cli/compare_report.py
@@ -634,7 +634,6 @@ class ComparisonData(object):
 
 def prepare_default_output_path(filesystem: ReportDirectory, created_at):
     latest_symlink_path = os.path.join(filesystem.get_comparison_dir(), 'latest')
-    latest_source = created_at
     comparison_path = os.path.join(filesystem.get_comparison_dir(), created_at)
 
     if not os.path.exists(comparison_path):

--- a/piperider_cli/compare_report.py
+++ b/piperider_cli/compare_report.py
@@ -831,13 +831,13 @@ class CompareReport(object):
         def output_report(directory):
             clone_directory(report_template_dir, directory)
             filename = os.path.join(directory, 'index.html')
-            with open(filename, 'w') as f:
+            with open(filename, 'w', encoding='utf-8') as f:
                 html = setup_report_variables(report_template_html, False, comparison_data.to_json())
                 f.write(html)
 
         def output_summary(directory, summary_data):
             filename = os.path.join(directory, 'summary.md')
-            with open(filename, 'w') as f:
+            with open(filename, 'w', encoding='utf-8') as f:
                 f.write(summary_data)
 
         data_id = comparison_data.id()
@@ -894,5 +894,5 @@ class CompareReport(object):
 
         if debug:
             # Write comparison data to file
-            with open(os.path.join(default_report_directory, 'comparison_data.json'), 'w') as f:
+            with open(os.path.join(default_report_directory, 'comparison_data.json'), 'w', encoding='utf-8') as f:
                 f.write(comparison_data.to_json())

--- a/piperider_cli/compare_report.py
+++ b/piperider_cli/compare_report.py
@@ -17,6 +17,7 @@ from piperider_cli.configuration import Configuration, ReportDirectory
 from piperider_cli.generate_report import setup_report_variables
 from piperider_cli.dbt.changeset import SummaryChangeSet
 from piperider_cli.dbt.utils import ChangeType
+from piperider_cli.utils import create_link, remove_link
 
 
 class RunOutput(object):
@@ -640,26 +641,11 @@ def prepare_default_output_path(filesystem: ReportDirectory, created_at):
         os.makedirs(comparison_path, exist_ok=True)
 
     # Create a symlink pointing to the latest comparison directory
-    if os.path.islink(latest_symlink_path):
-        os.unlink(latest_symlink_path)
+    remove_link(latest_symlink_path)
 
     console = Console()
     if not os.path.exists(latest_symlink_path):
-        try:
-            os.symlink(latest_source, latest_symlink_path)
-        except OSError as e:
-            """
-            System Error Codes:
-                ERROR_PRIVILEGE_NOT_HELD
-                1314 (0x522)
-                A required privilege is not held by the client.
-                https://learn.microsoft.com/en-us/windows/win32/debug/system-error-codes--1300-1699-
-            """
-            if e.winerror is not None and e.winerror == 1314:
-                console.print(
-                    f'[bold yellow]Warning:[/bold yellow] {e}. To solve this, run piperider as an administrator')
-            else:
-                raise e
+        create_link(comparison_path, latest_symlink_path)
     else:
         console.print(f'[bold yellow]Warning: {latest_symlink_path} already exists[/bold yellow]')
 

--- a/piperider_cli/configuration.py
+++ b/piperider_cli/configuration.py
@@ -342,7 +342,7 @@ class Configuration(object):
             config = _yml.load(f)
 
         config[key] = update_values
-        with open(FileSystem.PIPERIDER_CONFIG_PATH, 'w+') as f:
+        with open(FileSystem.PIPERIDER_CONFIG_PATH, 'w+', encoding='utf-8') as f:
             _yml.dump(config, f)
 
     @classmethod
@@ -588,7 +588,7 @@ class Configuration(object):
             # Only append a new line if the last datasource has no comment
             config.yaml_set_comment_before_after_key('profiler', before='\n')
 
-        with open(path, 'w') as fd:
+        with open(path, 'w', encoding='utf-8') as fd:
             yaml.YAML().dump(config, fd)
         pass
 
@@ -621,7 +621,7 @@ class Configuration(object):
 
         config_yaml = CommentedMap(config)
 
-        with open(path, 'w') as fd:
+        with open(path, 'w', encoding='utf-8') as fd:
             yaml.YAML().dump(config_yaml, fd)
 
     def dump_credentials(self, path, after_init_config=False):
@@ -640,7 +640,7 @@ class Configuration(object):
             creds[d.name] = dict(type=d.type_name, **d.credential)
 
         if creds:
-            with open(path, 'w') as fd:
+            with open(path, 'w', encoding='utf-8') as fd:
                 yaml.round_trip_dump(creds, fd)
 
     def to_sqlalchemy_config(self, datasource_name):

--- a/piperider_cli/generate_report.py
+++ b/piperider_cli/generate_report.py
@@ -60,7 +60,7 @@ def setup_report_variables(template_html: str, is_single: bool, data):
 
 def _generate_static_html(result, html, output_path):
     filename = os.path.join(output_path, "index.html")
-    with open(filename, 'w') as f:
+    with open(filename, 'w', encoding='utf-8') as f:
         html = setup_report_variables(html, True, result)
         f.write(html)
 

--- a/piperider_cli/runner.py
+++ b/piperider_cli/runner.py
@@ -30,6 +30,7 @@ from piperider_cli.exitcode import EC_ERR_TEST_FAILED
 from piperider_cli.metrics_engine import MetricEngine, MetricEventHandler
 from piperider_cli.profiler import ProfileSubject, Profiler, ProfilerEventHandler
 from piperider_cli.statistics import Statistics
+from piperider_cli.utils import create_link, remove_link
 
 
 class RunEventPayload:
@@ -342,26 +343,11 @@ def prepare_default_output_path(filesystem: ReportDirectory, created_at, ds):
         os.makedirs(output_path, exist_ok=True)
 
     # Create a symlink pointing to the latest output directory
-    if os.path.islink(latest_symlink_path):
-        os.unlink(latest_symlink_path)
+    remove_link(latest_symlink_path)
 
     console = Console()
     if not os.path.exists(latest_symlink_path):
-        try:
-            os.symlink(latest_source, latest_symlink_path)
-        except OSError as e:
-            """
-            System Error Codes:
-                ERROR_PRIVILEGE_NOT_HELD
-                1314 (0x522)
-                A required privilege is not held by the client.
-                https://learn.microsoft.com/en-us/windows/win32/debug/system-error-codes--1300-1699-
-            """
-            if e.winerror is not None and e.winerror == 1314:
-                console.print(
-                    f'[bold yellow]Warning:[/bold yellow] {e}. To solve this, run piperider as an administrator')
-            else:
-                raise e
+        create_link(output_path, latest_symlink_path)
     else:
         console.print(f'[bold yellow]Warning: {latest_symlink_path} already exists[/bold yellow]')
 

--- a/piperider_cli/runner.py
+++ b/piperider_cli/runner.py
@@ -785,7 +785,7 @@ class Runner():
         output_path = prepare_default_output_path(filesystem, created_at, ds)
         output_file = os.path.join(output_path, 'run.json')
 
-        with open(output_file, 'w') as f:
+        with open(output_file, 'w', encoding='utf-8') as f:
             f.write(json.dumps(run_result, separators=(',', ':')))
 
         if dbt_config:

--- a/piperider_cli/utils.py
+++ b/piperider_cli/utils.py
@@ -1,0 +1,37 @@
+import os
+import platform
+import subprocess
+
+
+def remove_link(link_path):
+    try:
+        if platform.system() == 'Windows':
+            if os.path.exists(link_path):
+                subprocess.run(["rmdir", link_path], shell=True, check=True)
+        else:
+            if os.path.exists(link_path):
+                os.unlink(link_path)
+    except OSError as e:
+        raise e
+
+
+def create_link(source: str, target: str):
+    if not os.path.isabs(source):
+        raise ValueError(f'source must be abspath: {source}')
+    if not os.path.isabs(target):
+        raise ValueError(f'target must be abspath: {target}')
+
+    remove_link(target)
+
+    # Check the platform
+    if platform.system() == "Windows":
+        # On Windows, try creating a junction
+        try:
+            subprocess.run(["mklink", "/J", target, source], shell=True, check=True,
+                           stderr=subprocess.DEVNULL,
+                           stdout=subprocess.DEVNULL)
+        except subprocess.CalledProcessError as e:
+            raise e
+    else:
+        # On non-Windows platforms, create a symbolic link
+        os.symlink(source, target)

--- a/tests/test_links.py
+++ b/tests/test_links.py
@@ -1,0 +1,31 @@
+import json
+import os
+import shutil
+
+import pytest
+from dbt.contracts.graph.manifest import WritableManifest
+
+from piperider_cli.dbt import disable_dbt_compile_stats
+from piperider_cli.dbt.list_task import dbt_version_obj, load_manifest
+from packaging import version
+
+from piperider_cli.utils import create_link
+
+
+def test_create_link():
+    dirname = os.path.join(os.getcwd(), "__create_link__")
+    dirname_latest = os.path.join(os.getcwd(), "__create_link__latest")
+
+    def cleanup():
+        if os.path.exists(dirname_latest):
+            os.unlink(dirname_latest)
+        if os.path.exists(dirname):
+            shutil.rmtree(dirname, ignore_errors=True)
+
+    cleanup()
+
+    try:
+        os.makedirs(dirname, exist_ok=True)
+        create_link(dirname, dirname_latest)
+    finally:
+        cleanup()


### PR DESCRIPTION
**PR checklist**

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed

**What type of PR is this?**

bugfix

**What this PR does / why we need it**:

A Windows user can run piperider without the administrator role.

**Which issue(s) this PR fixes**:

sc-31866


----

## Behavior changed

- for legacy duckdb implementation, it is poor to support `multi-` read and write, we treat it in a different way: only create an `sqlalchemy-engine` for it.

## Test Infra

- Add `jaffle_shop` e2e tests for windows, only 1 combination (the latest dbt and python)

