### PR TITLE
[Bug] Fix the package path of QueryComment

### DIFF
--- a/piperider_cli/dbt/list_task.py
+++ b/piperider_cli/dbt/list_task.py
@@ -9,9 +9,9 @@ from typing import Dict, List
 import agate
 import dbt.flags as flags_module
 from dbt.adapters.base import BaseAdapter, BaseRelation, Column as BaseColumn
+from dbt.adapters.contracts.connection import QueryComment
 from dbt.config.project import VarProvider
 from dbt.config.runtime import RuntimeConfig
-from dbt.contracts.connection import QueryComment
 from dbt.contracts.graph.manifest import Manifest, WritableManifest
 from dbt.contracts.project import PackageConfig, UserConfig
 from dbt.contracts.state import PreviousState


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some check items for you: -->

**PR checklist**

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed

**What type of PR is this?**

Fix of a deprecation.

**What this PR does / why we need it**:

dbt-core changed the package path of `dbt.contracts.connection` to `dbt.adapters.contracts.connection` in https://github.com/dbt-labs/dbt-core/commit/469a9aca06037a46bcf607ea70b4305d72ee6dd1, so the code should follow it.

**Which issue(s) this PR fixes**:

None

**Special notes for your reviewer**:

None

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

No