### PR TITLE
[Chore] sc-32147 Reduce the file size of `run.json` to speed up the report upload time

### DIFF
--- a/piperider_cli/compare_report.py
+++ b/piperider_cli/compare_report.py
@@ -30,6 +30,7 @@ class RunOutput(object):
         self.pass_count = 0
         self.fail_count = 0
         self.cloud = None
+        self.file_size = os.path.getsize(path)
 
         try:
             with open(path, 'r') as f:
@@ -68,10 +69,18 @@ class RunOutput(object):
         created_at_str = datetime_to_str(str_to_datetime(self.created_at),
                                          to_tzlocal=True)
 
+        def human_readable_size(size, decimal_places=2):
+            for unit in ['B', 'KiB', 'MiB', 'GiB', 'TiB', 'PiB']:
+                if size < 1024.0 or unit == 'PiB':
+                    break
+                size /= 1024.0
+            return f"{size:.{decimal_places}f} {unit}"
+
         return f'{self.name:12} ' \
                f'#table={self.table_count:<6} ' \
                f'#pass={self.pass_count:<5} ' \
                f'#fail={self.fail_count:<5} ' \
+               f'size={human_readable_size(self.file_size):<12}' \
                f'{created_at_str}'
 
 
@@ -311,10 +320,10 @@ class CompareReport(object):
         def _walk_throw_runs(path):
             outputs = []
             for root, dirs, _ in os.walk(path):
-                for dir in dirs:
-                    if dir == 'latest':
+                for dir_name in dirs:
+                    if dir_name == 'latest':
                         continue
-                    run_json = os.path.join(root, dir, 'run.json')
+                    run_json = os.path.join(root, dir_name, 'run.json')
                     if not os.path.exists(run_json):
                         continue
                     output = RunOutput(run_json)

--- a/piperider_cli/runner.py
+++ b/piperider_cli/runner.py
@@ -642,9 +642,9 @@ def get_git_branch():
 class Runner():
     @staticmethod
     def \
-            exec(datasource=None, table=None, output=None, skip_report=False, dbt_target_path: str = None,
-                 dbt_resources: Optional[dict] = None, dbt_select: tuple = None, dbt_state: str = None,
-                 report_dir: str = None, skip_datasource_connection: bool = False):
+        exec(datasource=None, table=None, output=None, skip_report=False, dbt_target_path: str = None,
+             dbt_resources: Optional[dict] = None, dbt_select: tuple = None, dbt_state: str = None,
+             report_dir: str = None, skip_datasource_connection: bool = False):
         console = Console()
 
         raise_exception_when_directory_not_writable(output)
@@ -858,7 +858,12 @@ class Runner():
                             manifest['nodes'][key]['raw_code'] = sha1.hexdigest()
                         return manifest
 
-                    run_result['dbt']['manifest'] = _slim_dbt_manifest(dbt_manifest)
+                    size = sys.getsizeof(dbt_manifest)
+                    if size > 1024 * 1024 * 10:
+                        # Reduce the manifest size if it's larger than 10MB
+                        run_result['dbt']['manifest'] = _slim_dbt_manifest(dbt_manifest)
+                    else:
+                        run_result['dbt']['manifest'] = dbt_manifest
                 if dbt_run_results:
                     run_result['dbt']['run_results'] = dbt_run_results
 

--- a/piperider_cli/runner.py
+++ b/piperider_cli/runner.py
@@ -1,3 +1,4 @@
+import hashlib
 import json
 import math
 import os
@@ -641,9 +642,9 @@ def get_git_branch():
 class Runner():
     @staticmethod
     def \
-        exec(datasource=None, table=None, output=None, skip_report=False, dbt_target_path: str = None,
-             dbt_resources: Optional[dict] = None, dbt_select: tuple = None, dbt_state: str = None,
-             report_dir: str = None, skip_datasource_connection: bool = False):
+            exec(datasource=None, table=None, output=None, skip_report=False, dbt_target_path: str = None,
+                 dbt_resources: Optional[dict] = None, dbt_select: tuple = None, dbt_state: str = None,
+                 report_dir: str = None, skip_datasource_connection: bool = False):
         console = Console()
 
         raise_exception_when_directory_not_writable(output)
@@ -849,7 +850,15 @@ class Runner():
             if dbt_config:
                 run_result['dbt'] = dict()
                 if dbt_manifest:
-                    run_result['dbt']['manifest'] = dbt_manifest
+                    def _slim_dbt_manifest(manifest):
+                        for key in manifest['nodes'].keys():
+                            raw_code = manifest['nodes'][key]['raw_code']
+                            sha1 = hashlib.sha1()
+                            sha1.update(raw_code.encode('utf-8'))
+                            manifest['nodes'][key]['raw_code'] = sha1.hexdigest()
+                        return manifest
+
+                    run_result['dbt']['manifest'] = _slim_dbt_manifest(dbt_manifest)
                 if dbt_run_results:
                     run_result['dbt']['run_results'] = dbt_run_results
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some check items for you: -->

**PR checklist**

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed

**What type of PR is this?**
Enhance

**What this PR does / why we need it**:
- Replace manifest `raw_code` field by sha1 hash to reduce the file size of `run.json` if the manifest size is larger than 10MB
- Show report size when selecting the upload reports

**Which issue(s) this PR fixes**:
sc-32147

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
