### PR TITLE
[Chore] refactor test-cli.py to test init, diagnose and run commands

### DIFF
--- a/piperider_cli/datasource/duckdb.py
+++ b/piperider_cli/datasource/duckdb.py
@@ -92,8 +92,14 @@ class DuckDBDataSource(DataSource):
         from piperider_cli.configuration import FileSystem
         dbpath = credential.get('path')
         if os.path.isabs(dbpath) is False:
-            dbpath = os.path.join(os.getcwd(), dbpath)
-        duckdb_path = os.path.abspath(dbpath)
+            current_directory_path = os.path.join(os.getcwd(), dbpath)
+            working_directory_path = os.path.join(FileSystem.WORKING_DIRECTORY, dbpath)
+            if os.path.exists(current_directory_path):
+                duckdb_path = os.path.abspath(current_directory_path)
+            else:
+                duckdb_path = os.path.abspath(working_directory_path)
+        else:
+            duckdb_path = dbpath
         if not os.path.exists(duckdb_path):
             raise PipeRiderDataBaseConnectionError(self.name, self.type_name, db_path=duckdb_path)
         return f"duckdb:///{duckdb_path}"

--- a/piperider_cli/dbtutil.py
+++ b/piperider_cli/dbtutil.py
@@ -382,7 +382,8 @@ def load_dbt_project(path: str):
 
     if not os.path.isabs(path):
         from piperider_cli.configuration import FileSystem
-        path = os.path.join(FileSystem.WORKING_DIRECTORY, path)
+        if os.path.exists(path) is False:
+            path = os.path.join(FileSystem.WORKING_DIRECTORY, path)
 
     with open(path, 'r') as fd:
         try:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,54 @@
+import os
+from unittest import TestCase, mock
+
+from click.testing import CliRunner
+
+from piperider_cli.cli import init, version, diagnose, run
+
+
+class TestPipeRiderCli(TestCase):
+    def setUp(self) -> None:
+        self.cli_runner = CliRunner()
+        self.unit_test_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'mock_dbt_project')
+        pass
+
+    def test_version_command(self):
+        result = self.cli_runner.invoke(version)
+        assert result.exit_code == 0
+
+    def test_init_command(self):
+        result = self.cli_runner.invoke(init, ["--dbt-project-dir", self.unit_test_dir])
+        assert result.exit_code == 0
+
+    @mock.patch('piperider_cli.validator.Validator.diagnose', return_value=True)
+    def test_diagnose_command(self, *args):
+        result = self.cli_runner.invoke(diagnose, ["--dbt-project-dir", self.unit_test_dir])
+        assert result.exit_code == 0
+
+    @mock.patch('piperider_cli.runner.Runner.exec', return_value=0)
+    @mock.patch('piperider_cli.generate_report.GenerateReport.exec', return_value=0)
+    @mock.patch('piperider_cli.cloud_connector.CloudConnector.is_login', return_value=False)
+    @mock.patch('piperider_cli.cloud_connector.CloudConnector.upload_latest_report', return_value=0)
+    def test_run_command(self, *args):
+        # Manually config dbt project and profiles dir
+        result = self.cli_runner.invoke(run, [
+            "--dbt-project-dir", self.unit_test_dir,
+            "--dbt-profiles-dir", self.unit_test_dir,
+        ])
+        assert result.exit_code == 0
+
+        # Table and dbt-list cannot be used together
+        result = self.cli_runner.invoke(run, [
+            "--dbt-project-dir", self.unit_test_dir,
+            "--table", "test",
+            "--dbt-list",
+        ])
+        assert result.exit_code == 1
+
+        # Select and dbt-list cannot be used together
+        result = self.cli_runner.invoke(run, [
+            "--dbt-project-dir", self.unit_test_dir,
+            "--select", "test",
+            "--dbt-list",
+        ])
+        assert result.exit_code == 1


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some check items for you: -->

**PR checklist**

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed

**What type of PR is this?**
Unit Test

**What this PR does / why we need it**:
- Add unit test for CLi to test `init`, `diagnose` and `run` commands
- Fix some path related issues
  - Currently, duckDB will only search the db file from CWD. After this fix, we will search CWD first and search working_dir secondly. 
  - When we use `--dbt-project-dir` to config dbt project dir, the method `load_dbt_project` will use a wrong path to load file.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
