### PR TITLE
[Bug] TypeError: __init__() got an unexpected keyword argument "execut…

### DIFF
--- a/piperider_cli/cli.py
+++ b/piperider_cli/cli.py
@@ -74,19 +74,8 @@ def add_options(options):
 
 
 class RunDataPath(click.Path):
-
     def __init__(self):
-        super().__init__(
-            exists=True,
-            file_okay=True,
-            dir_okay=False,
-            writable=False,
-            readable=True,
-            resolve_path=True,
-            allow_dash=False,
-            path_type=None,
-            executable=False
-        )
+        super().__init__(exists=True, dir_okay=False, resolve_path=True)
 
     def convert(
             self, value: t.Any, param: t.Optional["Parameter"], ctx: t.Optional["Context"]


### PR DESCRIPTION
This error happens if the 'click<=8.1.0'. Solution is make the library call more backward-compatible.

**PR checklist**

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed

**What type of PR is this?**
Bug
**What this PR does / why we need it**:


**Which issue(s) this PR fixes**:
sc-32225

**Special notes for your reviewer**:

