### PR TITLE
[Bug] PR-55 Fix option `--dbt-list` doesn't work issue

### DIFF
--- a/piperider_cli/dbtutil.py
+++ b/piperider_cli/dbtutil.py
@@ -10,9 +10,9 @@ import inquirer
 from jinja2 import UndefinedError
 from rich.console import Console
 from rich.table import Table
-from piperider_cli import yaml as pyml
 
 from piperider_cli import load_jinja_template, load_jinja_string_template
+from piperider_cli import yaml as pyml
 from piperider_cli.dbt.list_task import load_manifest, list_resources_unique_id_from_manifest, load_full_manifest
 from piperider_cli.error import \
     DbtProjectInvalidError, \
@@ -185,7 +185,9 @@ def get_dbt_state_candidate(dbt_state_dir: str, options: dict, *, select_for_met
     def profiling_chosen_fn(key, node):
         statistics = Statistics()
         if dbt_resources:
-            chosen = node.get('unique_id') in dbt_resources['models']
+            fqn = '.'.join(node.get('fqn'))
+            unique_id = node.get('unique_id')
+            chosen = unique_id in dbt_resources['models'] or fqn in dbt_resources['models']
             if not chosen:
                 statistics.add_field_one('filter')
             return chosen


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some check items for you: -->

**PR checklist**

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed

**What type of PR is this?**
Bugfix

**What this PR does / why we need it**:
- When the user uses `run` command with option `--dbt-list`, the list is piped from stdin. (Ex. `dbt list -s 'tag:piperider' | pieprider run --dbt-list` ). The dbt-list function doesn't work.
- Before, we only compared the node's `unique_id` with select dbt resources. However, the format of `uniqueId` could not be matched with dbt_resource.
  Ex. `node['uniuqe_id']` is `model.jaffle_shop.stg_customer`, `dbt_resources['models']` is `jaffle_shop.staging.stg_customers`
- In this fix, we will not only compare the `unique_id`. But also compare the dbt_resources with FQN.



**Which issue(s) this PR fixes**:
[PR-55](https://linear.app/piperider/issue/PR-55/piperider-run-options-dbt-list-doesnt-work)

**Special notes for your reviewer**:


**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
