### PR TITLE
[Bug] sc-32142 Throw NoneType error when piperider config file is empty

### DIFF
--- a/piperider_cli/configuration.py
+++ b/piperider_cli/configuration.py
@@ -344,7 +344,7 @@ class Configuration(object):
         _yml = yaml.YAML()
 
         with open(FileSystem.PIPERIDER_CONFIG_PATH, 'r') as f:
-            config = _yml.load(f)
+            config = _yml.load(f) or {}
 
         config[key] = update_values
         with open(FileSystem.PIPERIDER_CONFIG_PATH, 'w+', encoding='utf-8') as f:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some check items for you: -->

**PR checklist**

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed

**What type of PR is this?**
Bugfix

**What this PR does / why we need it**:
Fix NoneType error when piperider config file is empty

**Which issue(s) this PR fixes**:
sc-32142

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
