### PR TITLE
[Chore] Add utm_source in the cloud report

### DIFF
--- a/piperider_cli/cloud_connector.py
+++ b/piperider_cli/cloud_connector.py
@@ -427,7 +427,7 @@ class CloudConnector:
             console.print(ascii_table)
 
             for report in reports:
-                console.print(f'Report #{report[0]} URL: [deep_sky_blue1]{report[1]}[/deep_sky_blue1]', soft_wrap=True)
+                console.print(f'Report #{report[0]} URL: [deep_sky_blue1]{report[1]}?utm_source=cli[/deep_sky_blue1]', soft_wrap=True)
 
         if open_report:
             url = response.get('report_url')
@@ -499,7 +499,7 @@ class CloudConnector:
             console.print('Failed to create the comparison report')
         else:
             url = response.get('url')
-            console.print(f'Comparison report URL: {url}')
+            console.print(f'Comparison report URL: {url}?utm_source=cli')
 
         if debug:
             console.print(response)

--- a/piperider_cli/compare_report.py
+++ b/piperider_cli/compare_report.py
@@ -522,7 +522,7 @@ class CompareReport(object):
         if summary_data:
             console.print(f"Comparison summary: {summary_md_path}")
         if report_url:
-            console.print(f"Comparison report URL: {report_url}", soft_wrap=True)
+            console.print(f"Comparison report URL: {report_url}?utm_source=cli", soft_wrap=True)
 
         if open_report:
             if report_url:

--- a/piperider_cli/dbt/changeset.py
+++ b/piperider_cli/dbt/changeset.py
@@ -22,7 +22,7 @@ def embed_url_cli(content: str, url: str, unique_id: str, resource_type: str):
 
 
 def embed_url_cloud(content: str, url: str, unique_id: str, resource_type: str):
-    return f"[{content}]({url}#/{resource_type}s/{urllib.parse.quote(unique_id)})"
+    return f"[{content}]({url}?utm_source=pr#/{resource_type}s/{urllib.parse.quote(unique_id)})"
 
 
 embed_url = None
@@ -561,7 +561,7 @@ class SummaryChangeSet(DefaultChangeSetOpMixin):
     def generate_impact_summary_section(self, out: Callable[[str], None]) -> None:
         out("# Impact Summary")
         if self.get_url():
-            out(f"[PipeRider Report]({self.get_url()})")
+            out(f"[PipeRider Report]({self.get_url()}?utm_source=pr)")
         out("### Code Changes")
         mt = MarkdownTable(headers=['Added', 'Removed', 'Modified'])
         explicit_changes = self.models.explicit_changeset + self.metrics.explicit_changeset + self.seeds.explicit_changeset

--- a/static_report/src/components/LineageGraph/CopyGraphUrlButton.tsx
+++ b/static_report/src/components/LineageGraph/CopyGraphUrlButton.tsx
@@ -10,6 +10,24 @@ function getWindow(): Window | undefined {
   return window;
 }
 
+function patchUrl(url) {
+  const urlObj = new URL(url);
+  const utmParams = [
+    'utm_source',
+    'utm_medium',
+    'utm_campaign',
+    'utm_term',
+    'utm_content',
+  ];
+
+  for (const param of utmParams) {
+    urlObj.searchParams.delete(param);
+  }
+
+  urlObj.searchParams.append('utm_source', 'lineage');
+  return urlObj.toString();
+}
+
 export function CopyGraphUrlButton() {
   const _window = getWindow();
 
@@ -21,7 +39,7 @@ export function CopyGraphUrlButton() {
     if (!url) {
       return;
     }
-
+    url = patchUrl(url);
     setValue(url);
   }, [_window, hashParams, setValue]);
 


### PR DESCRIPTION
Add the cloud report with `utm_source` information

1. CLI: utm_source=cli
2. PR Comment: utm_source=pr
3. Copy button: utm_source=share
4. Lineage diff: utm_source=lineage 

**PR checklist**

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed

