### PR TITLE
[Chore] sc-32247 Fallback to use temp folder to store profile.yml

### DIFF
--- a/piperider_cli/__init__.py
+++ b/piperider_cli/__init__.py
@@ -3,6 +3,7 @@ import logging
 import os
 import re
 import sys
+import tempfile
 import webbrowser
 from datetime import datetime
 
@@ -11,6 +12,8 @@ from rich.console import Console
 from ruamel import yaml
 
 PIPERIDER_USER_HOME = os.path.expanduser('~/.piperider')
+if os.access(os.path.expanduser('~/'), os.W_OK) is False:
+    PIPERIDER_USER_HOME = os.path.join(tempfile.gettempdir(), '.piperider')
 PIPERIDER_USER_PROFILE = os.path.join(PIPERIDER_USER_HOME, 'profile.yml')
 
 

--- a/piperider_cli/__init__.py
+++ b/piperider_cli/__init__.py
@@ -3,7 +3,6 @@ import logging
 import os
 import re
 import sys
-import tempfile
 import webbrowser
 from datetime import datetime
 
@@ -11,10 +10,7 @@ from dateutil import tz
 from rich.console import Console
 from ruamel import yaml
 
-PIPERIDER_USER_HOME = os.path.expanduser('~/.piperider')
-if os.access(os.path.expanduser('~/'), os.W_OK) is False:
-    PIPERIDER_USER_HOME = os.path.join(tempfile.gettempdir(), '.piperider')
-PIPERIDER_USER_PROFILE = os.path.join(PIPERIDER_USER_HOME, 'profile.yml')
+from piperider_cli.event import PIPERIDER_USER_HOME, PIPERIDER_USER_PROFILE
 
 
 def create_logger(name) -> logging.Logger:

--- a/piperider_cli/__init__.py
+++ b/piperider_cli/__init__.py
@@ -3,6 +3,7 @@ import logging
 import os
 import re
 import sys
+import tempfile
 import webbrowser
 from datetime import datetime
 
@@ -10,7 +11,11 @@ from dateutil import tz
 from rich.console import Console
 from ruamel import yaml
 
-from piperider_cli.event import PIPERIDER_USER_HOME, PIPERIDER_USER_PROFILE
+PIPERIDER_USER_HOME = os.path.expanduser('~/.piperider')
+if os.access(os.path.expanduser('~/'), os.W_OK) is False:
+    # If we can't create file in user home directory, fallback to use temp folder
+    PIPERIDER_USER_HOME = os.path.join(tempfile.gettempdir(), '.piperider')
+PIPERIDER_USER_PROFILE = os.path.join(PIPERIDER_USER_HOME, 'profile.yml')
 
 
 def create_logger(name) -> logging.Logger:

--- a/piperider_cli/event/__init__.py
+++ b/piperider_cli/event/__init__.py
@@ -1,18 +1,13 @@
 import os
-import tempfile
 import uuid
 from typing import Union
 
 from rich.console import Console
 from ruamel import yaml
 
+from piperider_cli import PIPERIDER_USER_HOME, PIPERIDER_USER_PROFILE
 from piperider_cli.event.collector import Collector
 
-PIPERIDER_USER_HOME = os.path.expanduser('~/.piperider')
-if os.access(os.path.expanduser('~/'), os.W_OK) is False:
-    # If we can't create file in user home directory, fallback to use temp folder
-    PIPERIDER_USER_HOME = os.path.join(tempfile.gettempdir(), '.piperider')
-PIPERIDER_USER_PROFILE = os.path.join(PIPERIDER_USER_HOME, 'profile.yml')
 PIPERIDER_USER_EVENT_PATH = os.path.join(PIPERIDER_USER_HOME, '.unsend_events.json')
 PIPERIDER_FLUSH_EVENTS_WHITELIST = ['init', 'run', 'generate-report', 'compare-reports']
 

--- a/piperider_cli/event/__init__.py
+++ b/piperider_cli/event/__init__.py
@@ -1,4 +1,5 @@
 import os
+import tempfile
 import uuid
 from typing import Union
 
@@ -8,6 +9,9 @@ from ruamel import yaml
 from piperider_cli.event.collector import Collector
 
 PIPERIDER_USER_HOME = os.path.expanduser('~/.piperider')
+if os.access(os.path.expanduser('~/'), os.W_OK) is False:
+    # If we can't create file in user home directory, fallback to use temp folder
+    PIPERIDER_USER_HOME = os.path.join(tempfile.gettempdir(), '.piperider')
 PIPERIDER_USER_PROFILE = os.path.join(PIPERIDER_USER_HOME, 'profile.yml')
 PIPERIDER_USER_EVENT_PATH = os.path.join(PIPERIDER_USER_HOME, '.unsend_events.json')
 PIPERIDER_FLUSH_EVENTS_WHITELIST = ['init', 'run', 'generate-report', 'compare-reports']


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some check items for you: -->

**PR checklist**

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed

**What type of PR is this?**
Chore

**What this PR does / why we need it**:
- If user's home directory is read-only, needs to find a place to store `.piperider/profile.yml` 

**Which issue(s) this PR fixes**:
sc-32247

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
