### PR TITLE
[Bug] Handle naming conflict problem in profiler and report-generator

### DIFF
--- a/piperider_cli/cloud/__init__.py
+++ b/piperider_cli/cloud/__init__.py
@@ -197,14 +197,15 @@ class PipeRiderCloud:
         if response.status_code != 200:
             return None
 
-        responseData = response.json()
+        response_data = response.json()
 
-        def genProjects():
-            for workspace in responseData.get('data', []):
-                for project in workspace.get('projects', []):
-                    yield project
+        def gen_projects():
+            for workspace in response_data.get('data', []):
+                for workspace_project in workspace.get('projects', []):
+                    workspace_project['workspace_name'] = workspace.get('name')
+                    yield workspace_project
 
-        projects = list(genProjects())
+        projects = list(gen_projects())
         if len(projects) == 1:
             return PipeRiderProject(projects[0])
         else:

--- a/piperider_cli/dbt/changeset.py
+++ b/piperider_cli/dbt/changeset.py
@@ -202,6 +202,7 @@ class LookUpTable:
         return str(timedelta(seconds=seconds))[:-4]
 
     def _build_tests_mapping(self):
+        # TODO the test should be ref by the unique_id
         from collections import Counter
         # convert test results to (table_name, pass_or_not): count form
         b = Counter([(x.get('table'), x.get('status')) for x in self.c.base.get('tests', [])])
@@ -476,7 +477,7 @@ class SummaryChangeSet(DefaultChangeSetOpMixin):
         mt = MarkdownTable(headers=['', 'Model', column_header, 'Rows', 'Dbt Time', 'Failed Tests', 'All Tests'])
 
         def cols(c: ChangeUnit):
-            counts = self.tables.column_counts(table_name=c.table_name)
+            counts = self.tables.column_counts(c.unique_id)
             if c.change_type == ChangeType.ADDED:
                 _, t = counts
                 return t
