### PR TITLE
[Bug] comparison generating failed when impacted models are more than 50

### DIFF
--- a/piperider_cli/dbt/changeset.py
+++ b/piperider_cli/dbt/changeset.py
@@ -748,8 +748,11 @@ class SummaryChangeSet(DefaultChangeSetOpMixin):
 
         if len(changeset) > 50:
             remainings = len(changeset) - 50
-            mt.add_row(
-                ['', f'{remainings} more potentially impacted models', '', '', '', '', ''])
+            footer = ['', f'{remainings} more potentially impacted models']
+            if mt.num_of_columns > 2:
+                footer += [''] * (mt.num_of_columns - 2)
+
+            mt.add_row(footer)
 
         out(mt.build())
 
@@ -821,8 +824,11 @@ class SummaryChangeSet(DefaultChangeSetOpMixin):
 
         if len(changeset) > 50:
             remainings = len(changeset) - 50
-            mt.add_row(
-                ['', f'{remainings} more potentially impacted metrics', ''])
+            footer = ['', f'{remainings} more potentially impacted metrics']
+            if mt.num_of_columns > 2:
+                footer += [''] * (mt.num_of_columns - 2)
+
+            mt.add_row(footer)
 
         out(mt.build())
 


### PR DESCRIPTION
comparison generating failed when impacted models are more than 50. It's because the footer column count of the markdown is not the same as the header row count

**PR checklist**

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed

**What type of PR is this?**
Bug fix

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

