### PR TITLE
[Chore] Skip dbt-1.4.7 for regression error

### DIFF
--- a/.github/workflows/dbt-compatible-tests.yaml
+++ b/.github/workflows/dbt-compatible-tests.yaml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         version: [ '3.8', '3.9', '3.10', '3.11' ]
-        dbt: [ ">=1.3,<1.4", ">=1.4,<1.5", ">=1.5,<1.6" ]
+        dbt: [ ">=1.3,<1.4", ">=1.4,<1.4.7", ">=1.5,<1.6" ]
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Got a problem with the dbt 1.4 latest release, skip it for now. I will check it later.

---

* broken tests: https://github.com/InfuseAI/piperider/actions/runs/5783283543/job/15671764017
* diff between 1.4.6 and 1.4.7 https://github.com/dbt-labs/dbt-core/compare/v1.4.6...v1.4.7