### PR TITLE
[Bug] sc-31930 Force GitHub Action to switch branch even no recipe

### DIFF
--- a/piperider_cli/recipes/github_action.py
+++ b/piperider_cli/recipes/github_action.py
@@ -39,7 +39,8 @@ def run_external_command(command_line, env: Dict = None):
 def prepare_for_action(recipe_name: str = None):
     recipe_path = select_recipe_file(None if not recipe_name else recipe_name)
 
-    if recipe_path is not None:
+    if recipe_path:
+        print(f'[Prepare] check recipe from file: {recipe_path}')
         cfg = RecipeConfiguration.load(recipe_path)
         if cfg.base.branch:
             print(f'[Prepare] switch to base branch: {cfg.base.branch}')
@@ -48,9 +49,19 @@ def prepare_for_action(recipe_name: str = None):
             print(f'[Prepare] switch to target branch: {cfg.target.branch}')
             git_switch_to(cfg.target.branch)
 
-        ref_name = os.environ.get('GITHUB_HEAD_REF')
-        print(f'[Prepare] switch to GITHUB_HEAD_REF: {ref_name}')
-        git_switch_to(ref_name)
+        head_ref = os.environ.get('GITHUB_HEAD_REF')
+        print(f'[Prepare] switch to GITHUB_HEAD_REF: {head_ref}')
+        git_switch_to(head_ref)
+    else:
+        print('[Prepare] check GitHub HEAD_REF and BASE_REF')
+        head_ref = os.environ.get('GITHUB_HEAD_REF')
+        base_ref = os.environ.get('GITHUB_BASE_REF')
+
+        print(f'[Prepare] switch to GITHUB_BASE_REF branch: {base_ref}')
+        git_switch_to(base_ref)
+
+        print(f'[Prepare] switch to GITHUB_HEAD_REF branch: {head_ref}')
+        git_switch_to(head_ref)
 
 
 def make_recipe_command():


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some check items for you: -->

**PR checklist**

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed

**What type of PR is this?**
BugFix

**What this PR does / why we need it**:
Force to run git switch in GitHub Action even if there is no recipe file.

**Which issue(s) this PR fixes**:
sc-31930

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