@@ -490,7 +491,7 @@ class SummaryChangeSet(DefaultChangeSetOpMixin):
                 16 ($\color{green}{\text{ 1 }}$ / $\color{red}{\text{ 1 }}$ / $\color{orange}{\text{ 5 }}$)
                 """
 
-                changes = list(self.tables.columns_changed_iterator(c.table_name))
+                changes = list(self.tables.columns_changed_iterator(c.unique_id))
 
                 def col_state(c: ColumnChangeEntry):
                     if c.base_view.data is not None and c.target_view.data is not None:
@@ -518,7 +519,7 @@ class SummaryChangeSet(DefaultChangeSetOpMixin):
             return '-'
 
         def rows(c: ChangeUnit):
-            rows = self.tables.row_counts(table_name=c.table_name)
+            rows = self.tables.row_counts(c.unique_id)
             if c.change_type == ChangeType.ADDED:
                 _, t = rows
                 return t

--- a/piperider_cli/dbt/utils.py
+++ b/piperider_cli/dbt/utils.py
@@ -118,27 +118,33 @@ class JoinedTables:
             yield elem
 
     def _create_columns_and_their_metrics(self, table_name):
-        table = self._joined_tables[table_name]
+        table = self._joined_tables.get(table_name)
+        if table is None:
+            return [], None, None
         b = table.get("base", {}).get("columns", {})
         t = table.get("target", {}).get("columns", {})
         all_column_keys = sorted(set(list(b.keys()) + list(t.keys())))
         return all_column_keys, b, t
 
     def row_counts(self, table_name):
-        table = self._joined_tables[table_name]
+        table = self._joined_tables.get(table_name)
+        if table is None:
+            return math.nan, math.nan
         b = table.get("base", {}).get("row_count", math.nan)
         t = table.get("target", {}).get("row_count", math.nan)
         return b, t
 
     def column_counts(self, table_name):
-        table = self._joined_tables[table_name]
+        table = self._joined_tables.get(table_name)
+        if table is None:
+            return None, None
         b = table.get("base", {}).get("col_count")
         t = table.get("target", {}).get("col_count")
         return b, t
 
     def table_data_iterator(self):
         for table_name in self._joined_tables.keys():
-            table_data = self._joined_tables[table_name]
+            table_data = self._joined_tables.get(table_name)
             fallback = table_data.get('target') if table_data.get('target') else table_data.get('base')
             if fallback:
                 yield table_name, fallback.get('ref_id'), table_data.get('base'), table_data.get('target')

--- a/piperider_cli/dbt/utils.py
+++ b/piperider_cli/dbt/utils.py
@@ -108,8 +108,8 @@ class JoinedTables:
             result[key] = value
         return result
 
-    def columns_changed_iterator(self, table_name: str) -> Iterable[ColumnChangeEntry]:
-        all_column_keys, b, t = self._create_columns_and_their_metrics(table_name)
+    def columns_changed_iterator(self, ref_id: str) -> Iterable[ColumnChangeEntry]:
+        all_column_keys, b, t = self._create_columns_and_their_metrics(ref_id)
 
         for column_name in all_column_keys:
             elem = ColumnChangeEntry(column_name, b.get(column_name), t.get(column_name))
@@ -117,8 +117,8 @@ class JoinedTables:
                 continue
             yield elem
 
-    def _create_columns_and_their_metrics(self, table_name):
-        table = self._joined_tables.get(table_name)
+    def _create_columns_and_their_metrics(self, ref_id):
+        table = self.by_ref_id(ref_id)
         if table is None:
             return [], None, None
         b = table.get("base", {}).get("columns", {})
@@ -126,16 +126,22 @@ class JoinedTables:
         all_column_keys = sorted(set(list(b.keys()) + list(t.keys())))
         return all_column_keys, b, t
 
-    def row_counts(self, table_name):
-        table = self._joined_tables.get(table_name)
+    def row_counts(self, ref_id: str):
+        table = self.by_ref_id(ref_id)
         if table is None:
             return math.nan, math.nan
         b = table.get("base", {}).get("row_count", math.nan)
         t = table.get("target", {}).get("row_count", math.nan)
         return b, t
 
-    def column_counts(self, table_name):
-        table = self._joined_tables.get(table_name)
+    def by_ref_id(self, ref_id: str):
+        if ref_id in self._joined_tables:
+            return self._joined_tables.get(ref_id)
+        table_name = ref_id.split('.')[-1]
+        return self._joined_tables.get(table_name)
+
+    def column_counts(self, ref_id: str):
+        table = self.by_ref_id(ref_id)
         if table is None:
             return None, None
         b = table.get("base", {}).get("col_count")

--- a/piperider_cli/profiler/profiler.py
+++ b/piperider_cli/profiler/profiler.py
@@ -250,13 +250,12 @@ class Profiler:
             engine = self.data_source.get_engine_by_database(subject.database)
             table = map_name_tables.get(subject.ref_id)
 
-            tresult = {}
             if table is not None:
                 table_profiler = TableProfiler(engine, self.executor, subject, table, self.event_handler, self.config)
                 tresult = await table_profiler.fetch_schema()
                 profiled_tables[subject.ref_id] = tresult
             else:
-                profiled_tables[subject.ref_id] = tresult
+                profiled_tables[subject.ref_id] = dict(name=subject.name, columns={}, ref_id=subject.ref_id)
 
         profiled_tables = transform_as_run(profiled_tables)
         self.collected_metadata = CollectedMetadata(map_name_tables=map_name_tables,

--- a/piperider_cli/profiler/profiler.py
+++ b/piperider_cli/profiler/profiler.py
@@ -103,6 +103,8 @@ def transform_as_run(profiled_tables) -> Dict:
     from collections import Counter
 
     def _t(k):
+        if k is None:
+            return "__no_such_table__"
         return k.split(".")[-1]
 
     c = Counter([_t(ref_id) for ref_id in profiled_tables.keys()])

--- a/piperider_cli/profiler/profiler.py
+++ b/piperider_cli/profiler/profiler.py
@@ -5,7 +5,7 @@ import time
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
 from datetime import datetime, date, timezone
-from typing import Optional, Union, List, Tuple
+from typing import Dict, Optional, Union, List, Tuple
 
 import sentry_sdk
 from dateutil.relativedelta import relativedelta
@@ -99,16 +99,42 @@ class CollectedMetadata:
     subjects: List[ProfileSubject]
 
 
+def transform_as_run(profiled_tables) -> Dict:
+    from collections import Counter
+
+    def _t(k):
+        return k.split(".")[-1]
+
+    c = Counter([_t(ref_id) for ref_id in profiled_tables.keys()])
+    conflicts = [k for k, v in c.items() if v > 1]
+
+    if not conflicts:
+        return {_t(k): v for k, v in profiled_tables.items()}
+
+    rebuilt_profiled_tables = {}
+    for ref_id, tresult in profiled_tables.items():
+        table_name = _t(ref_id)
+        if table_name not in conflicts:
+            rebuilt_profiled_tables[table_name] = tresult
+            continue
+
+        rebuilt_profiled_tables[ref_id] = tresult
+        if tresult:
+            rebuilt_profiled_tables[table_name] = tresult
+
+    return rebuilt_profiled_tables
+
+
 class Profiler:
     """
     Profiler profile tables and columns by a sqlalchemy engine.
     """
 
     def __init__(
-        self,
-        data_source: DataSource,
-        event_handler: ProfilerEventHandler = DefaultProfilerEventHandler(),
-        config: Configuration = None
+            self,
+            data_source: DataSource,
+            event_handler: ProfilerEventHandler = DefaultProfilerEventHandler(),
+            config: Configuration = None
     ):
         self.data_source = data_source
         self.event_handler = event_handler
@@ -128,7 +154,7 @@ class Profiler:
         self.event_handler.handle_metadata_start()
         self.event_handler.handle_metadata_progress(total, completed)
         for subject in subjects:
-            def _fetch_table_task(subject):
+            def _fetch_table_task(subject: ProfileSubject):
                 engine = self.data_source.get_engine_by_database(subject.database)
                 schema = subject.schema.lower() if subject.schema is not None else None
                 table = None
@@ -138,14 +164,14 @@ class Profiler:
                     # ignore the table metadata fetch error
                     sentry_sdk.capture_exception(e)
                     pass
-                return subject.name, table
+                return subject, table
 
             future = _run_in_executor(self.executor, _fetch_table_task, subject)
             futures.append(future)
 
         for future in asyncio.as_completed(futures):
-            name, table = await future
-            map_name_tables[name] = table
+            subject, table = await future
+            map_name_tables[subject.ref_id] = table
             completed += 1
             self.event_handler.handle_metadata_progress(total, completed)
         self.event_handler.handle_metadata_end()
@@ -187,7 +213,7 @@ class Profiler:
 
             for subject in subjects:
                 name = subject.name
-                table = map_name_tables.get(name)
+                table = map_name_tables.get(subject.ref_id)
                 if table is None:
                     continue
                 engine = self.data_source.get_engine_by_database(subject.database)
@@ -204,9 +230,6 @@ class Profiler:
 
     async def _collect_metadata(self, subjects: List[ProfileSubject], metadata_subjects: List[ProfileSubject]):
         profiled_tables = {}
-        result = {
-            "tables": profiled_tables,
-        }
         if subjects is None:
             subjects = []
             table_names = inspect(self.data_source.get_engine_by_database()).get_table_names()
@@ -216,7 +239,6 @@ class Profiler:
 
         # Fetch schema data
         map_name_tables = await self._fetch_metadata(metadata_subjects if metadata_subjects else subjects)
-        map_name_tables = {k: v for k, v in map_name_tables.items() if v is not None}
 
         if metadata_subjects is None:
             # for compatible with non-dbt cases, we use subjects as the metadata_subjects
@@ -224,16 +246,20 @@ class Profiler:
 
         for subject in metadata_subjects:
             engine = self.data_source.get_engine_by_database(subject.database)
-            table = map_name_tables.get(subject.name)
-            if table is None:
-                continue
-            table_profiler = TableProfiler(engine, self.executor, subject, table, self.event_handler, self.config)
-            tresult = await table_profiler.fetch_schema()
-            profiled_tables[subject.name] = tresult
+            table = map_name_tables.get(subject.ref_id)
 
+            tresult = {}
+            if table is not None:
+                table_profiler = TableProfiler(engine, self.executor, subject, table, self.event_handler, self.config)
+                tresult = await table_profiler.fetch_schema()
+                profiled_tables[subject.ref_id] = tresult
+            else:
+                profiled_tables[subject.ref_id] = tresult
+
+        profiled_tables = transform_as_run(profiled_tables)
         self.collected_metadata = CollectedMetadata(map_name_tables=map_name_tables,
                                                     profiled_tables=profiled_tables,
-                                                    result=result,
+                                                    result=dict(tables=profiled_tables),
                                                     subjects=subjects)
         return self.collected_metadata
 

--- a/piperider_cli/runner.py
+++ b/piperider_cli/runner.py
@@ -362,6 +362,9 @@ def _append_descriptions(profile_result):
 
 
 def _clean_up_profile_null_properties(table_results):
+    if not table_results:
+        return
+
     removed = []
     for t_metric, t_metric_val in table_results.items():
         if t_metric_val is None:
@@ -406,6 +409,7 @@ def _append_descriptions_from_assertion(profile_result):
 
 def _analyse_and_log_run_event(profiled_result, assertion_results, dbt_test_results):
     tables = profiled_result.get('tables', [])
+    tables = {k: v for k, v in tables.items() if v}
     event_payload = RunEventPayload()
     event_payload.tables = len(tables)
 

--- a/piperider_cli/runner.py
+++ b/piperider_cli/runner.py
@@ -415,9 +415,11 @@ def _analyse_and_log_run_event(profiled_result, assertion_results, dbt_test_resu
 
     # Table info
     for t in tables:
-        event_payload.columns.append(profiled_result['tables'][t]['col_count'])
+        table = profiled_result['tables'][t]
+        # null col_count when the metadata is not available
+        event_payload.columns.append(table.get('col_count'))
         # null row_count when the table is not profiled
-        event_payload.rows.append(profiled_result['tables'][t].get('row_count'))
+        event_payload.rows.append(table.get('row_count'))
 
     # Count PipeRider assertions
     for r in assertion_results or []:

--- a/tests/profiler/test_multi_db.py
+++ b/tests/profiler/test_multi_db.py
@@ -29,6 +29,7 @@ class TestMultiDB:
         create_table(engine2, "test2", data)
 
         profiler = Profiler(data_source)
-        result = profiler.profile([ProfileSubject('test1', database='db1'), ProfileSubject('test2', database='db2')])
+        result = profiler.profile([ProfileSubject('test1', database='db1', ref_id='foo.test1'),
+                                   ProfileSubject('test2', database='db2', ref_id='foo.test2')])
         assert "test1" in result["tables"]
         assert "test2" in result["tables"]


### PR DESCRIPTION
**PR checklist**

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed

**What type of PR is this?**

bugfix

**What this PR does / why we need it**:

In a real case, users might use the same name for different dbt nodes. 

For example:

* define `transaction` in the sources
* define `transaction` in the seed
* define `transaction` in the model
* ~~define `transaction` in the staging model~~

> (venv) (⎈ |kind-kind:default)(base) ➜  tw_campaign_finance git:(chore/rename) ✗ dbt build
> 03:17:51  Running with dbt=1.5.2
> 03:17:51  Registered adapter: duckdb=1.5.2
> 03:17:51  Encountered an error:
> Compilation Error
>   dbt found two models with the name "transaction".
> 
>   Since these resources have the same name, dbt will be unable to find the correct resource
>   when looking for ref("transaction").
> 
>   To fix this, change the name of one of these resources:
>   - model.tw_campaign_finance.transaction (models/staging/transaction.sql)
>   - model.tw_campaign_finance.transaction (models/transaction.sql)


**Which issue(s) this PR fixes**:

sc-31825

**To Reviewers**:

There are two parts in the main goal

- [x] error handling in the report generator
- [x] fix the profiling output (`run.json`)

* The first, even if we lost data in `run.json` must not break the report-generating process. A weird one is better than nothing.
* Except if the data is unavailable, we need to put any table with the same name (e.g. `transaction`) to the profiling results.

-----


# Ref data for broken report

* We rename the model `campaign_transaction` to `transaction`, it will conflict with `sources.cy.transaction`
* `models/transaction.sql` is not present in the `run.json` (the `target` part from the comparison data)

```diff
(venv) (⎈ |kind-kind:default)(base) ➜  tw_campaign_finance git:(chore/rename) ✗ g show
commit eece695a3924161e959e0718096e3ed6ca6dcdd0 (HEAD -> chore/rename)
Author: Ching Yi, Chan <qrtt1@infuseai.io>
Date:   Wed Jul 26 19:18:57 2023 +0800

    rename to transaction

    Signed-off-by: Ching Yi, Chan <qrtt1@infuseai.io>

diff --git a/models/corporation_contribution.sql b/models/corporation_contribution.sql
index baea214..f116b66 100644
--- a/models/corporation_contribution.sql
+++ b/models/corporation_contribution.sql
@@ -32,7 +32,7 @@ select
     industry,
     industry_category

-from {{ ref('campaign_transaction') }}
+from {{ ref('transaction') }}
     left join corp_industry_category on
         who_id = corp_industry_category.id

diff --git a/models/campaign_transaction.sql b/models/transaction.sql
similarity index 100%
rename from models/campaign_transaction.sql
rename to models/transaction.sql
```



# Comparison Summary
| Resource | Total | Impacted | Explicit Changes | Implicit Changes
| -- | -- | -- | -- | --
| Models | 2 | 3 | 3 | 0
| Metrics | 0 | 0 | 0 | 0
# Models
| | Model | Columns <br> <img src="https://raw.githubusercontent.com/InfuseAI/piperider/main/images/icons/icon-diff-delta-plus%402x.png" width="10px"> <img src="https://raw.githubusercontent.com/InfuseAI/piperider/main/images/icons/icon-diff-delta-minus%402x.png" width="10px"> <img src="https://raw.githubusercontent.com/InfuseAI/piperider/main/images/icons/icon-diff-delta-explicit%402x.png" width="10px"> | Rows | Dbt Time | Failed Tests | All Tests
| -- | -- | -- | -- | -- | -- | --
| <img src="https://raw.githubusercontent.com/InfuseAI/piperider/main/images/icons/icon-diff-delta-plus%402x.png" width="16px"> | models/transaction.sql | None | nan | 0:00:03.11 | - | -
| <img src="https://raw.githubusercontent.com/InfuseAI/piperider/main/images/icons/icon-diff-delta-minus%402x.png" width="16px"> | ..els/campaign_transaction.sql | ~~26~~ | ~~nan~~ |  |  |
| <img src="https://raw.githubusercontent.com/InfuseAI/piperider/main/images/icons/icon-diff-delta-explicit%402x.png" width="16px"> | ..corporation_contribution.sql | 9 ($\color{green}{\text{ 0 }}$ / $\color{red}{\text{ 0 }}$ / $\color{orange}{\text{ 0 }}$) | nan | 0:00:00.15 $\color{green}{\text{ (↓ -0.01) }}$ | - | -
# Metrics
No changes detected


